### PR TITLE
[URFC] Patch samba vfs acl config options

### DIFF
--- a/package/network/services/samba36/Makefile
+++ b/package/network/services/samba36/Makefile
@@ -36,7 +36,7 @@ define Package/samba36-server
   SUBMENU:=Filesystem
   TITLE:=Samba 3.6 SMB/CIFS server
   URL:=http://www.samba.org/
-  DEPENDS:=+USE_GLIBC:librt $(ICONV_DEPENDS) +PACKAGE_SAMBA_LIBAVAHI_SUPPORT:libavahi-client
+  DEPENDS:=+USE_GLIBC:librt $(ICONV_DEPENDS) +PACKAGE_SAMBA_ACL_SUPPORT:libacl +PACKAGE_SAMBA_ATTR_SUPPORT:libattr +PACKAGE_SAMBA_LIBAVAHI_SUPPORT:libavahi-client
 endef
 
 define Package/samba36-server-avahi-service
@@ -66,6 +66,19 @@ define Package/samba36-server/config
 		depends on PACKAGE_samba36-server || PACKAGE_samba36-client
 		default -1
 
+	config PACKAGE_SAMBA_ACL_SUPPORT
+		bool "SAMBA: Enable POSIX ACL support"
+		depends on PACKAGE_samba36-server || PACKAGE_samba36-client
+		select PACKAGE_libacl
+		default n
+
+	config PACKAGE_SAMBA_ATTR_SUPPORT
+		bool "SAMBA: Enable Linux extended attribute support"
+		depends on PACKAGE_samba36-server || PACKAGE_samba36-client
+		select PACKAGE_libattr
+		default n
+		select PACKAGE_SAMBA_ACL_SUPPORT
+
 	config PACKAGE_SAMBA_LIBAVAHI_SUPPORT
 		bool "SAMBA: Enable mDNS support"
 		depends on PACKAGE_samba36-server
@@ -84,8 +97,6 @@ TARGET_CFLAGS += -DMAX_DEBUG_LEVEL=$(CONFIG_PACKAGE_SAMBA_MAX_DEBUG_LEVEL) -D__l
 TARGET_LDFLAGS += -Wl,--gc-sections
 
 CONFIGURE_VARS += \
-	ac_cv_lib_attr_getxattr=no \
-	ac_cv_search_getxattr=no \
 	ac_cv_file__proc_sys_kernel_core_pattern=yes \
 	libreplace_cv_HAVE_C99_VSNPRINTF=yes \
 	libreplace_cv_HAVE_GETADDRINFO=yes \
@@ -105,6 +116,12 @@ CONFIGURE_VARS += \
 	samba_cv_zlib_1_2_3=no \
 	ac_cv_path_PYTHON="" \
 	ac_cv_path_PYTHON_CONFIG=""
+
+ifeq ($(CONFIG_SAMBA_PACKAGE_ATTR_SUPPORT),)
+CONFIGURE_VARS += \
+	ac_cv_lib_attr_getxattr=no \
+	ac_cv_search_getxattr=no
+endif
 
 CONFIGURE_ARGS += \
 	--exec-prefix=/usr \
@@ -126,7 +143,6 @@ CONFIGURE_ARGS += \
 	--with-piddir=/var/run \
 	--with-privatedir=/etc/samba \
 	--with-sendfile-support \
-	--without-acl-support \
 	--without-cluster-support \
 	--without-ads \
 	--without-krb5 \
@@ -140,8 +156,20 @@ CONFIGURE_ARGS += \
 	--without-libsmbsharemodes \
 	--without-libtevent \
 	--without-libaddns \
-	--with-shared-modules=pdb_tdbsam,pdb_wbc_sam,idmap_nss,nss_info_template,auth_winbind,auth_wbc,auth_domain
 
+ifneq ($(CONFIG_PACKAGE_SAMBA_ATTR_SUPPORT),)
+SAMBA_STATIC_VFS += vfs_acl_xattr
+MAKEFLAGS += SAMBA_XATTR=1
+endif
+ifneq ($(CONFIG_PACKAGE_SAMBA_ACL_SUPPORT),)
+SAMBA_STATIC_VFS += vfs_posixacl
+CONFIGURE_ARGS += \
+	--with-acl-support
+MAKEFLAGS += SAMBA_ACL=1
+else
+CONFIGURE_ARGS += \
+	--without-acl-support
+endif
 ifneq ($(CONFIG_PACKAGE_SAMBA_LIBAVAHI_SUPPORT),)
 CONFIGURE_ARGS += \
 	--enable-avahi
@@ -150,6 +178,12 @@ CONFIGURE_ARGS += \
 	--disable-avahi
 endif
 
+ifneq ($(SAMBA_STATIC_VFS),)
+CONFIGURE_ARGS += \
+	--with-static-modules=$(shell echo $(SAMBA_STATIC_VFS)|tr -s ' '|tr ' ' ',')
+else
+	--with-shared-modules=pdb_tdbsam,pdb_wbc_sam,idmap_nss,nss_info_template,auth_winbind,auth_wbc,auth_domain
+endif
 
 MAKE_FLAGS += DYNEXP= PICFLAG= MODULES=
 

--- a/package/network/services/samba36/Makefile
+++ b/package/network/services/samba36/Makefile
@@ -35,7 +35,14 @@ define Package/samba36-server
   CATEGORY:=Network
   TITLE:=Samba 3.6 SMB/CIFS server
   URL:=http://www.samba.org/
-  DEPENDS:=+USE_GLIBC:librt $(ICONV_DEPENDS)
+  DEPENDS:=+USE_GLIBC:librt $(ICONV_DEPENDS) +PACKAGE_SAMBA_LIBAVAHI_SUPPORT:libavahi-client
+endef
+
+define Package/samba36-server-avahi-service
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Samba 3.6 SMB/CIFS server avahi service files
+  DEPENDS:=samba36-server +avahi-daemon
 endef
 
 define Package/samba36-client
@@ -46,11 +53,20 @@ define Package/samba36-client
   DEPENDS:=+libreadline +libncurses
 endef
 
+define Package/samba36-server-avahi-service/conffiles
+/etc/avahi/services/samba.service
+endef
+
 define Package/samba36-server/config
 	config PACKAGE_SAMBA_MAX_DEBUG_LEVEL
-		int "Maximum level of compiled-in debug messages"
+		int "SAMBA: Maximum level of compiled-in debug messages"
 		depends on PACKAGE_samba36-server || PACKAGE_samba36-client
 		default -1
+
+	config PACKAGE_SAMBA_LIBAVAHI_SUPPORT
+		bool "SAMBA: Enable mDNS support"
+		depends on PACKAGE_samba36-server
+		select PACKAGE_libavahi-client
 
 endef
 
@@ -90,7 +106,6 @@ CONFIGURE_VARS += \
 CONFIGURE_ARGS += \
 	--exec-prefix=/usr \
 	--prefix=/ \
-	--disable-avahi \
 	--disable-cups \
 	--disable-pie \
 	--disable-relro \
@@ -124,6 +139,15 @@ CONFIGURE_ARGS += \
 	--without-libaddns \
 	--with-shared-modules=pdb_tdbsam,pdb_wbc_sam,idmap_nss,nss_info_template,auth_winbind,auth_wbc,auth_domain
 
+ifneq ($(CONFIG_PACKAGE_SAMBA_LIBAVAHI_SUPPORT),)
+CONFIGURE_ARGS += \
+	--enable-avahi
+else
+CONFIGURE_ARGS += \
+	--disable-avahi
+endif
+
+
 MAKE_FLAGS += DYNEXP= PICFLAG= MODULES=
 
 define Package/samba36-server/conffiles
@@ -149,6 +173,11 @@ define Package/samba36-server/install
 	$(LN) samba_multicall $(1)/usr/sbin/smbpasswd
 endef
 
+define Package/samba36-server-avahi-service/install
+	$(INSTALL_DIR) $(1)/etc/avahi/services
+	$(INSTALL_DATA) ./files/samba.service $(1)/etc/avahi/services/
+endef
+
 define Package/samba36-client/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_BIN)/smbclient $(1)/usr/sbin
@@ -157,4 +186,4 @@ endef
 
 $(eval $(call BuildPackage,samba36-client))
 $(eval $(call BuildPackage,samba36-server))
-
+$(eval $(call BuildPackage,samba36-server-avahi-service))

--- a/package/network/services/samba36/Makefile
+++ b/package/network/services/samba36/Makefile
@@ -79,6 +79,12 @@ define Package/samba36-server/config
 		default n
 		select PACKAGE_SAMBA_ACL_SUPPORT
 
+	config PACKAGE_SAMBA_NETATALK_SUPPORT
+		bool "SAMBA: Enable netatalk interoperability"
+		depends on PACKAGE_samba36-server
+		default y if PACKAGE_netatalk
+		default n
+
 	config PACKAGE_SAMBA_LIBAVAHI_SUPPORT
 		bool "SAMBA: Enable mDNS support"
 		depends on PACKAGE_samba36-server
@@ -169,6 +175,10 @@ MAKEFLAGS += SAMBA_ACL=1
 else
 CONFIGURE_ARGS += \
 	--without-acl-support
+endif
+ifneq ($(CONFIG_PACKAGE_SAMBA_NETATALK_SUPPORT),)
+SAMBA_STATIC_VFS += vfs_netatalk
+MAKEFLAGS += SAMBA_NETATALK
 endif
 ifneq ($(CONFIG_PACKAGE_SAMBA_LIBAVAHI_SUPPORT),)
 CONFIGURE_ARGS += \

--- a/package/network/services/samba36/Makefile
+++ b/package/network/services/samba36/Makefile
@@ -33,6 +33,7 @@ PKG_BUILD_BIN:=$(PKG_BUILD_DIR)/$(MAKE_PATH)/bin
 define Package/samba36-server
   SECTION:=net
   CATEGORY:=Network
+  SUBMENU:=Filesystem
   TITLE:=Samba 3.6 SMB/CIFS server
   URL:=http://www.samba.org/
   DEPENDS:=+USE_GLIBC:librt $(ICONV_DEPENDS) +PACKAGE_SAMBA_LIBAVAHI_SUPPORT:libavahi-client
@@ -41,6 +42,7 @@ endef
 define Package/samba36-server-avahi-service
   SECTION:=net
   CATEGORY:=Network
+  SUBMENU:=Filesystem
   TITLE:=Samba 3.6 SMB/CIFS server avahi service files
   DEPENDS:=samba36-server +avahi-daemon
 endef
@@ -48,6 +50,7 @@ endef
 define Package/samba36-client
   SECTION:=net
   CATEGORY:=Network
+  SUBMENU:=Filesystem
   TITLE:=Samba 3.6 SMB/CIFS client
   URL:=http://www.samba.org/
   DEPENDS:=+libreadline +libncurses

--- a/package/network/services/samba36/files/samba.config
+++ b/package/network/services/samba36/files/samba.config
@@ -3,4 +3,5 @@ config samba
 	option 'workgroup'		'WORKGROUP'
 	option 'description'		'Lede'
 	option 'homes'			'1'
+	option 'mdns'			'0'
 

--- a/package/network/services/samba36/files/samba.init
+++ b/package/network/services/samba36/files/samba.init
@@ -32,6 +32,7 @@ smb_header() {
 	config_get workgroup   $1 workgroup   "${hostname:-Lede}"
 	config_get description $1 description "Samba on ${hostname:-Lede}"
 	config_get charset     $1 charset     "UTF-8"
+	config_get_boot mdns   $1 mdns	      0
 
 	mkdir -p /var/etc
 	sed -e "s#|NAME|#$name#g" \
@@ -108,6 +109,7 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/smbd -F
+	[ "${mdns}" -ne 0 ] && procd_add_mdns "smb" "tcp" "445" "daemon=smbd"
 	procd_set_param respawn
 	procd_close_instance
 

--- a/package/network/services/samba36/files/samba.service
+++ b/package/network/services/samba36/files/samba.service
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+ <name replace-wildcards="yes">%h Windows File Server</name>
+  <service>
+   <type>_smb._tcp</type>
+   <port>445</port>
+  </service>
+</service-group>

--- a/package/network/services/samba36/patches/600-enable-vfs-modules.patch
+++ b/package/network/services/samba36/patches/600-enable-vfs-modules.patch
@@ -1,0 +1,13 @@
+Index: samba-3.6.25/source3/Makefile.in
+===================================================================
+--- samba-3.6.25.orig/source3/Makefile.in
++++ samba-3.6.25/source3/Makefile.in
+@@ -1798,7 +1798,7 @@ utils/smbpasswd_multicall.o: utils/owrt_
+ 		echo "$(COMPILE_CC_PATH)" 1>&2;\
+ 		$(COMPILE_CC_PATH) >/dev/null 2>&1
+ 
+-SMBD_MULTI_O = $(patsubst smbd/server.o,smbd/server_multicall.o,$(SMBD_OBJ))
++SMBD_MULTI_O = $(patsubst smbd/server.o,smbd/server_multicall.o,$(SMBD_OBJ)) $(if $(SAMBA_XATTR),$(VFS_ACL_XATTR_OBJ)) $(if $(SAMBA_ACL),$(VFS_POSIXACL_OBJ)) $(if $(SAMBA_NETATALK),$(VFS_NETATALK_OBJ))
+ NMBD_MULTI_O = $(patsubst nmbd/nmbd.o,nmbd/nmbd_multicall.o,$(filter-out $(LIB_DUMMY_OBJ),$(NMBD_OBJ)))
+ SMBPASSWD_MULTI_O = $(patsubst utils/owrt_smbpasswd.o,utils/smbpasswd_multicall.o,$(filter-out $(LIB_DUMMY_OBJ),$(SMBPASSWD_OBJ)))
+ MULTI_O = multi.o


### PR DESCRIPTION
NOTE: This patch series has just been split up and is not yet tested; it is purely a request for comments before doing the heavy lifting of testing and debugging.

This patch series

1) Adds mDNS advertisements for Samba
2) Moves Samba under Network|Filesystems menu for menuconfig
3) Add ACL and XATTR support configuration option
4) Adds netatalk compatibility support configuration option

Any comments on improvements prior to submitting would be welcome.