### PR TITLE
[URFC] Replace busybox versions of commands with full versions

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -49,11 +49,11 @@ supivot() { # <new_root> <old_root>
 run_ramfs() { # <command> [...]
 	install_bin /bin/busybox /bin/ash /bin/sh /bin/mount /bin/umount	\
 		/sbin/pivot_root /sbin/reboot /bin/sync /bin/dd	/bin/grep       \
-		/bin/cp /bin/mv /bin/tar /usr/bin/md5sum "/usr/bin/[" /bin/dd	\
-		/bin/vi /bin/ls /bin/cat /usr/bin/awk /usr/bin/hexdump		\
-		/bin/sleep /bin/zcat /usr/bin/bzcat /usr/bin/printf /usr/bin/wc \
-		/bin/cut /usr/bin/printf /bin/sync /bin/mkdir /bin/rmdir	\
-		/bin/rm /usr/bin/basename /bin/kill /bin/chmod
+		/bin/cp /bin/mv /bin/tar /bin/md5sum "/bin/[" /bin/dd	\
+		/bin/vi /bin/ls /bin/cat /bin/awk /bin/hexdump		\
+		/bin/sleep /bin/zcat /bin/bzcat /bin/printf /bin/wc \
+		/bin/cut /bin/sync /bin/mkdir /bin/rmdir	\
+		/bin/rm /bin/basename /bin/kill /bin/chmod
 
 	install_bin /bin/uclient-fetch /bin/wget
 	install_bin /sbin/mtd

--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -23,10 +23,25 @@ install_bin() { # <file> [ <symlink> ... ]
 	install_file $files
 	shift
 	for link in "$@"; do {
-		dest="$RAM_ROOT/$link"
-		dir="$(dirname $dest)"
-		mkdir -p "$dir"
-		[ -f "$dest" ] || ln -s $src $dest
+		# Handle the case of using full versions of
+		# commands instead of busybox version; this
+		# only matters when busybox version is not
+		# compiled in (and hence /{s,}bin link doesn't
+		# exist)
+		if [ -L "$link" ]; then
+			dest="$RAM_ROOT/$link"
+			dir="$(dirname $dest)"
+			mkdir -p "$dir"
+			[ -f "$dest" ] || ln -s $src $dest
+		else
+			# We *only* have the full version, which
+			# is always in /usr/{s,}bin
+			$install_file /usr/$link
+			# For sysupgrade to work in case of full
+			# versions without busybox version we
+			# must ensure there are no hardcoded paths,
+			# so that PATH is always honoured
+		fi
 	}; done
 }
 

--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -32,12 +32,32 @@ define Package/iproute2/Default
   VARIANT:=$(1)
 endef
 
-define Package/ip
+define Package/ip-tiny
 $(call Package/iproute2/Default,tiny,Minimal)
   CONFLICTS:=ip-full
+  PROVIDES:=ip
 endef
 
-Package/ip-full=$(call Package/iproute2/Default,full,Full)
+define Package/ip-full
+$(call Package/iproute2/Default,full,Full)
+  PROVIDES:=ip
+endef
+
+define Package/iproute2-busybox
+  TITLE:=Routing control utility - full vs busybox
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=http://www.linuxfoundation.org/collaborate/workgroups/networking/iproute2
+  SUBMENU:=Routing and Redirection
+  MAINTAINER:=Russell Senior <russell@personaltelco.net>
+  DEPENDS:= +ip
+endef
+
+define Package/iproute2-busybox/config
+	config HAS_IPROUTE2
+		bool
+		default y
+endef
 
 define Package/tc
 $(call Package/iproute2/Default)
@@ -101,7 +121,11 @@ define Build/InstallDev
 	$(CP) $(PKG_BUILD_DIR)/lib/libnetlink.a $(1)/usr/lib/
 endef
 
-define Package/ip/install
+define Package/iproute2-busybox/install
+	true
+endef
+
+define Package/ip-tiny/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ip/ip $(1)/usr/bin/
 endef
@@ -138,10 +162,11 @@ define Package/nstat/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/misc/nstat $(1)/usr/sbin/
 endef
 
-$(eval $(call BuildPackage,ip))
+$(eval $(call BuildPackage,ip-tiny))
 $(eval $(call BuildPackage,ip-full))
 $(eval $(call BuildPackage,tc))
 $(eval $(call BuildPackage,genl))
 $(eval $(call BuildPackage,ip-bridge))
 $(eval $(call BuildPackage,ss))
 $(eval $(call BuildPackage,nstat))
+$(eval $(call BuildPackage,iproute2-busybox))

--- a/package/network/utils/iputils/Makefile
+++ b/package/network/utils/iputils/Makefile
@@ -76,6 +76,17 @@ define Package/iputils-ping6/description
   Sends ICMP ECHO_REQUEST to network hosts (IPv6).
 endef
 
+define Package/iputils-busybox
+$(call Package/iputils/Default)
+  TITLE:=iptutils - full vs busybox
+  DEPENDS:= +iputils-ping +IPV6:iputils-ping6
+endef
+
+define Package/iputils-busybox/config
+	config HAS_IPUTILS
+		bool
+		default y
+endef
 
 define Package/iputils-tftpd
 $(call Package/iputils/Default)
@@ -171,6 +182,10 @@ define Package/iputils-traceroute6/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/traceroute6 $(1)/usr/bin/
 endef
 
+define Package/iputils-busybox/install
+	true
+endef
+
 $(eval $(call BuildPackage,iputils-arping))
 $(eval $(call BuildPackage,iputils-clockdiff))
 $(eval $(call BuildPackage,iputils-ping))
@@ -179,3 +194,4 @@ $(eval $(call BuildPackage,iputils-tracepath))
 $(eval $(call BuildPackage,iputils-ping6))
 $(eval $(call BuildPackage,iputils-tracepath6))
 $(eval $(call BuildPackage,iputils-traceroute6))
+$(eval $(call BuildPackage,iputils-busybox))

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -39,7 +39,7 @@ config BUSYBOX_DEFAULT_FEATURE_INSTALLER
 	default n
 config BUSYBOX_DEFAULT_INSTALL_NO_USR
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_LOCALE_SUPPORT
 	bool
 	default n

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -315,6 +315,7 @@ config BUSYBOX_DEFAULT_GUNZIP
 	default y
 config BUSYBOX_DEFAULT_BUNZIP2
 	bool
+	default n if BUSYBOX_USE_BZIP2
 	default y
 config BUSYBOX_DEFAULT_UNLZMA
 	bool
@@ -378,6 +379,7 @@ config BUSYBOX_DEFAULT_RPM2CPIO
 	default n
 config BUSYBOX_DEFAULT_TAR
 	bool
+	default n if BUSYBOX_USE_TAR
 	default y
 config BUSYBOX_DEFAULT_FEATURE_TAR_CREATE
 	bool
@@ -417,12 +419,15 @@ config BUSYBOX_DEFAULT_UNZIP
 	default n
 config BUSYBOX_DEFAULT_BASENAME
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_CAT
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_DATE
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_DATE_ISOFMT
 	bool
@@ -435,6 +440,7 @@ config BUSYBOX_DEFAULT_FEATURE_DATE_COMPAT
 	default n
 config BUSYBOX_DEFAULT_DD
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_DD_SIGNAL_HANDLING
 	bool
@@ -453,6 +459,7 @@ config BUSYBOX_DEFAULT_HOSTID
 	default n
 config BUSYBOX_DEFAULT_ID
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_GROUPS
 	bool
@@ -462,18 +469,21 @@ config BUSYBOX_DEFAULT_SHUF
 	default n
 config BUSYBOX_DEFAULT_SYNC
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_SYNC_FANCY
 	bool
 	default n
 config BUSYBOX_DEFAULT_TEST
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_TEST_64
 	bool
 	default y
 config BUSYBOX_DEFAULT_TOUCH
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_TOUCH_NODEREF
 	bool
@@ -483,6 +493,7 @@ config BUSYBOX_DEFAULT_FEATURE_TOUCH_SUSV3
 	default y
 config BUSYBOX_DEFAULT_TR
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_TR_CLASSES
 	bool
@@ -513,18 +524,22 @@ config BUSYBOX_DEFAULT_CATV
 	default n
 config BUSYBOX_DEFAULT_CHGRP
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_CHMOD
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_CHOWN
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_CHOWN_LONG_OPTIONS
 	bool
 	default n
 config BUSYBOX_DEFAULT_CHROOT
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_CKSUM
 	bool
@@ -534,12 +549,14 @@ config BUSYBOX_DEFAULT_COMM
 	default n
 config BUSYBOX_DEFAULT_CP
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_CP_LONG_OPTIONS
 	bool
 	default n
 config BUSYBOX_DEFAULT_CUT
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_DF
 	bool
@@ -549,6 +566,7 @@ config BUSYBOX_DEFAULT_FEATURE_DF_FANCY
 	default n
 config BUSYBOX_DEFAULT_DIRNAME
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_DOS2UNIX
 	bool
@@ -558,12 +576,14 @@ config BUSYBOX_DEFAULT_UNIX2DOS
 	default n
 config BUSYBOX_DEFAULT_DU
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_DU_DEFAULT_BLOCKSIZE_1K
 	bool
 	default y
 config BUSYBOX_DEFAULT_ECHO
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FANCY_ECHO
 	bool
@@ -582,12 +602,14 @@ config BUSYBOX_DEFAULT_FEATURE_EXPAND_LONG_OPTIONS
 	default n
 config BUSYBOX_DEFAULT_EXPR
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_EXPR_MATH_SUPPORT_64
 	bool
 	default y
 config BUSYBOX_DEFAULT_FALSE
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FOLD
 	bool
@@ -597,6 +619,7 @@ config BUSYBOX_DEFAULT_FSYNC
 	default y
 config BUSYBOX_DEFAULT_HEAD
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FANCY_HEAD
 	bool
@@ -609,12 +632,14 @@ config BUSYBOX_DEFAULT_FEATURE_INSTALL_LONG_OPTIONS
 	default n
 config BUSYBOX_DEFAULT_LN
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_LOGNAME
 	bool
 	default n
 config BUSYBOX_DEFAULT_LS
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_LS_FILETYPES
 	bool
@@ -642,27 +667,33 @@ config BUSYBOX_DEFAULT_FEATURE_LS_COLOR_IS_DEFAULT
 	default y
 config BUSYBOX_DEFAULT_MD5SUM
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_MKDIR
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_MKDIR_LONG_OPTIONS
 	bool
 	default n
 config BUSYBOX_DEFAULT_MKFIFO
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_MKNOD
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_MV
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_MV_LONG_OPTIONS
 	bool
 	default n
 config BUSYBOX_DEFAULT_NICE
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_NOHUP
 	bool
@@ -675,12 +706,15 @@ config BUSYBOX_DEFAULT_PRINTENV
 	default n
 config BUSYBOX_DEFAULT_PRINTF
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_PWD
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_READLINK
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_READLINK_FOLLOW
 	bool
@@ -690,15 +724,18 @@ config BUSYBOX_DEFAULT_REALPATH
 	default n
 config BUSYBOX_DEFAULT_RM
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_RMDIR
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_RMDIR_LONG_OPTIONS
 	bool
 	default n
 config BUSYBOX_DEFAULT_SEQ
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_SHA1SUM
 	bool
@@ -714,6 +751,7 @@ config BUSYBOX_DEFAULT_SHA3SUM
 	default n
 config BUSYBOX_DEFAULT_SLEEP
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FANCY_SLEEP
 	bool
@@ -723,6 +761,7 @@ config BUSYBOX_DEFAULT_FEATURE_FLOAT_SLEEP
 	default n
 config BUSYBOX_DEFAULT_SORT
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_SORT_BIG
 	bool
@@ -750,24 +789,28 @@ config BUSYBOX_DEFAULT_TAC
 	default n
 config BUSYBOX_DEFAULT_TAIL
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FANCY_TAIL
 	bool
 	default y
 config BUSYBOX_DEFAULT_TEE
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_TEE_USE_BLOCK_IO
 	bool
 	default y
 config BUSYBOX_DEFAULT_TRUE
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_TTY
 	bool
 	default n
 config BUSYBOX_DEFAULT_UNAME
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_UNAME_OSNAME
 	string
@@ -780,6 +823,7 @@ config BUSYBOX_DEFAULT_FEATURE_UNEXPAND_LONG_OPTIONS
 	default n
 config BUSYBOX_DEFAULT_UNIQ
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_USLEEP
 	bool
@@ -792,6 +836,7 @@ config BUSYBOX_DEFAULT_UUENCODE
 	default n
 config BUSYBOX_DEFAULT_WC
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_WC_LARGE
 	bool
@@ -801,6 +846,7 @@ config BUSYBOX_DEFAULT_WHOAMI
 	default n
 config BUSYBOX_DEFAULT_YES
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_VERBOSE
 	bool
@@ -885,6 +931,7 @@ config BUSYBOX_DEFAULT_FEATURE_LOADFONT_RAW
 	default n
 config BUSYBOX_DEFAULT_MKTEMP
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_PIPE_PROGRESS
 	bool
@@ -921,6 +968,7 @@ config BUSYBOX_DEFAULT_FEATURE_AWK_GNU_EXTENSIONS
 	default y
 config BUSYBOX_DEFAULT_CMP
 	bool
+	default n if BUSYBOX_USE_DIFFUTILS
 	default y
 config BUSYBOX_DEFAULT_DIFF
 	bool
@@ -942,6 +990,7 @@ config BUSYBOX_DEFAULT_SED
 	default y
 config BUSYBOX_DEFAULT_VI
 	bool
+	default n if BUSYBOX_USE_VIM
 	default y
 config BUSYBOX_DEFAULT_FEATURE_VI_MAX_LEN
 	int
@@ -996,6 +1045,7 @@ config BUSYBOX_DEFAULT_FEATURE_ALLOW_EXEC
 	default y
 config BUSYBOX_DEFAULT_FIND
 	bool
+	default n if BUSYBOX_USE_FINDUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_PRINT0
 	bool
@@ -1068,6 +1118,7 @@ config BUSYBOX_DEFAULT_FEATURE_FIND_LINKS
 	default n
 config BUSYBOX_DEFAULT_GREP
 	bool
+	default n if BUSYBOX_USE_GREP
 	default y
 config BUSYBOX_DEFAULT_FEATURE_GREP_EGREP_ALIAS
 	bool
@@ -1080,6 +1131,7 @@ config BUSYBOX_DEFAULT_FEATURE_GREP_CONTEXT
 	default y
 config BUSYBOX_DEFAULT_XARGS
 	bool
+	default n if BUSYBOX_USE_FINDUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_XARGS_SUPPORT_CONFIRMATION
 	bool
@@ -1227,6 +1279,7 @@ config BUSYBOX_DEFAULT_FEATURE_SECURETTY
 	default n
 config BUSYBOX_DEFAULT_PASSWD
 	bool
+	default n if BUSYBOX_USE_SHADOW_UTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_PASSWD_WEAK_CHECK
 	bool
@@ -1365,6 +1418,7 @@ config BUSYBOX_DEFAULT_FEATURE_MDEV_LOAD_FIRMWARE
 	default n
 config BUSYBOX_DEFAULT_MOUNT
 	bool
+	default n if BUSYBOX_USE_UTIL_LINUX
 	default y
 config BUSYBOX_DEFAULT_FEATURE_MOUNT_FAKE
 	bool
@@ -1383,6 +1437,7 @@ config BUSYBOX_DEFAULT_FEATURE_MOUNT_NFS
 	default n
 config BUSYBOX_DEFAULT_FEATURE_MOUNT_CIFS
 	bool
+	default n if BUSYBOX_USE_CIFS_UTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_MOUNT_FLAGS
 	bool
@@ -1413,6 +1468,7 @@ config BUSYBOX_DEFAULT_FEATURE_BLKID_TYPE
 	default n
 config BUSYBOX_DEFAULT_DMESG
 	bool
+	default n if BUSYBOX_USE_UTIL_LINUX
 	default y
 config BUSYBOX_DEFAULT_FEATURE_DMESG_PRETTY
 	bool
@@ -1503,6 +1559,7 @@ config BUSYBOX_DEFAULT_HD
 	default n
 config BUSYBOX_DEFAULT_HWCLOCK
 	bool
+	default n if BUSYBOX_USE_UTIL_LINUX
 	default y
 config BUSYBOX_DEFAULT_FEATURE_HWCLOCK_LONG_OPTIONS
 	bool
@@ -1527,6 +1584,7 @@ config BUSYBOX_DEFAULT_LSUSB
 	default n
 config BUSYBOX_DEFAULT_MKSWAP
 	bool
+	default n if BUSYBOX_USE_UTIL_LINUX
 	default y
 config BUSYBOX_DEFAULT_FEATURE_MKSWAP_UUID
 	bool
@@ -1572,6 +1630,7 @@ config BUSYBOX_DEFAULT_SWITCH_ROOT
 	default y
 config BUSYBOX_DEFAULT_UMOUNT
 	bool
+	default n if BUSYBOX_USE_UTIL_LINUX
 	default y
 config BUSYBOX_DEFAULT_FEATURE_UMOUNT_ALL
 	bool
@@ -1680,6 +1739,7 @@ config BUSYBOX_DEFAULT_I2CDETECT
 	default n
 config BUSYBOX_DEFAULT_LESS
 	bool
+	default n if BUSYBOX_USE_LESS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_LESS_MAXLINES
 	int
@@ -1947,6 +2007,7 @@ config BUSYBOX_DEFAULT_NBDCLIENT
 	default n
 config BUSYBOX_DEFAULT_NC
 	bool
+	default n if BUSYBOX_USE_NETCAT
 	default y
 config BUSYBOX_DEFAULT_NC_SERVER
 	bool
@@ -1959,9 +2020,11 @@ config BUSYBOX_DEFAULT_NC_110_COMPAT
 	default n
 config BUSYBOX_DEFAULT_PING
 	bool
+	default n if BUSYBOX_USE_IPUTILS
 	default y
 config BUSYBOX_DEFAULT_PING6
 	bool
+	default n if BUSYBOX_USE_IPUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FANCY_PING
 	bool
@@ -1971,13 +2034,13 @@ config BUSYBOX_DEFAULT_WGET
 	default n
 config BUSYBOX_DEFAULT_FEATURE_WGET_STATUSBAR
 	bool
-	default y
+	default n
 config BUSYBOX_DEFAULT_FEATURE_WGET_AUTHENTICATION
 	bool
-	default y
+	default n
 config BUSYBOX_DEFAULT_FEATURE_WGET_LONG_OPTIONS
 	bool
-	default y
+	default n
 config BUSYBOX_DEFAULT_FEATURE_WGET_TIMEOUT
 	bool
 	default n
@@ -2010,6 +2073,7 @@ config BUSYBOX_DEFAULT_ARPING
 	default n
 config BUSYBOX_DEFAULT_BRCTL
 	bool
+	default n if BUSYBOX_USE_BRIDGE
 	default y
 config BUSYBOX_DEFAULT_FEATURE_BRCTL_FANCY
 	bool
@@ -2160,6 +2224,7 @@ config BUSYBOX_DEFAULT_FEATURE_INETD_RPC
 	default n
 config BUSYBOX_DEFAULT_IP
 	bool
+	default n if BUSYBOX_USE_IPROUTE2
 	default y
 config BUSYBOX_DEFAULT_FEATURE_IP_ADDRESS
 	bool
@@ -2424,6 +2489,7 @@ config BUSYBOX_DEFAULT_SMEMCAP
 	default n
 config BUSYBOX_DEFAULT_TOP
 	bool
+	default n if BUSYBOX_USE_PROCPS_NG
 	default y
 config BUSYBOX_DEFAULT_FEATURE_TOP_CPU_USAGE_PERCENTAGE
 	bool
@@ -2445,18 +2511,21 @@ config BUSYBOX_DEFAULT_FEATURE_TOPMEM
 	default n
 config BUSYBOX_DEFAULT_UPTIME
 	bool
+	default n if BUSYBOX_USE_COREUTILS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_UPTIME_UTMP_SUPPORT
 	bool
 	default n
 config BUSYBOX_DEFAULT_FREE
 	bool
+	default n if BUSYBOX_USE_PROCPS_NG
 	default y
 config BUSYBOX_DEFAULT_FUSER
 	bool
 	default n
 config BUSYBOX_DEFAULT_KILL
 	bool
+	default n if BUSYBOX_USE_PROCPS_NG
 	default y
 config BUSYBOX_DEFAULT_KILLALL
 	bool
@@ -2466,6 +2535,7 @@ config BUSYBOX_DEFAULT_KILLALL5
 	default n
 config BUSYBOX_DEFAULT_PGREP
 	bool
+	default n if BUSYBOX_USE_PROCPS_NG
 	default y
 config BUSYBOX_DEFAULT_PIDOF
 	bool
@@ -2481,6 +2551,7 @@ config BUSYBOX_DEFAULT_PKILL
 	default n
 config BUSYBOX_DEFAULT_PS
 	bool
+	default n if BUSYBOX_USE_PROCPS_NG
 	default y
 config BUSYBOX_DEFAULT_FEATURE_PS_WIDE
 	bool
@@ -2763,4 +2834,5 @@ config BUSYBOX_DEFAULT_FEATURE_KLOGD_KLOGCTL
 	default n
 config BUSYBOX_DEFAULT_LOGGER
 	bool
+	default n if BUSYBOX_USE_UTIL_LINUX
 	default y

--- a/package/utils/busybox/Config.in
+++ b/package/utils/busybox/Config.in
@@ -18,6 +18,172 @@ config BUSYBOX_CUSTOM
 	source "config/Config.in"
 	endif
 
+config BUSYBOX_USE_FULL_VERSIONS
+	bool "(EXPERIMENTAL) Use full versions of commands instead of busybox replacements"
+	default n
+
+if BUSYBOX_USE_FULL_VERSIONS
+	config BUSYBOX_USE_BRIDGE
+		bool "Use full bridge instead of busybox replacement"
+		depends on HAS_BRIDGE
+		select PACKAGE_bridge
+		default y
+		help
+		  Use the full versions of brctl command from bridge
+		  package instead of the cut down busybox replacement for
+		  this commands.
+
+	config BUSYBOX_USE_BZIP2
+		bool "Use full bzip2 instead of busybox replacements"
+		depends on HAS_BZIP2
+		select PACKAGE_bzip2
+		default y
+		help
+		  Use the full versions of brctl command from bridge
+		  package instead of the cut down busybox replacement for
+		  this commands.
+
+	config USE_CIFS_UTILS
+		bool "Use full cifs-utils instead of busybox replacement"
+		depends on HAS_CIFS_UTILS
+		select PACKAGE_cifsmount
+		default y
+		help
+		  Use the full versions of mount.cifs from cifs-utils
+		  package instead of the cut down busybox support
+		  in busybox's mount.
+
+	config BUSYBOX_USE_COREUTILS
+		bool "Use full coreutils instead of busybox replacements"
+		depends on HAS_COREUTILS
+		select PACKAGE_coreutils
+		select PACKAGE_coreutils-busybox
+		default y
+		help
+		  Use the full versions of commands available in coreutils
+		  package instead of the cut down busybox replacements for
+		  those commands.
+
+	config BUSYBOX_USE_DIFFUTILS
+		bool "Use full diffutils cmp instead of busybox replacement"
+		depends on HAS_DIFFUTILS
+		select PACKAGE_diffutils-cmp
+		default y
+		help
+		  Use the full version of cmp command from diffutils
+		  package instead of the cut down busybox replacement for
+		  this command.
+
+	config BUSYBOX_USE_FINDUTILS
+		bool "Use full findutils instead of busybox replacements"
+		depends on HAS_FINDUTILS
+		select PACKAGE_findutils-busybox
+		default y
+		help
+		  Use the full version of commands from findutils
+		  package instead of the cut down busybox replacements for
+		  these commands.
+
+	config BUSYBOX_USE_GREP
+		bool "Use full grep instead of busybox replacement"
+		depends on HAS_GREP
+		select PACKAGE_grep
+		default y
+		help
+		  Use the full version of grep command from grep
+		  package instead of the cut down busybox replacement for
+		  this command.
+
+	config BUSYBOX_USE_IPROUTE2
+		bool "Use full iproute2 instead of busybox replacements"
+		depends on HAS_IPROUTE2
+		select PACKAGE_iproute2-busybox
+		default y
+		help
+		  Use the full version of ip command from iproute2
+		  package instead of the cut down busybox replacement for
+		  this command.
+
+	config BUSYBOX_USE_IPUTILS
+		bool "Use full iputils instead of busybox replacements"
+		depends on HAS_IPUTILS
+		select PACKAGE_iputils-busybox
+		default y
+		help
+		  Use the full version of commands from findutils
+		  package instead of the cut down busybox replacements for
+		  these commands.
+
+	config BUSYBOX_USE_LESS
+		bool "Use full less instead of busybox replacement"
+		depends on HAS_LESS
+		select PACKAGE_less
+		default y
+		help
+		  Use the full version of less command from less
+		  package instead of the cut down busybox replacement for
+		  this command.
+
+	config BUSYBOX_USE_TAR
+		bool "Use full tar instead of busybox replacement"
+		depends on HAS_TAR
+		select PACKAGE_tar
+		default y
+		help
+		  Use the full version of tar command from netcat
+		  package instead of the cut down busybox replacement for
+
+	config BUSYBOX_USE_PROCPS_NG
+		bool "Use full procps-ng instead of busybox replacements"
+		depends on HAS_PROCPS_NG
+		select PACKAGE_procps-ng
+		select PACKAGE_procps-ng-busybox
+		default y
+		help
+		  Use the full versions of commands available in util-linux
+		  package instead of the cut down busybox replacements for
+		  those commands.
+
+	config BUSYBOX_USE_SHADOW_UTILS
+		bool "Use full passwd instead of busybox replacement"
+		depends on HAS_SHADOW
+		select PACKAGE_shadow
+		select PACKAGE_shadow-passwd
+		default y
+		help
+		  Use the full version of passwd  command from shadow-utils
+		  package instead of the cut down busybox replacement for
+		  this command.
+
+	config BUSYBOX_USE_NETCAT
+		bool "Use full netcat instead of busybox replacement"
+		depends on HAS_NETCAT
+		select PACKAGE_netcat
+		default y
+		help
+		  Use the full version of nc command from netcat
+		  package instead of the cut down busybox replacement for
+
+	config BUSYBOX_USE_UTIL_LINUX
+		bool "Use full util-linux instead of busybox replacements"
+		depends on HAS_UTIL_LINUX
+		select PACKAGE_util-linux-busybox
+		default y
+		help
+		  Use the full versions of commands available in util-linux
+		  package instead of the cut down busybox replacements for
+		  those commands.
+
+	config BUSYBOX_USE_VIM
+		bool "Use full vim instead of busybox replacement"
+		depends on HAS_VIM
+		select PACKAGE_vim
+		default y
+		help
+		  Use the full version of vi command from
+		  package instead of the cut down busybox replacement for
+endif
+
 config BUSYBOX_USE_LIBRPC
 	bool
 	default y if BUSYBOX_CUSTOM && BUSYBOX_CONFIG_FEATURE_HAVE_RPC

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.24.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/package/utils/busybox/convert_defaults.pl
+++ b/package/utils/busybox/convert_defaults.pl
@@ -1,5 +1,106 @@
 #!/usr/bin/env perl
 
+sub default_for_applet($$$) {
+	my $skip_hash = shift;
+	my $applet = shift;
+	my $default = shift;
+	my @newdefault = ();
+
+	foreach my $skip_flag (keys %$skip_hash) {
+		my $skip_applets = $skip_hash->{$skip_flag};
+		foreach my $skip_applet (@$skip_applets) {
+			if ($skip_applet eq $applet) {
+				push @newdefault, "n if $skip_flag";
+				break
+			}
+		}
+	}
+	push @newdefault, $default;
+
+	return \@newdefault;
+}
+
+sub skip_applet_if_prefer_full($$) {
+	my $applet = shift;
+	my $default = shift;
+
+	my %skip_hash = (
+	   "BUSYBOX_USE_BRIDGE", [ "BRCTL" ],
+	   "BUSYBOX_USE_BZIP2", [ "BUNZIP2" ],
+	   "BUSYBOX_USE_CIFS_UTILS", [ "FEATURE_MOUNT_CIFS" ],
+	   "BUSYBOX_USE_COREUTILS", [ "BASENAME",
+	      "CAT",
+	      "CHGRP",
+	      "CHMOD",
+	      "CHOWN",
+	      "CHROOT",
+	      "CP",
+	      "CUT",
+	      "DATE",
+	      "DD",
+	      "DIRNAME",
+	      "DU",
+	      "ECHO",
+	      "EXPR",
+	      "FALSE",
+	      "HEAD",
+	      "ID",
+	      "LN",
+	      "LS",
+	      "MD5SUM",
+	      "MKDIR",
+	      "MKFIFO",
+	      "MKNOD",
+	      "MKTEMP",
+	      "MV",
+	      "NICE",
+	      "PRINTF",
+	      "PWD",
+	      "READLINK",
+	      "RM",
+	      "RMDIR",
+	      "SEQ",
+	      "SLEEP",
+	      "SORT",
+	      "SYNC",
+	      "TAIL",
+	      "TEE",
+	      "TEST",
+	      "TOUCH",
+	      "TR",
+	      "TRUE",
+	      "UNAME",
+	      "UNIQ",
+	      "UPTIME",
+	      "WC",
+	      "YES" ],
+	   "BUSYBOX_USE_DIFFUTILS", [ "CMP" ],
+	   "BUSYBOX_USE_FINDUTILS", [ "FIND",
+	      "XARGS" ],
+	   "BUSYBOX_USE_GREP", [ "GREP" ],
+	   "BUSYBOX_USE_IPROUTE2", [ "IP" ],
+	   "BUSYBOX_USE_IPUTILS", [ "PING",
+	      "PING6" ],
+	   "BUSYBOX_USE_LESS", [ "LESS" ],
+	   "BUSYBOX_USE_TAR", [ "TAR" ],
+	   "BUSYBOX_USE_PROCPS_NG", [ "FREE",
+	      "KILL",
+	      "PGREP",
+	      "PS",
+	      "TOP" ],
+	   "BUSYBOX_USE_SHADOW_UTILS", [ "PASSWD" ],
+	   "BUSYBOX_USE_NETCAT", [ "NC" ],
+	   "BUSYBOX_USE_UTIL_LINUX", [ "DMESG" ,
+	      "HWCLOCK",
+	      "LOGGER",
+	      "MOUNT",
+	      "UMOUNT",
+	      "MKSWAP" ],
+	   "BUSYBOX_USE_VIM", [ "VI" ] );
+
+	return default_for_applet(\%skip_hash, $applet, $default);
+}
+
 while (<>) {
 	/^(# )?CONFIG_([^=]+)(=(.+)| is not set)/ and do {
 		my $default = $4;
@@ -9,6 +110,10 @@ while (<>) {
 		$default =~ /^\"/ and $type = "string";
 		$default =~ /^\d/ and $type = "int";
 		( $2 eq 'INSTALL_NO_USR' ) and $default = "y";
-		print "config BUSYBOX_DEFAULT_$name\n\t$type\n\tdefault $default\n";
+		$default = skip_applet_if_prefer_full($name, $default);
+		print "config BUSYBOX_DEFAULT_$name\n\t$type\n";
+		foreach my $defitem (@$default) {
+			print "\tdefault $defitem\n";
+		}
 	};
 }

--- a/package/utils/busybox/convert_defaults.pl
+++ b/package/utils/busybox/convert_defaults.pl
@@ -8,6 +8,7 @@ while (<>) {
 		my $type = "bool";
 		$default =~ /^\"/ and $type = "string";
 		$default =~ /^\d/ and $type = "int";
+		( $2 eq 'INSTALL_NO_USR' ) and $default = "y";
 		print "config BUSYBOX_DEFAULT_$name\n\t$type\n\tdefault $default\n";
 	};
 }

--- a/package/utils/busybox/files/cron
+++ b/package/utils/busybox/files/cron
@@ -4,7 +4,7 @@
 START=50
 
 USE_PROCD=1
-PROG=/usr/sbin/crond
+PROG=/sbin/crond
 
 validate_cron_section() {
 	uci_validate_section system system "${1}" \

--- a/package/utils/busybox/files/sysntpd
+++ b/package/utils/busybox/files/sysntpd
@@ -4,7 +4,7 @@
 START=98
 
 USE_PROCD=1
-PROG=/usr/sbin/ntpd
+PROG=/sbin/ntpd
 HOTPLUG_SCRIPT=/usr/sbin/ntpd-hotplug
 
 validate_ntp_section() {

--- a/package/utils/bzip2/Makefile
+++ b/package/utils/bzip2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bzip2
 PKG_VERSION:=1.0.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.bzip.org/$(PKG_VERSION)
@@ -82,6 +82,8 @@ endef
 define Package/bzip2/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bzip2-shared $(1)/usr/bin/bzip2
+	ln -sf bzip2 $(1)/usr/bin/bunzip2
+	ln -sf bzip2 $(1)/usr/bin/bzcat
 endef
 
 HOST_CFLAGS += \

--- a/package/utils/bzip2/Makefile
+++ b/package/utils/bzip2/Makefile
@@ -53,6 +53,12 @@ define Package/bzip2/description
 	data compressor. This package provides the binary.
 endef
 
+define Package/bzip2/config
+	config HAS_BZIP2
+		bool
+		default y
+endef
+
 TARGET_CFLAGS += \
 	$(FPIC) \
 	$(TARGET_LDFLAGS)

--- a/package/utils/util-linux/Makefile
+++ b/package/utils/util-linux/Makefile
@@ -35,6 +35,31 @@ define Package/util-linux/Default
   URL:=http://www.kernel.org/pub/linux/utils/util-linux/
 endef
 
+define Package/util-linux-busybox
+$(call Package/util-linux/Default)
+  TITLE:=Full util-linux commands instead of busybox replacements
+  DEPENDS:= \
++dmesg \
++hwclock \
++logger \
++mount-utils \
++swap-utils
+endef
+
+define Package/util-linux-busybox/description
+util-linux is a collection of system commands for Linux.
+
+This package selects the full versions of these commands
+for which busybox replacements are normally built
+into the system.
+endef
+
+define Package/util-linux-busybox/config
+	config HAS_UTIL_LINUX
+		bool
+		default y
+endef
+
 CONFIGURE_ARGS += \
 	--disable-rpath \
 	--disable-tls		\
@@ -647,6 +672,10 @@ define Package/wipefs/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/wipefs $(1)/usr/sbin/
 endef
 
+define Package/util-linux-busybox/install
+	true
+endef
+
 $(eval $(call BuildPackage,libblkid))
 $(eval $(call BuildPackage,libfdisk))
 $(eval $(call BuildPackage,libmount))
@@ -682,3 +711,4 @@ $(eval $(call BuildPackage,uuidgen))
 $(eval $(call BuildPackage,wall))
 $(eval $(call BuildPackage,whereis))
 $(eval $(call BuildPackage,wipefs))
+$(eval $(call BuildPackage,util-linux-busybox))


### PR DESCRIPTION
Hi,

Does this look more like what you'd like to see?  I had to update the script for Config-defaults.in and and Config-defaults.in because you can't select !SYMBOL which is what would be required to avoid needing to modify Config-defaults.

I've only tested the menuconfig part for now (I imagine there will be breakage in actual use due to the presence of hardcoded paths, hence I have marked the whole feature EXPERIMENTAL in the menuconfig).