### PR TITLE
base-files: sysfixtime typo in exclude dnsmasq.time

### DIFF
--- a/package/base-files/files/etc/init.d/sysfixtime
+++ b/package/base-files/files/etc/init.d/sysfixtime
@@ -28,7 +28,7 @@ maxtime() {
 	local file newest
 
 	for file in $( find /etc -type f ! -path /etc/dnsmasq.time ) ; do
-		[ -z "$newest" -o "$newest" -ot "$file"] && newest=$file
+		[ -z "$newest" -o "$newest" -ot "$file" ] && newest=$file
 	done
 	[ "$newest" ] && date -r "$newest" +%s
 }


### PR DESCRIPTION
Typo, missing space before ] in previous commit caused shell syntax
failure and incorrect restoration of time.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>