### PR TITLE
sdk: Allow to change ALL* package settings in SDK

### DIFF
--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -1,3 +1,19 @@
+menu "Global build settings"
+
+	config ALL_NONSHARED
+		bool "Select all target specific packages by default"
+		default ALL
+
+	config ALL_KMODS
+		bool "Select all kernel module packages by default"
+		default ALL
+
+	config ALL
+		bool "Select all userspace packages by default"
+		default y
+
+endmenu
+
 config MODULES
 	bool
 	default y


### PR DESCRIPTION
It is desirable to be able to use ./scripts/feeds install -a
when in the SDK without being forced to build a great number
of packages that are not actually wanted.

We therefore add the option of changing the various ALL package
build options so that we can default to packages not being built
unless we select them.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>

I find this quite useful and have tested it.