### PR TITLE
dropbear: Fix incorrect CONFIG_TARGET_INIT_PATH.

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -78,13 +78,13 @@ CONFIGURE_ARGS += \
 	--disable-zlib \
 	--enable-bundled-libtom
 
-TARGET_CFLAGS += -DDEFAULT_PATH=\\\"$(TARGET_INIT_PATH)\\\" -DARGTYPE=3 -ffunction-sections -fdata-sections
+TARGET_CFLAGS += -DDEFAULT_PATH=\\\"$(CONFIG_TARGET_INIT_PATH)\\\" -DARGTYPE=3 -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections
 
 define Build/Configure
 	$(Build/Configure/Default)
 
-	$(SED) 's,^#define DEFAULT_PATH .*$$$$,#define DEFAULT_PATH "$(TARGET_INIT_PATH)",g' \
+	$(SED) 's,^#define DEFAULT_PATH .*$$$$,#define DEFAULT_PATH "$(CONFIG_TARGET_INIT_PATH)",g' \
 		$(PKG_BUILD_DIR)/options.h
 
 	awk 'BEGIN { rc = 1 } \


### PR DESCRIPTION
Fix a „semantic typo“ introduced in b78aae793e20e06defa1e75ab4d30dbb6807c139, where TARGET_INIT_PATH was used instead of CONFIG_TARGET_INIT_PATH.

This led to problems when using scp ("-ash: scp not found") or directly executing remote commands via SSH, as well as code in /etc/profile that sits prior to setting a PATH.