### PR TITLE
target/convert-config: Fix keeping unset as unset

### DIFF
--- a/target/sdk/convert-config.pl
+++ b/target/sdk/convert-config.pl
@@ -2,33 +2,58 @@
 use strict;
 
 while (<>) {
+	my $match;
+	my $var;
+	my $val;
+	my $type;
 	chomp;
 	next if /^CONFIG_SIGNED_PACKAGES/;
-	next unless /^CONFIG_([^=]+)=(.*)$/;
 
-	my $var = $1;
-	my $val = $2;
-	my $type;
+	if (/^CONFIG_([^=]+)=(.*)$/) {
+		$var = $1;
+		$val = $2;
 
-	next if $var eq 'ALL';
+		next if $var eq 'ALL';
 
-	if ($val eq 'y') {
+		if ($val eq 'y') {
+			$type = "bool";
+		} elsif ($val eq 'm') {
+			$type = "tristate";
+		} elsif ($val =~ /^".*"$/) {
+			$type = "string";
+		} elsif ($val =~ /^\d+$/) {
+			$type = "int";
+		} else {
+			warn "WARNING: no type found for symbol CONFIG_$var=$val\n";
+			next;
+		}
+	} elsif (/^# CONFIG_BUSYBOX_(.*) is not set/) {
+		$var = "BUSYBOX_$1";
+		$val = 'n';
 		$type = "bool";
-	} elsif ($val eq 'm') {
-		$type = "tristate";
-	} elsif ($val =~ /^".*"$/) {
-		$type = "string";
-	} elsif ($val =~ /^\d+$/) {
-		$type = "int";
 	} else {
-		warn "WARNING: no type found for symbol CONFIG_$var=$val\n";
-		next;
+		# We don't want to preserve a record of deselecting
+		# packages because we may want build them in the SDK.
+		# non-package configs however may be important to preserve
+		# the same compilation settings for packages that get
+		# recompiled in the SDK.
+		# Also we want avoid preserving image generation settings
+		# because we set those while in ImageBuilder
+		next if /^(# )?CONFIG_PACKAGE/;
+		next if /^(# )?CONFIG_TARGET/;
+		if (/^# CONFIG_(.*) is not set/) {
+			$var = $1;
+			$val = 'n';
+			$type = "bool";
+                }
 	}
 
-	print <<EOF;
+	if (($var ne '') && ($type ne '') && ($val ne '')) {
+		print <<EOF;
 config $var
 	$type
 	default $val
 
 EOF
+	}
 }


### PR DESCRIPTION
The configuration preservation mechanism fails to keep items was are unset
as unset.  For busybox this causes issues when building with custom
settings in the SDK.  Therefore preserve busybox unset settings.
In addition we preserve non-package selection unset settings because
they may be important for making sure we compile and identical
package for packages that are recompiled in the SDK.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>

I've been using this along with other patches related to preventing SDK
reconfiguration in my own tree.