### PR TITLE
dnsmasq: Set the default dhcp lease file and resolv file

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -72,8 +72,9 @@ append_parm() {
 	local section="$1"
 	local option="$2"
 	local switch="$3"
+	local default="$4"
 	local _loctmp
-	config_get _loctmp "$section" "$option"
+	config_get _loctmp "$section" "$option" "$default"
 	[ -z "$_loctmp" ] && return 0
 	xappend "$switch=$_loctmp"
 }
@@ -157,8 +158,8 @@ dnsmasq() {
 	config_list_foreach "$cfg" "notinterface" append_notinterface
 	config_list_foreach "$cfg" "addnhosts" append_addnhosts
 	config_list_foreach "$cfg" "bogusnxdomain" append_bogusnxdomain
-	append_parm "$cfg" "leasefile" "--dhcp-leasefile"
-	append_parm "$cfg" "resolvfile" "--resolv-file"
+	append_parm "$cfg" "leasefile" "--dhcp-leasefile" "/tmp/dhcp.leases"
+	append_parm "$cfg" "resolvfile" "--resolv-file" "/tmp/resolv.conf.auto"
 	append_parm "$cfg" "serversfile" "--servers-file"
 	append_parm "$cfg" "tftp_root" "--tftp-root"
 	append_parm "$cfg" "dhcp_boot" "--dhcp-boot"
@@ -173,9 +174,16 @@ dnsmasq() {
 	config_get_bool readethers "$cfg" readethers
 	[ "$readethers" = "1" -a \! -e "/etc/ethers" ] && touch /etc/ethers
 
-	config_get leasefile $cfg leasefile
+	config_get leasefile $cfg leasefile "/tmp/dhcp.leases"
 	[ -n "$leasefile" -a \! -e "$leasefile" ] && touch "$leasefile"
 	config_get_bool cachelocal "$cfg" cachelocal 1
+
+	config_get_bool noresolv "$cfg" noresolv 0
+	if [ "$noresolv" != "1" ]; then
+		config_get resolvfile "$cfg" resolvfile "/tmp/resolv.conf.auto"
+		# So jail doesn't complain if file missing
+		[ -n "$resolvfile" -a \! -e "$resolvfile" ] && touch "$resolvfile"
+	fi
 
 	config_get hostsfile "$cfg" dhcphostsfile
 	[ -e "$hostsfile" ] && xappend "--dhcp-hostsfile=$hostsfile"


### PR DESCRIPTION
Instead of making assumptions about the leasefile and resolv file make sure
we use what the user configures, but fall back to defaults if no configuration
is specified

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

Conflicts:
	package/network/services/dnsmasq/files/dnsmasq.init