### PR TITLE
lantiq: Fritzbox WLAN 7320 - Unhardcode MAC-Address

### DIFF
--- a/target/linux/lantiq/dts/FRITZ7320.dts
+++ b/target/linux/lantiq/dts/FRITZ7320.dts
@@ -88,7 +88,6 @@
 
 		etop@E180000 {
 			phy-mode = "mii";
-			mac-address = [ 00 11 22 33 44 55 ];
 		};
 
 		ifxhcd@E101000 {


### PR DESCRIPTION
This PR removes the hardcoded MAC-Address for the PHY.

signed-off-by: Guido Lipke <lipkegu@gmail.com>