### PR TITLE
target/imagebuilder: Fix sorting package list breaks opkg dependency …

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -104,7 +104,7 @@ _call_info: FORCE
 	echo 'Available Profiles:'
 	echo; $(PROFILE_LIST)
 
-BUILD_PACKAGES:=$(sort $(DEFAULT_PACKAGES) $(USER_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel)
+BUILD_PACKAGES:=$(USER_PACKAGES) $(sort $(DEFAULT_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel)
 # "-pkgname" in the package list means remove "pkgname" from the package list
 BUILD_PACKAGES:=$(filter-out $(filter -%,$(BUILD_PACKAGES)) $(patsubst -%,%,$(filter -%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
 PACKAGES:=


### PR DESCRIPTION
…handling for provides

When imagebuild sorts package lists it breaks opkg's ability to realize
that a providers for a Provides has already been installed, when the sort
results in the provider being later in the list of packages that a package
which depends on a Provides (and hence the provider is not yet installed
for opkg to realize the provider was available doesn't not handle the case
of a package that is to be installed satisfying a dependency, only one that
is already installed (or which it schedules to be installed, which in the
absence of an installed provider is whichever provider happens to be the
default)

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

It'll probably be quite a while before I get a chance to do the real fix, which is to patch upstream's opkg so it's suitable for LEDE, hence this workaround for now.