### PR TITLE
toolchain: Disable building GDB by default

### DIFF
--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -244,7 +244,7 @@ config GDB
 	bool
 	depends on !(aarch64 || aarch64_be)
 	prompt "Build gdb" if TOOLCHAINOPTS
-	default y if !EXTERNAL_TOOLCHAIN
+	default n if !EXTERNAL_TOOLCHAIN
 	help
 	  Enable if you want to build the gdb.
 


### PR DESCRIPTION
If you need to debug you should be able to enable this manually.

Signed-off-by: Daniel Engberg daniel.engberg.lists@pyret.net