### PR TITLE
ar71xx: add GPIO pin for usb power switch for RouterBOARD RB912UAG

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ar71xx/base-files/etc/board.d/03_gpio_switches
@@ -21,6 +21,10 @@ cpe210|\
 cpe510)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "20"
 	;;
+rb-912uag-2hpnd|\
+rb-912uag-5hpnd)
+	ucidef_add_gpio_switch "usb_power_switch" "USB Power Switch" "52"
+	;;
 esac
 
 board_config_flush


### PR DESCRIPTION
RB912 has one usb shared between external USB and miniPCIe slot. GPIO52 can reroute power to external USB (=1) or internal miniPCIe slot (=0)

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>