### PR TITLE
brcm63xx: add sysupgrade images

### DIFF
--- a/target/linux/brcm63xx/image/Makefile
+++ b/target/linux/brcm63xx/image/Makefile
@@ -129,7 +129,7 @@ define Build/cfe-spw303v-bin
 		--output $@ --boardid $(CFE_BOARD_ID) --chipid $(CFE_CHIP_ID) \
 		--entry $(LOADER_ENTRY) --load-addr $(LOADER_ENTRY) \
 		$(call rootfspad/$(call Image/FileSystemStrip,$(word 2,$^))) \
-		$(CFE_EXTRAS)
+		$(CFE_EXTRAS) $(1)
 endef
 
 define Build/spw303v-bin

--- a/target/linux/brcm63xx/image/bcm63xx.mk
+++ b/target/linux/brcm63xx/image/bcm63xx.mk
@@ -16,23 +16,25 @@ define Device/bcm63xx
   KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma | lzma-cfe
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-lzma elf
   IMAGES := cfe.bin
-  IMAGE/cfe.bin := cfe-bin
+  IMAGE/cfe.bin := cfe-bin --pad $$$$(shell expr $$$$(FLASH_MB) / 2)
   IMAGE/cfe-4M.bin := cfe-bin --pad 2
   IMAGE/cfe-8M.bin := cfe-bin --pad 4
   IMAGE/cfe-16M.bin := cfe-bin --pad 8
   IMAGE/cfe-bc221.bin := cfe-bin --layoutver 5
   IMAGE/cfe-old.bin := cfe-old-bin
+  IMAGE/sysupgrade.bin := cfe-bin
+  FLASH_MB := 4
   CFE_BOARD_ID :=
   CFE_CHIP_ID :=
   CFE_EXTRAS :=
 endef
+DEVICE_VARS += FLASH_MB
 DEVICE_VARS += CFE_BOARD_ID CFE_CHIP_ID CFE_EXTRAS
 
 define Device/bcm63xx_netgear
   $(Device/bcm63xx)
   IMAGES := factory.chk sysupgrade.bin
   IMAGE/factory.chk := cfe-bin | netgear-chk
-  IMAGE/sysupgrade.bin := cfe-bin
   NETGEAR_BOARD_ID :=
   NETGEAR_REGION :=
 endef
@@ -177,7 +179,7 @@ define Device/A4001N
   DEVICE_DTS := a4001n
   CFE_BOARD_ID := 96328dg2x2
   CFE_CHIP_ID := 6328
-  CFE_EXTRAS := --pad 4
+  FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(USB2_PACKAGES) $(B43_PACKAGES)
 endef
@@ -185,11 +187,12 @@ TARGET_DEVICES += A4001N
 
 define Device/A4001N1
   $(Device/bcm63xx)
+  IMAGES += sysupgrade.bin
   DEVICE_TITLE := ADB P.DG A4001N1
   DEVICE_DTS := a4001n1
   CFE_BOARD_ID := 963281T_TEF
   CFE_CHIP_ID := 6328
-  CFE_EXTRAS := --pad 8
+  FLASH_MB := 16
   DEVICE_PACKAGES := \
     $(USB2_PACKAGES) $(B43_PACKAGES)
 endef
@@ -326,11 +329,12 @@ TARGET_DEVICES += BTV2500V
 ### Comtrend ###
 define Device/AR5381u
   $(Device/bcm63xx)
+  IMAGES += sysupgrade.bin
   DEVICE_TITLE := Comtrend AR-5381u
   DEVICE_DTS := ar-5381u
   CFE_BOARD_ID := 96328A-1241N
   CFE_CHIP_ID := 6328
-  CFE_EXTRAS := --pad 8
+  FLASH_MB := 16
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -338,11 +342,12 @@ TARGET_DEVICES += AR5381u
 
 define Device/AR5387un
   $(Device/bcm63xx)
+  IMAGES += sysupgrade.bin
   DEVICE_TITLE := Comtrend AR-5387un
   DEVICE_DTS := ar-5387un
   CFE_BOARD_ID := 96328A-1441N1
   CFE_CHIP_ID := 6328
-  CFE_EXTRAS := --pad 8
+  FLASH_MB := 16
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -383,11 +388,13 @@ TARGET_DEVICES += CT-6373
 
 define Device/VR-3025u
   $(Device/bcm63xx)
+  IMAGES += sysupgrade.bin
   DEVICE_TITLE := Comtrend VR-3025u
   DEVICE_DTS := vr-3025u
   CFE_BOARD_ID := 96368M-1541N
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --pad 16 --image-offset 0x20000 --block-size 0x20000
+  CFE_EXTRAS := --image-offset 0x20000 --block-size 0x20000
+  FLASH_MB := 32
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -399,7 +406,7 @@ define Device/VR-3025un
   DEVICE_DTS := vr-3025un
   CFE_BOARD_ID := 96368M-1341N
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --pad 4
+  FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -411,7 +418,7 @@ define Device/VR-3026e
   DEVICE_DTS := vr-3026e
   CFE_BOARD_ID := 96368MT-1341N1
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --pad 4
+  FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -423,7 +430,7 @@ define Device/WAP-5813n
   DEVICE_DTS := wap-5813n
   CFE_BOARD_ID := 96369R-1231N
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --pad 4
+  FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -505,7 +512,7 @@ define Device/DSL275XB-D1
   DEVICE_DTS := dsl-275xb-d
   CFE_BOARD_ID := AW5200B
   CFE_CHIP_ID := 6318
-  CFE_EXTRAS := --pad 4
+  FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -650,11 +657,13 @@ TARGET_DEVICES += HG556a-C
 
 define Device/HG622
   $(Device/bcm63xx)
+  IMAGES += sysupgrade.bin
   DEVICE_TITLE := Huawei EchoLife HG622
   DEVICE_DTS := hg622
   CFE_BOARD_ID := 96368MVWG_hg622
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --image-offset 0x20000 --block-size 0x20000 --tag-version 7 --pad 8
+  CFE_EXTRAS := --image-offset 0x20000 --block-size 0x20000 --tag-version 7
+  FLASH_MB := 16
   DEVICE_PACKAGES := \
     $(RT28_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -666,7 +675,8 @@ define Device/HG655b
   DEVICE_DTS := hg655b
   CFE_BOARD_ID := HW65x
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --image-offset 0x20000 --tag-version 7 --pad 4
+  CFE_EXTRAS := --image-offset 0x20000 --tag-version 7
+  FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(RT28_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -777,11 +787,12 @@ TARGET_DEVICES += EVG2000
 ### NuCom ###
 define Device/R5010UNv2
   $(Device/bcm63xx)
+  IMAGES += sysupgrade.bin
   DEVICE_TITLE := NuCom R5010UN v2
   DEVICE_DTS := r5010unv2
   CFE_BOARD_ID := 96328ang
   CFE_CHIP_ID := 6328
-  CFE_EXTRAS := --pad 8
+  FLASH_MB := 16
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -876,7 +887,7 @@ define Device/FAST2704N
   DEVICE_DTS := fast2704n
   CFE_BOARD_ID := F@ST2704N
   CFE_CHIP_ID := 6318
-  CFE_EXTRAS := --pad 4
+  FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -888,7 +899,7 @@ define Device/FAST2704V2
   DEVICE_DTS := fast2704v2
   CFE_BOARD_ID := F@ST2704V2
   CFE_CHIP_ID := 6328
-  CFE_EXTRAS := --pad 4
+  FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -935,13 +946,12 @@ TARGET_DEVICES += NEUFBOX6
 define Device/SPW303V
   $(Device/bcm63xx)
   IMAGES := factory.bin sysupgrade.bin
-  IMAGE/factory.bin := cfe-spw303v-bin | spw303v-bin | xor-image
+  IMAGE/factory.bin := cfe-spw303v-bin --pad 4 | spw303v-bin | xor-image
   IMAGE/sysupgrade.bin := cfe-spw303v-bin | spw303v-bin
   DEVICE_TITLE := T-Com Speedport W 303V
   DEVICE_DTS := spw303v
   CFE_BOARD_ID := 96358-502V
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --pad 4
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -1002,7 +1012,8 @@ define Device/CPA-ZNTE60T
   DEVICE_DTS := cpva642
   CFE_BOARD_ID := CPVA642
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --signature "Telsey Tlc" --signature2 "99.99.999" --second-image-flag "0" --pad 4
+  CFE_EXTRAS := --signature "Telsey Tlc" --signature2 "99.99.999" --second-image-flag "0"
+  FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(RT63_PACKAGES) $(USB2_PACKAGES)
 endef

--- a/target/linux/brcm63xx/image/bcm63xx.mk
+++ b/target/linux/brcm63xx/image/bcm63xx.mk
@@ -23,12 +23,14 @@ define Device/bcm63xx
   IMAGE/cfe-bc221.bin := cfe-bin --layoutver 5
   IMAGE/cfe-old.bin := cfe-old-bin
   IMAGE/sysupgrade.bin := cfe-bin
+  BLOCK_SIZE := 0x10000
+  IMAGE_OFFSET :=
   FLASH_MB := 4
   CFE_BOARD_ID :=
   CFE_CHIP_ID :=
-  CFE_EXTRAS :=
+  CFE_EXTRAS := --block-size $$(BLOCK_SIZE) --image-offset $$(if $$(IMAGE_OFFSET),$$(IMAGE_OFFSET),$$(BLOCK_SIZE))
 endef
-DEVICE_VARS += FLASH_MB
+DEVICE_VARS += BLOCK_SIZE FLASH_MB IMAGE_SIZE
 DEVICE_VARS += CFE_BOARD_ID CFE_CHIP_ID CFE_EXTRAS
 
 define Device/bcm63xx_netgear
@@ -205,7 +207,7 @@ define Device/RG100A
   DEVICE_DTS := rg100a
   CFE_BOARD_ID := 96358VW2
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --block-size 0x20000 --image-offset 0x20000
+  BLOCK_SIZE := 0x20000
   DEVICE_PACKAGES := \
     $(USB2_PACKAGES) $(B43_PACKAGES)
 endef
@@ -230,7 +232,7 @@ define Device/F5D7633
   DEVICE_DTS := f5d7633
   CFE_BOARD_ID := 96348GW-10
   CFE_CHIP_ID := 6348
-  CFE_EXTRAS := --block-size 0x20000 --image-offset 0x20000
+  BLOCK_SIZE := 0x20000
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -296,7 +298,7 @@ define Device/HomeHub2A
   DEVICE_DTS := homehub2a
   CFE_BOARD_ID := HOMEHUB2A
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --image-offset 0x20000 --block-size 0x20000
+  BLOCK_SIZE := 0x20000
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -308,7 +310,7 @@ define Device/BTV2110
   DEVICE_DTS := v2110
   CFE_BOARD_ID := V2110
   CFE_CHIP_ID := 6348
-  CFE_EXTRAS := --layoutver 5
+  CFE_EXTRAS += --layoutver 5
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -320,7 +322,7 @@ define Device/BTV2500V
   DEVICE_DTS := v2500v-bb
   CFE_BOARD_ID := V2500V_BB
   CFE_CHIP_ID := 6348
-  CFE_EXTRAS := --layoutver 5
+  CFE_EXTRAS += --layoutver 5
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -393,7 +395,7 @@ define Device/VR-3025u
   DEVICE_DTS := vr-3025u
   CFE_BOARD_ID := 96368M-1541N
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --image-offset 0x20000 --block-size 0x20000
+  BLOCK_SIZE := 0x20000
   FLASH_MB := 32
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
@@ -550,7 +552,7 @@ define Device/RTA770BW
   DEVICE_DTS := rta770bw
   CFE_BOARD_ID := RTA770BW
   CFE_CHIP_ID := 6345
-  CFE_EXTRAS := --layoutver 5
+  CFE_EXTRAS += --layoutver 5
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -563,7 +565,7 @@ define Device/RTA770W
   DEVICE_DTS := rta770w
   CFE_BOARD_ID := RTA770W
   CFE_CHIP_ID := 6345
-  CFE_EXTRAS := --layoutver 5
+  CFE_EXTRAS += --layoutver 5
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -575,7 +577,7 @@ define Device/RTA1025W_16
   DEVICE_DTS := rta1025w
   CFE_BOARD_ID := RTA1025W_16
   CFE_CHIP_ID := 6348
-  CFE_EXTRAS := --layoutver 5
+  CFE_EXTRAS += --layoutver 5
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -587,7 +589,7 @@ define Device/RTA1320_16M
   DEVICE_DTS := rta1320
   CFE_BOARD_ID := RTA1320_16M
   CFE_CHIP_ID := 6338
-  CFE_EXTRAS := --layoutver 5
+  CFE_EXTRAS += --layoutver 5
 endef
 TARGET_DEVICES += RTA1320_16M
 
@@ -598,7 +600,7 @@ define Device/HG520v
   DEVICE_DTS := hg520v
   CFE_BOARD_ID := HW6358GW_B
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --rsa-signature "EchoLife_HG520v"
+  CFE_EXTRAS += --rsa-signature "EchoLife_HG520v"
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -610,7 +612,8 @@ define Device/HG553
   DEVICE_DTS := hg553
   CFE_BOARD_ID := HW553
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --rsa-signature "EchoLife_HG553" --image-offset 0x20000 --block-size 0x20000 --tag-version 7
+  CFE_EXTRAS += --rsa-signature "EchoLife_HG553" --tag-version 7
+  BLOCK_SIZE := 0x20000
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -623,7 +626,8 @@ define Device/HG556a-A
   DEVICE_DTS := hg556a-a
   CFE_BOARD_ID := HW556
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --rsa-signature "EchoLife_HG556a" --image-offset 0x20000 --block-size 0x10000 --tag-version 8
+  CFE_EXTRAS += --rsa-signature "EchoLife_HG556a" --tag-version 8
+  IMAGE_OFFSET := 0x20000
   DEVICE_PACKAGES := \
     $(ATH9K_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -636,7 +640,8 @@ define Device/HG556a-B
   DEVICE_DTS := hg556a-b
   CFE_BOARD_ID := HW556
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --rsa-signature "EchoLife_HG556a" --image-offset 0x20000 --block-size 0x20000 --tag-version 8
+  CFE_EXTRAS += --rsa-signature "EchoLife_HG556a" --tag-version 8
+  BLOCK_SIZE := 0x20000
   DEVICE_PACKAGES := \
     $(ATH9K_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -649,7 +654,8 @@ define Device/HG556a-C
   DEVICE_DTS := hg556a-c
   CFE_BOARD_ID := HW556
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --rsa-signature "EchoLife_HG556a" --image-offset 0x20000 --block-size 0x20000 --tag-version 8
+  CFE_EXTRAS += --rsa-signature "EchoLife_HG556a" --tag-version 8
+  BLOCK_SIZE := 0x20000
   DEVICE_PACKAGES := \
     $(RT28_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -662,7 +668,8 @@ define Device/HG622
   DEVICE_DTS := hg622
   CFE_BOARD_ID := 96368MVWG_hg622
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --image-offset 0x20000 --block-size 0x20000 --tag-version 7
+  CFE_EXTRAS += --tag-version 7
+  BLOCK_SIZE := 0x20000
   FLASH_MB := 16
   DEVICE_PACKAGES := \
     $(RT28_PACKAGES) $(USB2_PACKAGES)
@@ -675,7 +682,8 @@ define Device/HG655b
   DEVICE_DTS := hg655b
   CFE_BOARD_ID := HW65x
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --image-offset 0x20000 --tag-version 7
+  CFE_EXTRAS += --tag-version 7
+  IMAGE_OFFSET := 0x20000
   FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(RT28_PACKAGES) $(USB2_PACKAGES)
@@ -746,7 +754,7 @@ define Device/DGND3700v1
   DEVICE_DTS := dgnd3700v1
   CFE_BOARD_ID := 96368MVWG
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --image-offset 0x20000 --block-size 0x20000
+  BLOCK_SIZE := 0x20000
   NETGEAR_BOARD_ID := U12L144T01_NETGEAR_NEWLED
   NETGEAR_REGION := 1
   DEVICE_PACKAGES := \
@@ -761,7 +769,7 @@ define Device/DGND3800B
   DEVICE_DTS := dgnd3700v1
   CFE_BOARD_ID := 96368MVWG
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --image-offset 0x20000 --block-size 0x20000
+  BLOCK_SIZE := 0x20000
   NETGEAR_BOARD_ID := U12L144T11_NETGEAR_NEWLED
   NETGEAR_REGION := 1
   DEVICE_PACKAGES := \
@@ -776,7 +784,7 @@ define Device/EVG2000
   DEVICE_DTS := evg2000
   CFE_BOARD_ID := 96369PVG
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --image-offset 0x20000 --block-size 0x20000
+  BLOCK_SIZE := 0x20000
   NETGEAR_BOARD_ID := U12H154T90_NETGEAR
   NETGEAR_REGION := 1
   DEVICE_PACKAGES := \
@@ -805,7 +813,7 @@ define Device/A226G
   DEVICE_DTS := a226g
   CFE_BOARD_ID := DWV-S0
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --signature2 IMAGE --tag-version 8
+  CFE_EXTRAS += --signature2 IMAGE --tag-version 8
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -817,7 +825,7 @@ define Device/A226M
   DEVICE_DTS := a226m
   CFE_BOARD_ID := DWV-S0
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --signature2 IMAGE --tag-version 8
+  CFE_EXTRAS += --signature2 IMAGE --tag-version 8
   DEVICE_PACKAGES := \
     $(USB2_PACKAGES)
 endef
@@ -829,7 +837,8 @@ define Device/A226M-FWB
   DEVICE_DTS := a226m-fwb
   CFE_BOARD_ID := DWV-S0
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --block-size 0x20000 --image-offset 0x20000 --signature2 IMAGE --tag-version 8
+  CFE_EXTRAS += --signature2 IMAGE --tag-version 8
+  BLOCK_SIZE := 0x20000
   DEVICE_PACKAGES := \
     $(USB2_PACKAGES)
 endef
@@ -841,7 +850,8 @@ define Device/AGPF-S0
   DEVICE_DTS := agpf-s0
   CFE_BOARD_ID := AGPF-S0
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --block-size 0x20000 --image-offset 0x20000 --signature2 IMAGE --tag-version 8
+  CFE_EXTRAS += --signature2 IMAGE --tag-version 8
+  BLOCK_SIZE := 0x20000
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -912,7 +922,7 @@ define Device/NEUFBOX4-SER
   DEVICE_DTS := nb4-ser-r0
   CFE_BOARD_ID := 96358VW
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --rsa-signature "LEDE-$(REVISION)"
+  CFE_EXTRAS += --rsa-signature "LEDE-$(REVISION)"
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -924,7 +934,7 @@ define Device/NEUFBOX4-FXC
   DEVICE_DTS := nb4-fxc-r1
   CFE_BOARD_ID := 96358VW
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --rsa-signature "LEDE-$(REVISION)"
+  CFE_EXTRAS += --rsa-signature "LEDE-$(REVISION)"
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -936,7 +946,7 @@ define Device/NEUFBOX6
   DEVICE_DTS := nb6-ser-r0
   CFE_BOARD_ID := NB6-SER-r0
   CFE_CHIP_ID := 6362
-  CFE_EXTRAS := --rsa-signature "LEDE-$(REVISION)"
+  CFE_EXTRAS += --rsa-signature "LEDE-$(REVISION)"
   DEVICE_PACKAGES := \
     $(B43_PACKAGES) $(USB2_PACKAGES)
 endef
@@ -986,7 +996,7 @@ define Device/GW6200
   DEVICE_DTS := gw6200
   CFE_BOARD_ID := 96348GW
   CFE_CHIP_ID := 6348
-  CFE_EXTRAS := --rsa-signature "$(shell printf '\x99')"
+  CFE_EXTRAS += --rsa-signature "$(shell printf '\x99')"
   DEVICE_PACKAGES := \
     $(BRCMWL_PACKAGES) $(USB1_PACKAGES)
 endef
@@ -1000,7 +1010,7 @@ define Device/CVPA502PLUS
   DEVICE_DTS := cpva502plus
   CFE_BOARD_ID := CPVA502+
   CFE_CHIP_ID := 6348
-  CFE_EXTRAS := --signature "Telsey Tlc" --signature2 "99.99.999" --second-image-flag "0"
+  CFE_EXTRAS += --signature "Telsey Tlc" --signature2 "99.99.999" --second-image-flag "0"
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -1012,7 +1022,7 @@ define Device/CPA-ZNTE60T
   DEVICE_DTS := cpva642
   CFE_BOARD_ID := CPVA642
   CFE_CHIP_ID := 6358
-  CFE_EXTRAS := --signature "Telsey Tlc" --signature2 "99.99.999" --second-image-flag "0"
+  CFE_EXTRAS += --signature "Telsey Tlc" --signature2 "99.99.999" --second-image-flag "0"
   FLASH_MB := 8
   DEVICE_PACKAGES := \
     $(RT63_PACKAGES) $(USB2_PACKAGES)
@@ -1038,7 +1048,8 @@ define Device/TD-W8900GB
   DEVICE_DTS := td-w8900gb
   CFE_BOARD_ID := 96348GW-11
   CFE_CHIP_ID := 6348
-  CFE_EXTRAS := --rsa-signature "$(shell printf 'PRID\x89\x10\x00\x02')" --image-offset 0x20000
+  CFE_EXTRAS += --rsa-signature "$(shell printf 'PRID\x89\x10\x00\x02')"
+  IMAGE_OFFSET := 0x20000
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef
@@ -1065,7 +1076,7 @@ define Device/P870HW-51a_v2
   DEVICE_DTS := p870hw-51a-v2
   CFE_BOARD_ID := 96368VVW
   CFE_CHIP_ID := 6368
-  CFE_EXTRAS := --rsa-signature "ZyXEL" --signature "ZyXEL_0001"
+  CFE_EXTRAS += --rsa-signature "ZyXEL" --signature "ZyXEL_0001"
   DEVICE_PACKAGES := \
     $(B43_PACKAGES)
 endef


### PR DESCRIPTION
Some devices require padded images in order to prevent CFE from flashing them
to the wrong offset.
For small flashes (4/8) this is no big deal, but for larger flashes (16/32) this
implies 8 and 16 MB images, which is way too large and some devices aren't
capable of flashing them through sysupgrade.

Maybe we should omit sysupgrade images for devices with <=8MB flashes?

CC @KanjiMonster 