### PR TITLE
Full versions vs. BusyBox

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -49,11 +49,11 @@ supivot() { # <new_root> <old_root>
 run_ramfs() { # <command> [...]
 	install_bin /bin/busybox /bin/ash /bin/sh /bin/mount /bin/umount	\
 		/sbin/pivot_root /sbin/reboot /bin/sync /bin/dd	/bin/grep       \
-		/bin/cp /bin/mv /bin/tar /usr/bin/md5sum "/usr/bin/[" /bin/dd	\
-		/bin/vi /bin/ls /bin/cat /usr/bin/awk /usr/bin/hexdump		\
-		/bin/sleep /bin/zcat /usr/bin/bzcat /usr/bin/printf /usr/bin/wc \
-		/bin/cut /usr/bin/printf /bin/sync /bin/mkdir /bin/rmdir	\
-		/bin/rm /usr/bin/basename /bin/kill /bin/chmod
+		/bin/cp /bin/mv /bin/tar /bin/md5sum "/bin/[" /bin/dd	\
+		/bin/vi /bin/ls /bin/cat /bin/awk /bin/hexdump		\
+		/bin/sleep /bin/zcat /bin/bzcat /bin/printf /bin/wc \
+		/bin/cut /bin/sync /bin/mkdir /bin/rmdir	\
+		/bin/rm /bin/basename /bin/kill /bin/chmod
 
 	install_bin /bin/uclient-fetch /bin/wget
 	install_bin /sbin/mtd

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -39,7 +39,7 @@ config BUSYBOX_DEFAULT_FEATURE_INSTALLER
 	default n
 config BUSYBOX_DEFAULT_INSTALL_NO_USR
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_LOCALE_SUPPORT
 	bool
 	default n

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.24.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/package/utils/busybox/convert_defaults.pl
+++ b/package/utils/busybox/convert_defaults.pl
@@ -8,6 +8,7 @@ while (<>) {
 		my $type = "bool";
 		$default =~ /^\"/ and $type = "string";
 		$default =~ /^\d/ and $type = "int";
+		( $2 eq 'INSTALL_NO_USR' ) and $default = "y";
 		print "config BUSYBOX_DEFAULT_$name\n\t$type\n\tdefault $default\n";
 	};
 }

--- a/package/utils/busybox/files/cron
+++ b/package/utils/busybox/files/cron
@@ -4,7 +4,7 @@
 START=50
 
 USE_PROCD=1
-PROG=/usr/sbin/crond
+PROG=/sbin/crond
 
 validate_cron_section() {
 	uci_validate_section system system "${1}" \

--- a/package/utils/busybox/files/sysntpd
+++ b/package/utils/busybox/files/sysntpd
@@ -4,7 +4,7 @@
 START=98
 
 USE_PROCD=1
-PROG=/usr/sbin/ntpd
+PROG=/sbin/ntpd
 HOTPLUG_SCRIPT=/usr/sbin/ntpd-hotplug
 
 validate_ntp_section() {

--- a/package/utils/bzip2/Makefile
+++ b/package/utils/bzip2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bzip2
 PKG_VERSION:=1.0.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.bzip.org/$(PKG_VERSION)
@@ -82,6 +82,8 @@ endef
 define Package/bzip2/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bzip2-shared $(1)/usr/bin/bzip2
+	ln -sf bzip2 $(1)/usr/bin/bunzip2
+	ln -sf bzip2 $(1)/usr/bin/bzcat
 endef
 
 HOST_CFLAGS += \


### PR DESCRIPTION
Hi Felix, John,

Does this look more like what you are thinking?  If so I will test it before issuing a real PR.

A couple of notes:

1) Based on a grep of an ar71xx rootfs and of the package directory the only hard-coded references to busybox applets in /usr seems to be for ntpd and crond in their respecitve initscripts.
2) Based on that I'm wondering if makes sense to drop the /usr/bin/env and /usr/bin/awk symlinks too (since the only breakage might be in packages and third party scripts, not anything critical to device operation).