### PR TITLE
lua: host-compile install to correct directory

### DIFF
--- a/package/utils/lua/Makefile
+++ b/package/utils/lua/Makefile
@@ -111,7 +111,7 @@ define Build/Compile
 endef
 
 define Host/Configure
-	$(SED) 's,"/usr/local/","$(STAGING_DIR)/host/",' $(HOST_BUILD_DIR)/src/luaconf.h
+	$(SED) 's,"/usr/local/","$(STAGING_DIR_HOST)/",' $(HOST_BUILD_DIR)/src/luaconf.h
 endef
 
 ifeq ($(HOST_OS),Darwin)
@@ -132,7 +132,7 @@ endef
 
 define Host/Install
 	$(MAKE) -C $(HOST_BUILD_DIR) \
-		INSTALL_TOP="$(STAGING_DIR)/host" \
+		INSTALL_TOP="$(STAGING_DIR_HOST)" \
 		install
 endef
 


### PR DESCRIPTION
Host lua was being installed in stagingdir/targetdir/host rather than
stagingdir/host

Fixes bash: /home/kevin/git/github/lede/staging_dir/host/bin/lua: No
such file or directory warnings when Minify LUA sources is enabled due
to no local lua interpreter available to interpret LuaSrcDiet

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>