### PR TITLE
package/system/ca-certificates: Add certificate bundle package

### DIFF
--- a/package/system/ca-certificates/Makefile
+++ b/package/system/ca-certificates/Makefile
@@ -26,6 +26,13 @@ define Package/ca-certificates
   PKGARCH:=all
 endef
 
+define Package/ca-bundle
+  SECTION:=base
+  CATEGORY:=Base system
+  TITLE:=System CA certificates as a bundle
+  PKGARCH:=all
+endef
+
 define Build/Install
 	mkdir -p \
 		$(PKG_INSTALL_DIR)/usr/sbin \
@@ -47,4 +54,9 @@ define Package/ca-certificates/install
 	done
 endef
 
+define Package/ca-bundle/install
+	$(INSTALL_DIR) $(1)/etc/ssl/certs
+	cat $(PKG_INSTALL_DIR)/usr/share/ca-certificates/*/*.crt >$(1)/etc/ssl/certs/ca-certificates.crt
+endef
 $(eval $(call BuildPackage,ca-certificates))
+$(eval $(call BuildPackage,ca-bundle))


### PR DESCRIPTION
Some SSL applications requires a certificates bundle rather
than a directory containing certificates.  For thos applications
we build the ca-bundle package

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>

NOTE: This still needs be tested, but looks easy enough that I post already anywayh