### PR TITLE
[RFC] package/utils/mdadm: Fix missing conffile and add initscript

### DIFF
--- a/package/utils/mdadm/Makefile
+++ b/package/utils/mdadm/Makefile
@@ -33,6 +33,11 @@ define Package/mdadm/description
  A tool for managing Linux Software RAID arrays.
 endef
 
+define Package/mdadm/conffiles
+/etc/mdadm.conf
+/etc/config/mdadm
+endef
+
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections
 
@@ -47,6 +52,10 @@ endef
 define Package/mdadm/install
 	$(INSTALL_DIR) $(1)/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mdadm $(1)/sbin
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/mdadm.init $(1)/etc/init.d/mdadm
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/mdadm.config $(1)/etc/config/mdadm
 endef
 
 $(eval $(call BuildPackage,mdadm))

--- a/package/utils/mdadm/files/mdadm.config
+++ b/package/utils/mdadm/files/mdadm.config
@@ -1,0 +1,3 @@
+config mdadm
+	option email root
+

--- a/package/utils/mdadm/files/mdadm.init
+++ b/package/utils/mdadm/files/mdadm.init
@@ -1,0 +1,34 @@
+#!/bin/sh /etc/rc.common
+
+START=13
+STOP=98
+
+USE_PROCD=1
+PROG=/sbin/mdadm
+NAME=mdadm
+
+mdadm_email() {
+	local cfg="$1"
+	if [ ! -x /sbin/sendmail ]; then
+		return
+	fi
+	config_get email "$cfg" email
+}
+
+start_service() {
+	local email
+
+	config_load mdadm
+	config_foreach mdadm_email mdadm
+
+	$PROG --assemble --scan
+
+	procd_open_instance
+	procd_set_param command "$PROG" --monitor ${email:+--mail=$email} --syslog --scan
+	procd_close_instance
+}
+
+stop_service() {
+	$PROG --stop --scan
+}
+


### PR DESCRIPTION
Start arrays on boot, stop them on shutdown, and enable
monitoring to syslog.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

Has been tested in some iteration however I had to rebase, but because it seems simple enough that it shouldn't be a problem, I submit anyway