### PR TITLE
toolchain: Explicitly disable debugging

### DIFF
--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -106,7 +106,7 @@ menuconfig DEVEL
 
 	config EXTRA_OPTIMIZATION
 		string "Additional compiler options" if DEVEL
-		default "-fno-caller-saves -fno-plt" if !CONFIG_EXTERNAL_TOOLCHAIN && !arc
-		default "-fno-caller-saves"
+		default "-fno-caller-saves -fno-plt -DNDEBUG" if !CONFIG_EXTERNAL_TOOLCHAIN && !arc
+		default "-fno-caller-saves -DNDEBUG"
 		help
 		  Extra target-independent optimizations to use when building for the target.


### PR DESCRIPTION
Add -DNDEBUG to avoid debugging code being built 

Signed-off-by: Daniel Engberg daniel.engberg.lists@pyret.net