### PR TITLE
ramips:add Widora-NEO board support

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -51,6 +51,7 @@ ramips_setup_interfaces()
 	ncs601w|\
 	w150m|\
 	wnce2001|\
+	widora|\
 	zte-q7)
 		ucidef_add_switch "switch0"
 		ucidef_add_switch_attr "switch0" "enable" "false"

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -200,6 +200,9 @@ get_status_led() {
 	wrtnode)
 		status_led="wrtnode:blue:indicator"
 		;;
+	widora)
+		status_led="$board:orange:wifi"
+		;;
 	esac
 }
 

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -502,6 +502,9 @@ ramips_board_detect() {
 	*"WZR-AGL300NH")
 		name="wzr-agl300nh"
 		;;
+	*"Widora-NEO")
+		name="widora"
+		;;
 	*"X5")
 		name="x5"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -149,6 +149,7 @@ platform_check_image() {
 	wt1520|\
 	wt3020|\
 	wzr-agl300nh|\
+	widora|\
 	x5|\
 	x8|\
 	y1|\

--- a/target/linux/ramips/dts/WIDORA.dts
+++ b/target/linux/ramips/dts/WIDORA.dts
@@ -1,0 +1,169 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+/ {
+	compatible = "mediatek,widora", "mediatek,mt7628an-soc";
+	model = "Widora-NEO";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wifi {
+			label = "widora:orange:wifi";
+			gpios = <&wgpio 0 0>;
+			default-state = "on";
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wps {
+			label = "reset";
+			gpios = <&gpio1 6 1>;
+			linux,code = <0x211>;
+		};
+	};
+
+	wgpio: gpio-wifi {
+		compatible = "mediatek,gpio-wifi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "gpio";
+			ralink,function = "gpio";
+		};
+
+		perst {
+			ralink,group = "perst";
+			ralink,function = "gpio";
+		};
+
+		refclk {
+			ralink,group = "refclk";
+			ralink,function = "gpio";
+		};
+
+		i2s {
+			ralink,group = "i2s";
+			ralink,function = "gpio";
+		};
+
+		spis {
+			ralink,group = "spis";
+			ralink,function = "gpio";
+		};
+
+		wled_kn {
+			ralink,group = "wled_kn";
+			ralink,function = "gpio";
+		};
+
+		wled_an {
+			ralink,group = "wled_an";
+			ralink,function = "wled_an";
+		};
+
+		wdt {
+			ralink,group = "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+
+&spi0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80", "w25q128";
+		spi-max-frequency = <40000000>;
+		m25p,chunked-io = <31>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x0fb0000>;
+		};
+	};
+
+	spidev@1 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "linux,spidev";
+		reg = <1>;
+		spi-max-frequency = <40000000>;
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&sdhci {
+	status = "okay";
+	mediatek,cd-low;
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7688.mk
+++ b/target/linux/ramips/image/mt7688.mk
@@ -17,3 +17,11 @@ define Device/wrtnode2r
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += wrtnode2r
+
+define Device/widora
+  DTS := WIDORA
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Widora-NEO
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += widora


### PR DESCRIPTION
Widora-NEO board is based MT7688AN MIPS CPU,which has 128MB DRAM,16MB FLASH,1SD card connect,1WAN/LAN,3UART,4PWM.Yet another Open Source Hardware,designed by mango.