### PR TITLE
script/symlink-tree.sh: Fix missing config dir

### DIFF
--- a/scripts/symlink-tree.sh
+++ b/scripts/symlink-tree.sh
@@ -4,6 +4,7 @@
 
 FILES="
 	BSDmakefile
+	config
 	Config.in
 	LICENSE
 	Makefile
@@ -18,6 +19,9 @@ FILES="
 	target
 	toolchain
 	tools"
+
+OPTIONAL_FILES="
+	.git"
 
 if [ -f feeds.conf ] ; then
 	FILES="$FILES feeds.conf"
@@ -41,5 +45,8 @@ for file in $FILES; do
 		exit 1
 	}
 	ln -s "$PWD/$file" "$1/"
+done
+for file in $OPTIONAL_FILES; do
+	[ -e "$PWD/$file" ] && ln -s "$PWD/$file" "$1/"
 done
 exit 0


### PR DESCRIPTION
Apparently symlink-tree has not been used in quite some time as it
fails to symlink the always required config dir

Also, if we pulled from git but .git is missing we get
many error messages on the symlinked tree without this
patch (which symlinks .git, if present)

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>