### PR TITLE
ramips: fix Netgear EX2700 images

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -7,13 +7,9 @@ define Build/tplink-header
 		-o $@.new -k $@  && mv $@.new $@
 endef
 
-define Build/pad-ex2700
-	cat ex2700-fakeroot.uImage >> $@; cat ex2700-fakeroot.uImage >> $@;
-	dd if=$@ of=$@.new bs=64k conv=sync && truncate -s 128 $@.new && mv $@.new $@
-endef
-
-define Build/append-ex2700
-	cat ex2700-fakeroot.uImage >> $@
+define Build/pad-kernel-ex2700
+	dd if=$@ of=$@.new bs=64k conv=sync && truncate -s -64 $@.new \
+		&& cat ex2700-fakeroot.uImage >> $@.new && mv $@.new $@
 endef
 
 define Build/netgear-header
@@ -58,7 +54,7 @@ define Device/ex2700
   DTS := EX2700
   IMAGE_SIZE := $(ex2700_mtd_size)
   IMAGES += factory.bin
-  KERNEL := $(KERNEL_DTB) | pad-ex2700 | uImage lzma | append-ex2700
+  KERNEL := $(KERNEL_DTB) | uImage lzma | pad-kernel-ex2700
   IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | netgear-header -B EX2700 -H 29764623+4+0+32+2x2+0
   DEVICE_TITLE := Netgear EX2700
 endef


### PR DESCRIPTION
The bootloader on this device expects the kernel partition to end
on a 64k boundary. The last 64 byte of the kernel partition must
contain a valid uImage header (the fakeroot partition).

Signed-off-by: Joseph C. Lehner <joseph.c.lehner@gmail.com>