### PR TITLE
sdk: Allow to configure feeds in SDK

### DIFF
--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -5,3 +5,7 @@ config MODULES
 
 source "Config-build.in"
 source "tmp/.config-package.in"
+
+menu "Configure feeds"
+source "tmp/.config-feeds.in"
+endmenu


### PR DESCRIPTION
A user might reasonably want to have more/different
feeds built by the SDK vs. core, therefore allow to
reconfigure feeds in SDK.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>