### PR TITLE
kmod-sched-cake:Add support for cake qdisc

### DIFF
--- a/package/kernel/kmod-sched-cake/Makefile
+++ b/package/kernel/kmod-sched-cake/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2016 LEDE
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=sched-cake
+PKG_VERSION:=2016-05-31
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=git://github.com/dtaht/sch_cake
+PKG_SOURCE_VERSION:=292b57c714f0f9a856c5822b7b3b9fb931873db7
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_ID:=$(PKG_SOURCE_VERSION)
+PKG_MAINTAINER:=Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/sched-cake
+  SUBMENU:=Network Support
+  TITLE:=Cake fq_codel derived shaper
+  URL:=https://github.com/dtaht/sch_cake
+  FILES:=$(PKG_BUILD_DIR)/sch_cake.ko
+  VERSION:=$(LINUX_VERSION)-$(LINUX_RELEASE)
+  AUTOLOAD:=$(call AutoLoad,75,sch_cake)
+endef
+
+include $(INCLUDE_DIR)/kernel-defaults.mk
+
+define KernelPackage/sched-cake/description
+  Common Applications Kept Enhanced fq_codel derived shaper
+endef
+
+define Build/Compile
+	$(MAKE) $(KERNEL_MAKEOPTS) SUBDIRS="$(PKG_BUILD_DIR)" modules
+endef
+
+$(eval $(call KernelPackage,sched-cake))


### PR DESCRIPTION
Add 'cake' qdisc kernel module package.

V2 - KDB Small update to base on latest cake tc changes (wash option
deprecated)
V3 - KDB Move kmod-sched-cake package to kernel as is kernel related
V4 - KDB Split into individual patches, kmod & tc

Signed-off-by: Hannu Nyman <hannu.nyman@iki.fi>
Acked-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>