### PR TITLE
package/libs/libnl-tiny: Honor TARGET_CFLAGS

### DIFF
--- a/package/libs/libnl-tiny/src/Makefile
+++ b/package/libs/libnl-tiny/src/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 WFLAGS=-Wall
-CFLAGS=-O2
+CFLAGS=$(TARGET_CFLAGS)
 INCLUDES=-Iinclude
 
 LIBNAME=libnl-tiny.so


### PR DESCRIPTION
Honor CFLAGS instead of hardcode O2

Signed-off-by: Daniel Engberg daniel.engberg.lists@pyret.net