### PR TITLE
[URFC] default sdk ib: Make building minimal sdk and ib the default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ key-build*
 .emacs.desktop*
 TAGS*~
 git-src
+.minimal-sdk
+.nas

--- a/README
+++ b/README
@@ -21,6 +21,19 @@ To build your own firmware you need to have access to a Linux, BSD or MacOSX sys
 (case-sensitive filesystem required). Cygwin will not be supported because of
 the lack of case sensitiveness in the file system.
 
+If you wish to build a minimal sdk or use the nas device type profile, then
+*before* any other commands (or else 'rm -rf .config tmp'), you need to either
+
+touch .minimal-sdk
+
+for selecting the minimal sdk package set (but you still must leave
+SDK selected in menuconfig to actually build a minimal SDK).
+
+or
+
+touch .nas
+
+for selecting the nas package set.
 
 Sunshine!
 	Your LEDE Community

--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -17,6 +17,7 @@ menu "Global build settings"
 
 	config ALL
 		bool "Select all userspace packages by default"
+		depends on !SDK_MINIMAL
 		default n
 
 	config SIGNED_PACKAGES

--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -8,7 +8,7 @@ menu "Target Images"
 
 	menuconfig TARGET_ROOTFS_INITRAMFS
 		bool "ramdisk"
-		default y if USES_INITRAMFS
+		default y if ( USES_INITRAMFS && !SDK_MINIMAL )
 		help
 		  Embed the root filesystem into the kernel (initramfs).
 
@@ -54,13 +54,13 @@ menu "Target Images"
 
 	config TARGET_ROOTFS_CPIOGZ
 		bool "cpio.gz"
-		default y if USES_CPIOGZ
+		default y if ( USES_CPIOGZ && !SDK_MINIMAL )
 		help
 		  Build a compressed cpio archive of the root filesystem.
 
 	config TARGET_ROOTFS_TARGZ
 		bool "tar.gz"
-		default y if USES_TARGZ
+		default y if ( USES_TARGZ && !SDK_MINIMAL )
 		help
 		  Build a compressed tar archive of the root filesystem.
 
@@ -68,7 +68,7 @@ menu "Target Images"
 
 	menuconfig TARGET_ROOTFS_EXT4FS
 		bool "ext4"
-		default y if USES_EXT4
+		default y if ( USES_EXT4 && !SDK_MINIMAL )
 		help
 		  Build an ext4 root filesystem.
 
@@ -126,20 +126,20 @@ menu "Target Images"
 
 	config TARGET_ROOTFS_JFFS2
 		bool "jffs2"
-		default y if USES_JFFS2
+		default y if ( USES_JFFS2 && !SDK_MINIMAL )
 		help
 		  Build a JFFS2 root filesystem.
 
 	config TARGET_ROOTFS_JFFS2_NAND
 		bool "jffs2 for NAND"
-		default y if USES_JFFS2_NAND
+		default y if ( USES_JFFS2_NAND && !SDK_MINIMAL )
 		depends on USES_JFFS2_NAND
 		help
 		  Build a JFFS2 root filesystem for NAND flash.
 
 	menuconfig TARGET_ROOTFS_SQUASHFS
 		bool "squashfs"
-		default y if USES_SQUASHFS
+		default y if ( USES_SQUASHFS && !SDK_MINIMAL )
 		help
 		  Build a squashfs-lzma root filesystem.
 
@@ -151,7 +151,7 @@ menu "Target Images"
 
 	menuconfig TARGET_ROOTFS_UBIFS
 		bool "ubifs"
-		default y if USES_UBIFS
+		default y if ( USES_UBIFS && !SDK_MINIMAL )
 		depends on USES_UBIFS
 		help
 		  Build a UBIFS root filesystem.
@@ -189,7 +189,7 @@ menu "Target Images"
 		depends on TARGET_x86
 		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_ISO || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS
 		select PACKAGE_grub2
-		default y
+		default y if !SDK_MINIMAL
 
 	config GRUB_CONSOLE
 		bool "Use Console Terminal (in addition to Serial)"
@@ -245,7 +245,7 @@ menu "Target Images"
 	config TARGET_IMAGES_GZIP
 		bool "GZip images"
 		depends on TARGET_IMAGES_PAD || TARGET_ROOTFS_EXT4FS
-		default y
+		default y if !SDK_MINIMAL
 
 	comment "Image Options"
 

--- a/package/system/usign/Makefile
+++ b/package/system/usign/Makefile
@@ -29,6 +29,7 @@ define Package/usign
   CATEGORY:=Base system
   DEPENDS:=+libubox
   TITLE:=OpenWrt signature verification utility
+  DEFAULT:=m if SIGNED_PACKAGES
 endef
 
 CMAKE_OPTIONS += \

--- a/scripts/metadata.pl
+++ b/scripts/metadata.pl
@@ -372,7 +372,9 @@ EOF
 	print "\tdefault \"\"\n";
 
 	my %kver;
+	my $minimal_sdk = 0;
 	foreach my $target (@target) {
+		$target->{minimal_sdk} and $minimal_sdk = 1;
 		my $v = kver($target->{version});
 		next if $kver{$v};
 		$kver{$v} = 1;
@@ -386,6 +388,16 @@ EOF
 	foreach my $def (sort keys %defaults) {
 		print "\tconfig DEFAULT_".$def."\n";
 		print "\t\tbool\n\n";
+	}
+
+	if ($minimal_sdk) {
+		print <<EOF;
+config SDK_MINIMAL
+	bool
+	default y
+	select SDK
+
+EOF
 	}
 }
 

--- a/scripts/metadata.pm
+++ b/scripts/metadata.pm
@@ -96,6 +96,7 @@ sub parse_target_metadata($) {
 		};
 		/^Target-Profile-Packages:\s*(.*)\s*$/ and $profile->{packages} = [ split(/\s+/, $1) ];
 		/^Target-Profile-Description:\s*(.*)\s*/ and $profile->{desc} = get_multiline(*FILE);
+		/^Minimal-SDK:\s*1\s*/ and $target->{minimal_sdk} = 1;
 	}
 	close FILE;
 	foreach my $target (@target) {

--- a/target/convert-config.pl
+++ b/target/convert-config.pl
@@ -11,6 +11,7 @@ EOF
 while (<>) {
 	chomp;
 	next if /^CONFIG_SIGNED_PACKAGES/;
+	next if /^CONFIG_SDK_MINIMAL/;
 	next unless /^CONFIG_([^=]+)=(.*)$/;
 
 	my $var = $1;

--- a/target/imagebuilder/Config.in
+++ b/target/imagebuilder/Config.in
@@ -1,6 +1,7 @@
 config IB
 	bool "Build the LEDE Image Builder"
 	depends on !EXTERNAL_TOOLCHAIN
+	default y if SDK_MINIMAL
 	help
 	  This is essentially a stripped-down version of the buildroot
 	  with precompiled packages, kernel image and image building tools.
@@ -8,7 +9,7 @@ config IB
 
 config IB_STANDALONE
 	bool "Include package repositories"
-	default y
+	default y if !SDK_MINIMAL
 	depends on IB
 	help
 	  Disabling this option will cause the ImageBuilder to embed only

--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -24,8 +24,10 @@ all: compile
 $(BIN_DIR)/$(IB_NAME).tar.bz2: clean
 	rm -rf $(PKG_BUILD_DIR)
 	mkdir -p $(IB_KDIR) $(IB_LDIR) $(PKG_BUILD_DIR)/staging_dir/host/lib \
-		$(PKG_BUILD_DIR)/target $(PKG_BUILD_DIR)/scripts $(IB_DTSDIR)
+		$(PKG_BUILD_DIR)/target $(IB_DTSDIR)
 	-cp $(TOPDIR)/.config $(PKG_BUILD_DIR)/.config
+	$(SED) 's/^SDK_MINIMAL=y/# SDK_MINIMAL is no set/' $(PKG_BUILD_DIR)/.config
+	../convert-config.pl $(TOPDIR)/.config > $(PKG_BUILD_DIR)/Config-build.in
 	$(CP) \
 		$(INCLUDE_DIR) $(SCRIPT_DIR) \
 		$(TOPDIR)/rules.mk \
@@ -33,7 +35,13 @@ $(BIN_DIR)/$(IB_NAME).tar.bz2: clean
 		./files/repositories.conf \
 		$(TMP_DIR)/.targetinfo \
 		$(TMP_DIR)/.packageinfo \
+		./files/Config.in \
+		$(TOPDIR)/config/Config-images.in \
 		$(PKG_BUILD_DIR)/
+	if [ -r $(TOPDIR)/linux/$(BOARD)/image/Config.in ]; then \
+		$(CP) $(TOPDIR)/linux/$(BOARD)/image/Config.in $(PKG_BUILD_DIR)/Config-$(BOARD).in ; \
+		echo "\nsource \"Config-$(BOARD).in\"" >$(PKG_BUILD_DIR)/Config.in ; \
+	fi
 
 ifeq ($(CONFIG_IB_STANDALONE),)
 	echo '## Remote package repositories' >> $(PKG_BUILD_DIR)/repositories.conf

--- a/target/imagebuilder/files/Config.in
+++ b/target/imagebuilder/files/Config.in
@@ -1,0 +1,2 @@
+source "Config-build.in"
+source "Config-images.in"

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -9,8 +9,11 @@
 TOPDIR:=${CURDIR}
 LC_ALL:=C
 LANG:=C
-export TOPDIR LC_ALL LANG
+export TOPDIR LC_ALL LANG IB
 export OPENWRT_VERBOSE=s
+
+IB:=1
+
 all: help
 
 include $(TOPDIR)/include/host.mk
@@ -194,6 +197,31 @@ endif
 		$(if $(FILES),USER_FILES="$(FILES)") \
 		$(if $(PACKAGES),USER_PACKAGES="$(PACKAGES)") \
 		$(if $(BIN_DIR),BIN_DIR="$(BIN_DIR)"))
+
+.config: ./scripts/config/conf
+	@+if [ \! -e .config ] || ! grep CONFIG_HAVE_DOT_CONFIG .config >/dev/null; then \
+		[ -e $(HOME)/.cshorewrt/defconfig ] && cp $(HOME)/.cshorewrt/defconfig .config; \
+		$(_SINGLE)$(NO_TRACE_MAKE) menuconfig $(PREP_MK); \
+	fi
+
+defconfig: scripts/config/conf FORCE
+	touch .config
+	@if [ -e $(HOME)/.cshorewrt/defconfig ]; then cp $(HOME)/.cshorewrt/defconfig .config; fi
+	$< --defconfig=.config Config.in
+
+confdefault-y=allyes
+confdefault-m=allmod
+confdefault-n=allno
+confdefault:=$(confdefault-$(CONFDEFAULT))
+
+oldconfig: scripts/config/conf FORCE
+	$< --$(if $(confdefault),$(confdefault),old)config Config.in
+
+menuconfig: scripts/config/mconf FORCE
+	if [ \! -e .config -a -e $(HOME)/.cshorewrt/defconfig ]; then \
+		cp $(HOME)/.cshorewrt/defconfig .config; \
+	fi
+	$< Config.in
 
 .SILENT: help info image
 

--- a/target/sdk/Config.in
+++ b/target/sdk/Config.in
@@ -5,5 +5,3 @@ config SDK
 	  This is essentially a stripped-down version of the buildroot
 	  with a precompiled toolchain. It can be used to develop and
 	  test packages for LEDE before including them in the buildroot
-
-

--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -95,7 +95,7 @@ $(BIN_DIR)/$(SDK_NAME).tar.bz2: clean
 	rm -rf \
 		$(SDK_BUILD_DIR)/target/linux/*/files* \
 		$(SDK_BUILD_DIR)/target/linux/*/patches*
-	./convert-config.pl $(TOPDIR)/.config > $(SDK_BUILD_DIR)/Config-build.in
+	../convert-config.pl $(TOPDIR)/.config > $(SDK_BUILD_DIR)/Config-build.in
 	$(CP) -L \
 		$(TOPDIR)/LICENSE \
 		$(TOPDIR)/rules.mk \
@@ -109,6 +109,7 @@ $(BIN_DIR)/$(SDK_NAME).tar.bz2: clean
 		$(TOPDIR)/package/Makefile \
 		$(SDK_BUILD_DIR)/package/
 
+	$(SED) 's/^SDK_MINIMAL=y/# SDK_MINIMAL is not set/' $(SDK_BUILD_DIR)/.config
 	-rm -f $(SDK_BUILD_DIR)/feeds.conf.default
 	$(if $(BASE_FEED),echo "$(BASE_FEED)" > $(SDK_BUILD_DIR)/feeds.conf.default)
 	if [ -f $(TOPDIR)/feeds.conf ]; then \


### PR DESCRIPTION
Make the default building a minimal sdk (consisting of only the
toolchain, kernel, and all binary packages for source packages
depended on by the toolchain and kernel and chosen target) and
minimal imagebuilder (no packages included since that would defeat
build a minimal sdk), and building everything else from the
SDK (and have images generated by imagebuilder for which enable
menuconfig because with no packages built during core build it
doesn't make sense to configure and build images).

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

NOTE: that I plan on removing the DEFAULT_MODULE_PACKAGES as that becomes unnecessary with the SOURCE_<src-pkg-name> logic in a patch in my RFC patch for preventing reconfiguration of already built packages in SDK.