### PR TITLE
base-files: improve dnsmasq.time handling for dnssec

### DIFF
--- a/package/base-files/files/etc/init.d/sysfixtime
+++ b/package/base-files/files/etc/init.d/sysfixtime
@@ -10,8 +10,8 @@ HWCLOCK=/sbin/hwclock
 boot() {
 	start && exit 0
 
+	local maxtime="$(maxtime)"
 	local curtime="$(date +%s)"
-	local maxtime="$(find /etc -type f -exec date -r {} +%s \; | sort -nr | head -n1)"
 	[ $curtime -lt $maxtime ] && date -s @$maxtime
 }
 
@@ -22,4 +22,13 @@ start() {
 stop() {
 	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -w -f $RTC_DEV && \
 		logger -t sysfixtime "saved '$(date)' to $RTC_DEV"
+}
+
+maxtime() {
+	local file newest
+
+	for file in $( find /etc -type f ! -path /etc/dnsmasq.time ) ; do
+		[ -z "$newest" -o "$newest" -ot "$file"] && newest=$file
+	done
+	[ "$newest" ] && date -r "$newest" +%s
 }

--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -151,6 +151,8 @@ $(call Package/dnsmasq/install,$(1))
 ifneq ($(CONFIG_PACKAGE_dnsmasq_full_dnssec),)
 	$(INSTALL_DIR) $(1)/usr/share/dnsmasq
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/trust-anchors.conf $(1)/usr/share/dnsmasq
+	$(INSTALL_DIR) $(1)/lib/upgrade
+	$(INSTALL_BIN) ./files/dnsmasqsec-add-conffiles.sh $(1)/lib/upgrade
 endif
 endef
 

--- a/package/network/services/dnsmasq/files/dnsmasqsec-add-conffiles.sh
+++ b/package/network/services/dnsmasq/files/dnsmasqsec-add-conffiles.sh
@@ -1,0 +1,16 @@
+add_dnsmasqsec_conffiles()
+{
+	local filelist="$1"
+
+	# do NOT include timestamp in a backup, only system upgrade
+	# dnsmasq restart ensures file timestamp is up to date
+	if [ -z $NEED_IMAGE ]; then
+		if [ $(ubus call service list '{"name":"dnsmasq"}' | jsonfilter -e '@.*.instances.instance1.running') = "true" ]; then
+			/etc/init.d/dnsmasq restart
+			sleep 1
+			echo "/etc/dnsmasq.time" >>$filelist
+		fi
+	fi
+}
+
+sysupgrade_init_conffiles="$sysupgrade_init_conffiles add_dnsmasqsec_conffiles"


### PR DESCRIPTION
dnsmasq uses dnsmasq.time to validate if the system clock is current or not.  This process is particularly important when dnsmasq's 'dnssec-check-unsigned' option is enabled.

