### PR TITLE
[RFC] Base patch full vs busybox

### DIFF
--- a/include/package.mk
+++ b/include/package.mk
@@ -238,6 +238,20 @@ define Build/IncludeOverlay
   endef
 endef
 
+define Package/BusyBoxReplacement/Default
+  define Package/$(1)/postrm
+  #!/bin/sh
+  /bin/busybox $(4) -h 2>&1 | grep -q BusyBox && ln -sf $(if $(3),$(3)/)busybox $(2)/$(4)
+  $(5)
+  exit 0
+  endef
+  define Package/$(1)/install-location
+	$(INSTALL_DIR) $$(1)/$(2)
+	$(INSTALL_BIN) $(6) $$(1)/$(2)/$(4)
+	$(7)
+  endef
+endef
+
 define BuildPackage
   $(Build/IncludeOverlay)
   $(eval $(Package/Default))

--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -23,10 +23,17 @@ install_bin() { # <file> [ <symlink> ... ]
 	install_file $files
 	shift
 	for link in "$@"; do {
-		dest="$RAM_ROOT/$link"
-		dir="$(dirname $dest)"
-		mkdir -p "$dir"
-		[ -f "$dest" ] || ln -s $src $dest
+		# handle case of using full version of commands
+		# rather than busybox versions
+		if [ -L $link ] && readlink "$link" | grep -q "$(basename "$src")"; then
+			dest="$RAM_ROOT/$link"
+			dir="$(dirname $dest)"
+			mkdir -p "$dir"
+			[ -f "$dest" ] || ln -s $src $dest
+		else
+			[ -x "$link" ] && files="$link $(libs $link)"
+			install_file $files
+		fi
 	}; done
 }
 

--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iproute2
 PKG_VERSION:=4.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://kernel.org/pub/linux/utils/net/iproute2/
@@ -37,7 +37,11 @@ $(call Package/iproute2/Default,tiny,Minimal)
   CONFLICTS:=ip-full
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,ip,/sbin,../bin,ip,,$(PKG_BUILD_DIR)/ip/ip))
+
 Package/ip-full=$(call Package/iproute2/Default,full,Full)
+
+$(eval $(call Package/BusyBoxReplacement/Default,ip-full,/sbin,../bin,ip,,$(PKG_BUILD_DIR)/ip/ip))
 
 define Package/tc
 $(call Package/iproute2/Default)
@@ -101,14 +105,12 @@ define Build/InstallDev
 	$(CP) $(PKG_BUILD_DIR)/lib/libnetlink.a $(1)/usr/lib/
 endef
 
-define Package/ip/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ip/ip $(1)/usr/bin/
+define Package/ip-tiny/install
+	$(call Package/ip-tiny/install-location,$(1))
 endef
 
 define Package/ip-full/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ip/ip $(1)/usr/sbin/
+	$(call Package/ip-full/install-location,$(1))
 endef
 
 define Package/tc/install

--- a/package/network/utils/iputils/Makefile
+++ b/package/network/utils/iputils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iputils
 PKG_VERSION:=20101006
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-s$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.skbuff.net/iputils
@@ -42,6 +42,7 @@ define Package/iputils-arping/description
   Sends ARP REQUEST to a neighbour host.
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,iputils-arping,/usr/sbin../../bin,arping,,$(PKG_BUILD_DIR)/arping))
 
 define Package/iputils-clockdiff
 $(call Package/iputils/Default)
@@ -64,6 +65,7 @@ define Package/iputils-ping/description
   Sends ICMP ECHO_REQUEST to network hosts (IPv4).
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,iputils-ping,/bin,,ping,,$(PKG_BUILD_DIR)/ping))
 
 define Package/iputils-ping6
 $(call Package/iputils/Default)
@@ -76,6 +78,7 @@ define Package/iputils-ping6/description
   Sends ICMP ECHO_REQUEST to network hosts (IPv6).
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,iputils-ping6,/bin,,ping6,,$(PKG_BUILD_DIR)/ping6))
 
 define Package/iputils-tftpd
 $(call Package/iputils/Default)
@@ -87,6 +90,7 @@ define Package/iputils-tftpd/description
   Trivial File Transfer Protocol server.
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,iputils-tftpd,/usr/sbin,../../bin,tftpd,,$(PKG_BUILD_DIR)/tftpd))
 
 define Package/iputils-tracepath
 $(call Package/iputils/Default)
@@ -122,6 +126,8 @@ define Package/iputils-traceroute6/description
   Traces path to a network host (IPv6).
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,iputils-traceroute6,/usr/bin,../../bin,traceroute6,,$(PKG_BUILD_DIR)/traceroute6))
+
 ifdef CONFIG_USE_MUSL
   TARGET_CFLAGS += -D__UCLIBC__
 endif
@@ -132,8 +138,7 @@ MAKE_FLAGS += \
 	CONFIG_USE_UCLIBC="$(CONFIG_USE_UCLIBC)$(CONFIG_USE_MUSL)" \
 
 define Package/iputils-arping/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/arping $(1)/usr/bin/
+	$(call Package/iputils-ping/install-location,$(1))
 endef
 
 define Package/iputils-clockdiff/install
@@ -142,18 +147,15 @@ define Package/iputils-clockdiff/install
 endef
 
 define Package/iputils-ping/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ping $(1)/usr/bin/
+	$(call Package/iputils-ping/install-location,$(1))
 endef
 
 define Package/iputils-ping6/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ping6 $(1)/usr/bin/
+	$(call Package/iputils-ping6/install-location,$(1))
 endef
 
 define Package/iputils-tftpd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tftpd $(1)/usr/sbin/
+	$(call Package/iputils-ping/install-location,$(1))
 endef
 
 define Package/iputils-tracepath/install
@@ -167,8 +169,7 @@ define Package/iputils-tracepath6/install
 endef
 
 define Package/iputils-traceroute6/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/traceroute6 $(1)/usr/bin/
+	$(call Package/iputils-ping/install-location,$(1))
 endef
 
 $(eval $(call BuildPackage,iputils-arping))

--- a/package/utils/bzip2/Makefile
+++ b/package/utils/bzip2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bzip2
 PKG_VERSION:=1.0.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.bzip.org/$(PKG_VERSION)
@@ -53,6 +53,15 @@ define Package/bzip2/description
 	data compressor. This package provides the binary.
 endef
 
+define Package/bzip2/postrm
+#!/bin/sh
+  #!/bin/sh
+  /bin/busybox bzip2 -h 2>&1 | grep -q BusyBox && ln -sf ../../bin/busybox /usr/bin/bzip2 || rm -f /usr/bin/bzip2
+  /bin/busybox bunzip2 -h 2>&1 | grep -q BusyBox && ln -sf ../../bin/busybox /usr/bin/bunzip2 || rm -f /usr/bin/bunzip2
+  /bin/busybox bzcat -h 2>&1 | grep -q BusyBox && ln -sf ../../bin/busybox /usr/bin/bzcat || rm -f /usr/bin/bzcat
+exit 0
+endef
+
 TARGET_CFLAGS += \
 	$(FPIC) \
 	$(TARGET_LDFLAGS)
@@ -82,6 +91,8 @@ endef
 define Package/bzip2/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bzip2-shared $(1)/usr/bin/bzip2
+	ln -sf bzip2 $(1)/usr/bin/bunzip2
+	ln -sf bzip2 $(1)/usr/bin/bzcat
 endef
 
 HOST_CFLAGS += \

--- a/package/utils/util-linux/Makefile
+++ b/package/utils/util-linux/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=util-linux
 PKG_VERSION:=2.28
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/$(PKG_NAME)/v2.28
@@ -178,6 +178,8 @@ define Package/blkid/description
  library.
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,blkid,/sbin,../bin,blkid,,$(PKG_BUILD_DIR)/.libs/blkid))
+
 define Package/cal
 $(call Package/util-linux/Default)
   TITLE:=display a calendar
@@ -187,6 +189,8 @@ endef
 define Package/cal/description
  cal displays a simple calendar
 endef
+
+$(eval $(call Package/BusyBoxReplacement/Default,cal,/usr/bin,../../bin,cal,,$(PKG_BUILD_DIR)/cal))
 
 define Package/cfdisk
 $(call Package/util-linux/Default)
@@ -205,6 +209,8 @@ $(call Package/util-linux/Default)
   DEPENDS:= +librt
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,dmesg,/bin,,dmesg,,$(PKG_BUILD_DIR)/dmesg))
+
 define Package/dmesg/description
  dmesg  is used to examine or control the kernel ring buffer
 endef
@@ -220,6 +226,8 @@ define Package/fdisk/description
  a menu-driven program for creation and manipulation of partition tables
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,fdisk,/sbin,../bin,fdisk,,$(PKG_BUILD_DIR)/.libs/fdisk))
+
 define Package/findfs
 $(call Package/util-linux/Default)
   TITLE:=find a filesystem by label or UUID
@@ -232,6 +240,8 @@ define Package/findfs/description
  a label matching label or a UUID equal to uuid
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,findfs,/sbin,../bin,findfs,,$(PKG_BUILD_DIR)/.libs/findfs))
+
 define Package/flock
 $(call Package/util-linux/Default)
   TITLE:=manage locks from shell scripts
@@ -240,6 +250,8 @@ endef
 define Package/flock/description
   manages flock locks from within shell scripts or the command line
 endef
+
+$(eval $(call Package/BusyBoxReplacement/Default,flock,/usr/bin,../../bin,flock,,$(PKG_BUILD_DIR)/flock))
 
 define Package/getopt
 $(call Package/util-linux/Default)
@@ -251,6 +263,8 @@ define Package/getopt/description
  by shell procedures, and to check for legal options
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,getopt,/bin,,getopt,,$(PKG_BUILD_DIR)/getopt))
+
 define Package/hwclock
 $(call Package/util-linux/Default)
   TITLE:=query or set the hardware clock
@@ -259,6 +273,8 @@ endef
 define Package/hwclock/description
  hwclock is a tool for accessing the Hardware Clock
 endef
+
+$(eval $(call Package/BusyBoxReplacement/Default,hwclock,/sbin,../bin,hwclock,,$(PKG_BUILD_DIR)/hwclock))
 
 define Package/logger
 $(call Package/util-linux/Default)
@@ -269,6 +285,8 @@ define Package/logger/description
  logger makes entries in the system log, it provides a shell command interface
  to the syslog system log module
 endef
+
+$(eval $(call Package/BusyBoxReplacement/Default,logger,/usr/bin,../../bin,logger,,$(PKG_BUILD_DIR)/logger))
 
 define Package/look
 $(call Package/util-linux/Default)
@@ -289,6 +307,8 @@ define Package/losetup/description
  losetup is used to associate loop devices with regular files or block devices,
  to detach loop devices and to query the status of a loop device
 endef
+
+$(eval $(call Package/BusyBoxReplacement/Default,losetup,/sbin,../bin,losetup,,$(PKG_BUILD_DIR)/.libs/losetup))
 
 define Package/lsblk
 $(call Package/util-linux/Default)
@@ -320,6 +340,10 @@ endef
 define Package/mount-utils/description
  contains: mount, umount, findmnt
 endef
+
+$(eval $(call Package/BusyBoxReplacement/Default,mount-utils,/bin,,mount,\
+/bin/busybox umount -h 2>&1 | grep -q BusyBox && ln -sf busybox /bin/umount \
+,$(PKG_BUILD_DIR)/.libs/mount,$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/umount $$(1)/bin/umount))
 
 define Package/namei
 $(call Package/util-linux/Default)
@@ -373,6 +397,10 @@ define Package/script-utils/description
  contains: script, scriptreplay
 endef
 
+$(eval $(call Package/BusyBoxReplacement/Default,script-utils,/usr/bin,../../bin,script,\
+/bin/busybox scriptreplay -h 2>&1 | grep -q BusyBox && ln -sf ../../busybox /usr/bin/scriptreplay,\
+$(PKG_BUILD_DIR)/script,$(INSTALL_BIN) $(PKG_BUILD_DIR)/scriptreplay $$(1)/usr/bin/scriptreplay))
+
 define Package/setterm
 $(call Package/util-linux/Default)
   TITLE:=set terminal attributes
@@ -406,6 +434,10 @@ endef
 define Package/swap-utils/description
  contains: mkswap, swaplabel
 endef
+
+$(eval $(call Package/BusyBoxReplacement/Default,swap-utils,/sbin,../bin,mkswap,\
+/bin/busybox swaplabel -h 2>&1 | grep -q BusyBox && ln -sf ../bin/busybox /sbin/swaplabel || rm -f /sbin/swaplabel,\
+$(PKG_BUILD_DIR)/.libs/mkswap,$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/swaplabel $$(1)/sbin/swaplabel))
 
 define Package/uuidd
 $(call Package/util-linux/Default)
@@ -443,6 +475,8 @@ define Package/wall/description
  wall sends a message to everybody logged in with their mesg permission
  set to yes
 endef
+
+$(eval $(call Package/BusyBoxReplacement/Default,wall,/usr/bin,../../bin,wall,,$(PKG_BUILD_DIR)/wall))
 
 define Package/whereis
 $(call Package/util-linux/Default)
@@ -502,13 +536,11 @@ define Package/blkdiscard/install
 endef
 
 define Package/blkid/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/blkid $(1)/usr/sbin/
+	$(call Package/blkid/install-location,$(1))
 endef
 
 define Package/cal/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cal $(1)/usr/bin/
+	$(call Package/cal/install-location,$(1))
 endef
 
 define Package/cfdisk/install
@@ -517,38 +549,31 @@ define Package/cfdisk/install
 endef
 
 define Package/dmesg/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dmesg $(1)/usr/sbin/
+	$(call Package/dmesg/install-location,$(1))
 endef
 
 define Package/fdisk/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/fdisk $(1)/usr/sbin/
+	$(call Package/fdisk/install-location,$(1))
 endef
 
 define Package/findfs/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/findfs $(1)/usr/sbin/
+	$(call Package/findfs/install-location,$(1))
 endef
 
 define Package/flock/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/flock $(1)/usr/bin/
+	$(call Package/flock/install-location,$(1))
 endef
 
 define Package/getopt/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/getopt $(1)/usr/bin/
+	$(call Package/getopt/install-location,$(1))
 endef
 
 define Package/hwclock/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hwclock $(1)/usr/sbin/
+	$(call Package/hwclock/install-location,$(1))
 endef
 
 define Package/logger/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/logger $(1)/usr/bin/
+	$(call Package/logger/install-location,$(1))
 endef
 
 define Package/look/install
@@ -557,8 +582,7 @@ define Package/look/install
 endef
 
 define Package/losetup/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/losetup $(1)/usr/sbin/
+	$(call Package/losetup/install-location,$(1))
 endef
 
 define Package/lsblk/install
@@ -573,7 +597,7 @@ endef
 
 define Package/mount-utils/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/{u,}mount $(1)/usr/bin/
+	$(call Package/mount-utils/install-location,$(1))
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/mountpoint $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/findmnt $(1)/usr/bin/
 endef
@@ -601,9 +625,7 @@ define Package/partx-utils/install
 endef
 
 define Package/script-utils/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/script $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/scriptreplay $(1)/usr/bin/
+	$(call Package/script-utils/install-location,$(1))
 endef
 
 define Package/setterm/install
@@ -617,9 +639,7 @@ define Package/sfdisk/install
 endef
 
 define Package/swap-utils/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/mkswap $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/swaplabel $(1)/usr/sbin/
+	$(call Package/swap-utils/install-location,$(1))
 endef
 
 define Package/uuidd/install
@@ -633,8 +653,7 @@ define Package/uuidgen/install
 endef
 
 define Package/wall/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wall $(1)/usr/bin/
+	$(call Package/wall/install-location,$(1))
 endef
 
 define Package/whereis/install


### PR DESCRIPTION
This is not fully compile and image tested, but is more as a request for comments to see if I should be only concerned with this for my personal tree, or if it of interest for you folks.  I have a corresponding patchset for the packages feed that does the same kind of thing.

Basically this patchset takes the attitude towards full versions vs. busybox version of commands that seems to be implemented for bzip2, which is that we don't care about not needing --override to opkg in order to install the full version (and in fact this is preferred, since it means the full version is the same path location as the busybox version), but takes the additional step of making sure that if the full verison is removed that the busybox symlink is restored.

It also takes care of making sure sysupgrade gets the necessary files when the full version is installed into the image without the corresponding busybox applet compiled in.