### PR TITLE
scripts/ipkg-build: fix deprecated GZIP environment variable warning

### DIFF
--- a/scripts/ipkg-build
+++ b/scripts/ipkg-build
@@ -15,7 +15,7 @@ FIND="${FIND:-$(which gfind)}"
 TAR="${TAR:-$(which tar)}"
 SVN="$(which svn)"
 GIT="$(which git)"
-export GZIP="-n"
+GZIP="$(which gzip)"
 
 # look up date of last commit
 if [ -d "$TOPDIR/.git" ]; then
@@ -139,20 +139,20 @@ mkdir $tmp_dir
 
 echo $CONTROL > $tmp_dir/tarX
 # Preserve permissions (-p) when creating data.tar.gz as non-root user
-( cd $pkg_dir && $TAR $ogargs -X $tmp_dir/tarX --format=gnu --sort=name -czpf $tmp_dir/data.tar.gz --mtime="$TIMESTAMP" . )
+( cd $pkg_dir && $TAR $ogargs -X $tmp_dir/tarX --format=gnu --sort=name -cpf -  --mtime="$TIMESTAMP" . | $GZIP -n - > $tmp_dir/data.tar.gz )
 
 installed_size=`stat -c "%s" $tmp_dir/data.tar.gz`
 sed -i -e "s/^Installed-Size: .*/Installed-Size: $installed_size/" \
 	$pkg_dir/$CONTROL/control
 
-( cd $pkg_dir/$CONTROL && $TAR $ogargs --format=gnu --sort=name -czf $tmp_dir/control.tar.gz --mtime="$TIMESTAMP" . )
+( cd $pkg_dir/$CONTROL && $TAR $ogargs --format=gnu --sort=name -cf -  --mtime="$TIMESTAMP" . | $GZIP -n - > $tmp_dir/control.tar.gz )
 rm $tmp_dir/tarX
 
 echo "2.0" > $tmp_dir/debian-binary
 
 pkg_file=$dest_dir/${pkg}_${version}_${arch}.ipk
 rm -f $pkg_file
-( cd $tmp_dir && $TAR $ogargs --format=gnu --sort=name -zcf $pkg_file --mtime="$TIMESTAMP" ./debian-binary ./data.tar.gz ./control.tar.gz )
+( cd $tmp_dir && $TAR $ogargs --format=gnu --sort=name -cf -  --mtime="$TIMESTAMP" ./debian-binary ./data.tar.gz ./control.tar.gz | $GZIP -n - > $pkg_file )
 
 rm $tmp_dir/debian-binary $tmp_dir/data.tar.gz $tmp_dir/control.tar.gz
 rmdir $tmp_dir


### PR DESCRIPTION
According to gzip 1.7 release note:

The GZIP environment variable is now obsolescent; gzip now warns if
it is used, and rejects attempts to use dangerous options or operands.
You can use an alias or script instead.

Fix this warning by using pipe instead

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>