### PR TITLE
[RFC] package/boot/uboot-envtools: Fails to build on x86_64 so don't build …

### DIFF
--- a/package/boot/uboot-envtools/Makefile
+++ b/package/boot/uboot-envtools/Makefile
@@ -33,6 +33,7 @@ define Package/uboot-envtools
   CATEGORY:=Utilities
   TITLE:=read/modify U-Boot bootloader environment
   URL:=http://www.denx.de/wiki/U-Boot
+  DEPENDS:= @!TARGET_x86_64
 endef
 
 define Package/uboot-envtools/description


### PR DESCRIPTION
…there

uboot-envtools fails to build on x86_64 and is not applicable
there in any case, so make package depend on NOT x86_64.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>

This is probably applicable to more than just x86_64, hence provided for informational purposes