### PR TITLE
ramips: cleanup for Hame MPR-A2

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -47,6 +47,7 @@ ramips_setup_interfaces()
 	linkits7688d | \
 	m2m|\
 	microwrt|\
+	mpr-a2|\
 	ncs601w|\
 	w150m|\
 	wnce2001|\
@@ -261,7 +262,6 @@ ramips_setup_macs()
 	freestation5|\
 	hlk-rm04|\
 	mpr-a1|\
-	mpr-a2|\
 	psr-680w|\
 	sl-r7205|\
 	y1|\

--- a/target/linux/ramips/dts/MPRA2.dts
+++ b/target/linux/ramips/dts/MPRA2.dts
@@ -101,7 +101,8 @@
 };
 
 &esw {
-	mediatek,portmap = <0x2f>;
+	mediatek,portmap = <0x1>;
+	mediatek,portdisable = <0x3e>;
 };
 
 &wmac {


### PR DESCRIPTION
- disable all ethernet ports except port 0 on MPR-A2

Port 0 is the only ethernet port on this router, so disable all other PHYs in order to save power.

- don't use a VLAN for the single ethernet port of the MPR-A2

Like A5-V11, this router only has one ethernet port.

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>