### PR TITLE
[RFC] package/kernel: Build it87 hardware monitor module

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -93,6 +93,20 @@ endef
 $(eval $(call KernelPackage,hwmon-ina2xx))
 
 
+define KernelPackage/hwmon-it87
+  TITLE:=IT87 monitoring support
+  KCONFIG:=CONFIG_SENSORS_IT87
+  FILES:=$(LINUX_DIR)/drivers/hwmon/it87.ko
+  AUTOLOAD:=$(call AutoProbe,it87)
+  $(call AddDepends/hwmon,+kmod-i2c-core +kmod-hwmon-vid +PACKAGE_kmod-thermal:kmod-thermal)
+endef
+
+define KernelPackage/hwmon-it87/description
+ Kernel module for it87 thermal and voltage monitor chip
+endef
+
+$(eval $(call KernelPackage,hwmon-it87))
+
 define KernelPackage/hwmon-lm63
   TITLE:=LM63/64 monitoring support
   KCONFIG:=CONFIG_SENSORS_LM63


### PR DESCRIPTION
Add packaging of it87 hardware monitor kernel module.  It is
a common thermal and voltage monitor that is in many x86
(at least) devices, and is just another i2c hwmon module.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

Has been tested in some iteration, however not since I've rebased.  Simple enough to submit anyway.