### PR TITLE
lantiq-xrx200: Fritzbox WLAN 3370 - Unhardcode MAC-Address

### DIFF
--- a/target/linux/lantiq/dts/FRITZ3370.dts
+++ b/target/linux/lantiq/dts/FRITZ3370.dts
@@ -220,7 +220,6 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		reg = <0>;
-		mac-address = [ 00 11 22 33 44 55 ];
 		lantiq,switch;
 
 		ethernet@0 {


### PR DESCRIPTION
This Pr removes the hardcoded MAC-Address in the Fritzbox 3370 dts file.

signed-off-by: Guido Lipke <lipkegu@gmail.com>