### PR TITLE
target/sdk: Allow to configure feeds in SDK

### DIFF
--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -5,3 +5,7 @@ config MODULES
 
 source "Config-build.in"
 source "tmp/.config-package.in"
+
+menu "Configure feeds"
+source "tmp/.config-feeds.in"
+endmenu


### PR DESCRIPTION
We may want more feeds in SDK than in core, hence allow to configure feeds in SDK.