### PR TITLE
Cleanup ZBT-WE826 DTS, add USB WWAN kmods

### DIFF
--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -144,7 +144,8 @@ get_status_led() {
 		status_led="$board:amber:cpu"
 		;;
 	oy-0001|\
-	sl-r7205)
+	sl-r7205|\
+	zbt-we826)
 		status_led="$board:green:wifi"
 		;;
 	psr-680w)

--- a/target/linux/ramips/dts/ZBT-WE826.dts
+++ b/target/linux/ramips/dts/ZBT-WE826.dts
@@ -3,122 +3,123 @@
 #include "mt7620a.dtsi"
 
 / {
-       compatible = "zbtlink,zbt-we826", "ralink,mt7620a-soc";
-       model = "ZBT-WE826";
+	compatible = "zbtlink,zbt-we826", "ralink,mt7620a-soc";
+	model = "ZBT-WE826";
 
-       chosen {
-               bootargs = "console=ttyS0,115200";
-       };
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
 
-       palmbus@10000000 {
-               gpio0: gpio@600 {
-                       status = "okay";
-               };
+	palmbus@10000000 {
+		gpio0: gpio@600 {
+			status = "okay";
+		};
 
-               gpio1: gpio@638 {
-                       status = "okay";
-               };
+		gpio1: gpio@638 {
+			status = "okay";
+		};
 
-               gpio3: gpio@688 {
-                       status = "okay";
-               };
+		gpio3: gpio@688 {
+			status = "okay";
+		};
 
-               spi@b00 {
-                       status = "okay";
+		spi@b00 {
+			status = "okay";
 
-                       en25q128@0 {
-                               #address-cells = <1>;
-                               #size-cells = <1>;
-                               compatible = "w25q128";
-                               reg = <0 0>;
-                               linux,modalias = "m25p80";
-                               spi-max-frequency = <10000000>;
+			en25q128@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "w25q128";
+				reg = <0 0>;
+				linux,modalias = "m25p80";
+				spi-max-frequency = <10000000>;
 
-                               partition@0 {
-                                       label = "u-boot";
-                                       reg = <0x0 0x30000>;
-                                       read-only;
-                               };
+				partition@0 {
+					label = "u-boot";
+					reg = <0x0 0x30000>;
+					read-only;
+				};
 
-                               partition@30000 {
-                                       label = "u-boot-env";
-                                       reg = <0x30000 0x10000>;
-                                       read-only;
-                               };
+				partition@30000 {
+					label = "u-boot-env";
+					reg = <0x30000 0x10000>;
+					read-only;
+				};
 
-                               factory: partition@40000 {
-                                       label = "factory";
-                                       reg = <0x40000 0x10000>;
-                                       read-only;
-                               };
+				factory: partition@40000 {
+					label = "factory";
+					reg = <0x40000 0x10000>;
+					read-only;
+				};
 
-                               partition@50000 {
-                                       label = "firmware";
-                                       reg = <0x50000 0xfb0000>;
-                               };
-                       };
-               };
-       };
+				partition@50000 {
+					label = "firmware";
+					reg = <0x50000 0xfb0000>;
+				};
+			};
+		};
+	};
 
-       sdhci@10130000 {
-               status = "okay";
-       };
+	sdhci@10130000 {
+		status = "okay";
+	};
 
-       ehci@101c0000 {
-               status = "okay";
-       };
+	ehci@101c0000 {
+		status = "okay";
+	};
 
-       ohci@101c1000 {
-               status = "okay";
-       };
+	ohci@101c1000 {
+		status = "okay";
+	};
 
-       ethernet@10100000 {
-               mtd-mac-address = <&factory 0x4>;
-               ralink,port-map = "wllll";
-       };
+	ethernet@10100000 {
+		mtd-mac-address = <&factory 0x4>;
+		ralink,port-map = "wllll";
+	};
 
-       wmac@10180000 {
-               ralink,mtd-eeprom = <&factory 0>;
-       };
+	wmac@10180000 {
+		ralink,mtd-eeprom = <&factory 0>;
+	};
 
-       pinctrl {
-               state_default: pinctrl0 {
-                       default {
-                               ralink,group = "i2c", "uartf", "wled", "spi refclk", "pa";
-                               ralink,function = "gpio";
-                       };
-               };
-       };
+	pinctrl {
+		state_default: pinctrl0 {
+			default {
+				ralink,group = "i2c", "uartf", "wled", "spi refclk", "pa";
+				ralink,function = "gpio";
+			};
+		};
+	};
 
-       gpio-leds {
-               compatible = "gpio-leds";
-               power {
-                       label = "zbt-we826:green:power";
-                       gpios = <&gpio1 14 0>;
-               };
-               usb {
-                       label = "zbt-we826:green:usb";
-                       gpios = <&gpio1 15 0>;
-               };
-               air {
-                       label = "zbt-we826:green:wifi";
-                       gpios = <&gpio3 0 1>;
-               };
-       };
+	gpio-leds {
+		compatible = "gpio-leds";
+		power {
+			label = "zbt-we826:green:power";
+			gpios = <&gpio1 14 0>;
+		};
+		usb {
+			label = "zbt-we826:green:usb";
+			gpios = <&gpio1 15 0>;
+		};
+		air {
+			label = "zbt-we826:green:wifi";
+			gpios = <&gpio3 0 1>;
+		};
+	};
 
-       gpio-keys-polled {
-               compatible = "gpio-keys-polled";
-               #address-cells = <1>;
-               #size-cells = <0>;
-               poll-interval = <20>;
-               reset {
-                       label = "reset";
-                       gpios = <&gpio0 1 1>;
-                       linux,code = <0x198>;
-               };
-       };
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 1>;
+			linux,code = <0x198>;
+		};
+	};
 
-       pcie@10140000 {
-               status = "okay";
-       };
+	pcie@10140000 {
+		status = "okay";
+	};
+
 };

--- a/target/linux/ramips/mt7620/profiles/zbt.mk
+++ b/target/linux/ramips/mt7620/profiles/zbt.mk
@@ -6,11 +6,11 @@
 #
 
 define Profile/ZBT-WE826
-	NAME:=ZBT-WE826 Device
+	NAME:=ZBT-WE826
 	PACKAGES:=\
-		kmod-scsi-core kmod-scsi-generic kmod-mmc kmod-sdhci \
-		block-mount kmod-usb-core kmod-usb-dwc2 kmod-usb2 kmod-usb-ohci \
-		kmod-mt76
+		kmod-mt76 kmod-scsi-core kmod-scsi-generic kmod-mmc kmod-sdhci \
+		block-mount kmod-usb-core kmod-usb2 kmod-usb-ohci kmod-usb-serial \
+		kmod-usb-serial-option kmod-usb-serial-wwan comgt wwan
 endef
 
 define Profile/ZBT-WE826/Description


### PR DESCRIPTION
Cleanup ZBT-WE826 support:
* Refactor DTS
* Update diag.sh to blink WLAN LED (device has no WPS or status LED)
* Refactor makefile:
   * Add usb-serial-option kmods, comgt and wwan as these are sold on AliExpress with integrated WWAN miniPCIe cards and internal antennae
   * Remove usb-dwc2 kmod as device does not have USB OTG ports