### PR TITLE
ramips / mediatek audio related patches

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -172,6 +172,10 @@ ramips_setup_interfaces()
 	wrh-300cr)
 		ucidef_set_interface_lan "eth0"
 		;;
+	duzun-dm06)
+		ucidef_add_switch "switch0" \
+			"1:lan" "0:wan" "6@eth0"
+		;;
 	e1700|\
 	mt7620a_mt7530)
 		ucidef_add_switch "switch1" \

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -151,6 +151,9 @@ ramips_board_detect() {
 	*"Dovado Tiny AC")
 		name="tiny-ac"
 		;;
+	*"DuZun DM06")
+		name="duzun-dm06"
+		;;
 	*"E1700")
 		name="e1700"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -50,6 +50,7 @@ platform_check_image() {
 	dir-620-a1|\
 	dir-620-d1|\
 	dir-810l|\
+	duzun-dm06|\
 	e1700|\
 	esr-9753|\
 	ex2700|\

--- a/target/linux/ramips/dts/DUZUN-DM06.dts
+++ b/target/linux/ramips/dts/DUZUN-DM06.dts
@@ -1,0 +1,155 @@
+/dts-v1/;
+
+/include/ "mt7628an.dtsi"
+
+/ {
+	compatible = "duzun,dm06-mt7628an", "mediatek,mt7628an-soc";
+	model = "DuZun DM06";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 14 1>;
+			linux,code = <0x198>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 6 1>;
+			linux,code = <0x211>;
+		};
+	};
+
+	sound {
+		compatible = "simple-audio-card";
+		simple-audio-card,name = "Audio-I2S";
+		simple-audio-card,format = "i2s";
+		simple-audio-card,bitclock-master = <&dailink0_master>;
+		simple-audio-card,frame-master = <&dailink0_master>;
+		simple-audio-card,widgets =
+			"Headphone", "Headphones";
+		simple-audio-card,routing =
+			"Headphones", "HP_L",
+			"Headphones", "HP_R";
+		simple-audio-card,mclk-fs = <256>;
+
+		simple-audio-card,cpu {
+			sound-dai = <&i2s>;
+		};
+
+		dailink0_master: simple-audio-card,codec {
+			sound-dai = <&codec>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt", "uart1";
+			ralink,function = "gpio";
+		};
+	};
+
+	i2s_pins: i2s {
+		i2s {
+			ralink,group = "i2s";
+			ralink,function = "i2s";
+		};
+	};
+
+	wm8960_mclk_pins: wm8960_mclk {
+		wm8960_mclk {
+			ralink,group = "refclk";
+			ralink,function = "reclk";
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&i2c {
+	status = "okay";
+
+	codec: wm8960@1a {
+		#sound-dai-cells = <0>;
+		compatible = "wlf,wm8960";
+		reg = <0x1a>;
+
+		wlf,shared-lrclk;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&esw {
+	mediatek,portmap = <0x3>;
+	mediatek,portdisable = <0x3c>;
+};
+
+&i2s {
+	#sound-dai-cells = <0>;
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2s_pins>, <&wm8960_mclk_pins>;
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&gdma {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80";
+		spi-max-frequency = <60000000>;
+		m25p,chunked-io = <32>;
+		m25p,fast-read;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x7b0000>;
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -176,7 +176,7 @@
 		};
 
 		i2c: i2c@900 {
-			compatible = "link,mt7620a-i2c", "ralink,rt2880-i2c";
+			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
 			resets = <&rstctrl 16>;

--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -281,7 +281,7 @@
 		};
 
 		gdma: gdma@2800 {
-			compatible = "ralink,mt7620a-gdma", "ralink,rt2880-gdma";
+			compatible = "ralink,mt7620a-gdma", "ralink,rt3883-gdma";
 			reg = <0x2800 0x800>;
 
 			resets = <&rstctrl 14>;

--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -192,7 +192,7 @@
 		};
 
 		i2s: i2s@a00 {
-			compatible = "ralink,mt7620a-i2s";
+			compatible = "mediatek,mt7620-i2s";
 			reg = <0xa00 0x100>;
 
 			resets = <&rstctrl 17>;
@@ -201,8 +201,11 @@
 			interrupt-parent = <&intc>;
 			interrupts = <10>;
 
+			txdma-req = <2>;
+			rxdma-req = <3>;
+
 			dmas = <&gdma 4>,
-				<&gdma 5>;
+				<&gdma 6>;
 			dma-names = "tx", "rx";
 
 			status = "disabled";

--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -107,6 +107,28 @@
 			pinctrl-0 = <&i2c_pins>;
 		};
 
+		i2s: i2s@a00 {
+			compatible = "mediatek,mt7621-i2s";
+			reg = <0xa00 0x100>;
+
+			clocks = <&sysclock>;
+
+			resets = <&rstctrl 17>;
+			reset-names = "i2s";
+
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SHARED 16 IRQ_TYPE_LEVEL_HIGH>;
+
+			txdma-req = <2>;
+			rxdma-req = <3>;
+
+			dmas = <&gdma 4>,
+				<&gdma 6>;
+			dma-names = "tx", "rx";
+
+			status = "disabled";
+		};
+
 		memc: memc@5000 {
 			compatible = "mtk,mt7621-memc";
 			reg = <0x300 0x100>;

--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -89,6 +89,24 @@
 			};
 		};
 
+		i2c: i2c@900 {
+			compatible = "mediatek,mt7621-i2c";
+			reg = <0x900 0x100>;
+
+			clocks = <&sysclock>;
+
+			resets = <&rstctrl 16>;
+			reset-names = "i2c";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c_pins>;
+		};
+
 		memc: memc@5000 {
 			compatible = "mtk,mt7621-memc";
 			reg = <0x300 0x100>;
@@ -188,17 +206,17 @@
 		state_default: pinctrl0 {
 		};
 
-		spi_pins: spi {
-			spi {
-				ralink,group = "spi";
-				ralink,function = "spi";
-			};
-		};
-
 		i2c_pins: i2c {
 			i2c {
 				ralink,group = "i2c";
 				ralink,function = "i2c";
+			};
+		};
+
+		spi_pins: spi {
+			spi {
+				ralink,group = "spi";
+				ralink,function = "spi";
 			};
 		};
 

--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -144,6 +144,40 @@
 				m25p,chunked-io = <32>;
 			};
 		};
+
+		gdma: gdma@2800 {
+			compatible = "ralink,rt3883-gdma";
+			reg = <0x2800 0x800>;
+
+			resets = <&rstctrl 14>;
+			reset-names = "dma";
+
+			interrupt-parent = <&gic>;
+			interrupts = <0 13 4>;
+
+			#dma-cells = <1>;
+			#dma-channels = <16>;
+			#dma-requests = <16>;
+
+			status = "disabled";
+		};
+
+		hsdma: hsdma@7000 {
+			compatible = "mediatek,mt7621-hsdma";
+			reg = <0x7000 0x1000>;
+
+			resets = <&rstctrl 5>;
+			reset-names = "hsdma";
+
+			interrupt-parent = <&gic>;
+			interrupts = <0 11 4>;
+
+			#dma-cells = <1>;
+			#dma-channels = <1>;
+			#dma-requests = <1>;
+
+			status = "disabled";
+		};
 	};
 
 	pinctrl: pinctrl {

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -110,7 +110,7 @@
 		};
 
 		i2c: i2c@900 {
-			compatible = "mediatek,mt7628-i2c";
+			compatible = "mediatek,mt7621-i2c";
 			reg = <0x900 0x100>;
 
 			resets = <&rstctrl 16>;

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -126,7 +126,7 @@
 		};
 
 		i2s: i2s@a00 {
-			compatible = "ralink,mt7620a-i2s";
+			compatible = "mediatek,mt7628-i2s";
 			reg = <0xa00 0x100>;
 
 			resets = <&rstctrl 17>;
@@ -135,8 +135,11 @@
 			interrupt-parent = <&intc>;
 			interrupts = <10>;
 
-			dmas = <&gdma 2>,
-				<&gdma 3>;
+			txdma-req = <2>;
+			rxdma-req = <3>;
+
+			dmas = <&gdma 4>,
+				<&gdma 6>;
 			dma-names = "tx", "rx";
 
 			status = "disabled";

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -249,7 +249,7 @@
 		};
 
 		gdma: gdma@2800 {
-			compatible = "ralink,mt7620a-gdma", "ralink,rt2880-gdma";
+			compatible = "ralink,rt3883-gdma";
 			reg = <0x2800 0x800>;
 
 			resets = <&rstctrl 14>;

--- a/target/linux/ramips/dts/rt2880.dtsi
+++ b/target/linux/ramips/dts/rt2880.dtsi
@@ -114,6 +114,22 @@
 			status = "disabled";
 		};
 
+		i2c: i2c@900 {
+			compatible = "ralink,rt2880-i2c";
+			reg = <0x900 0x100>;
+
+			resets = <&rstctrl 9>;
+			reset-names = "i2c";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c_pins>;
+		};
+
 		uartlite: uartlite@c00 {
 			compatible = "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
@@ -135,6 +151,13 @@
 			sdram {
 				ralink,group = "sdram";
 				ralink,function = "sdram";
+			};
+		};
+
+		i2c_pins: i2c {
+			i2c {
+				ralink,group = "i2c";
+				ralink,function = "i2c";
 			};
 		};
 

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -166,6 +166,22 @@
 			status = "disabled";
 		};
 
+		i2c@900 {
+			compatible = "ralink,rt2880-i2c";
+			reg = <0x900 0x100>;
+
+			resets = <&rstctrl 16>;
+			reset-names = "i2c";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c_pins>;
+		};
+
 		spi0: spi@b00 {
 			compatible = "ralink,rt3050-spi", "ralink,rt2880-spi";
 			reg = <0xb00 0x100>;
@@ -209,6 +225,13 @@
 			sdram {
 				ralink,group = "sdram";
 				ralink,function = "sdram";
+			};
+		};
+
+		i2c_pins: i2c {
+			i2c {
+				ralink,group = "i2c";
+				ralink,function = "i2c";
 			};
 		};
 

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -149,6 +149,23 @@
 			status = "disabled";
 		};
 
+		gdma: gdma@700 {
+			compatible = "ralink,rt305x-gdma";
+			reg = <0x700 0x100>;
+
+			resets = <&rstctrl 14>;
+			reset-names = "dma";
+
+			interrupt-parent = <&intc>;
+			interrupts = <7>;
+
+			#dma-cells = <1>;
+			#dma-channels = <8>;
+			#dma-requests = <8>;
+
+			status = "disabled";
+		};
+
 		spi0: spi@b00 {
 			compatible = "ralink,rt3050-spi", "ralink,rt2880-spi";
 			reg = <0xb00 0x100>;

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -182,6 +182,24 @@
 			pinctrl-0 = <&i2c_pins>;
 		};
 
+		i2s@a00 {
+			compatible = "ralink,rt3050-i2s";
+			reg = <0xa00 0x100>;
+
+			resets = <&rstctrl 17>;
+			reset-names = "i2s";
+
+			interrupt-parent = <&intc>;
+			interrupts = <10>;
+
+			txdma-req = <2>;
+
+			dmas = <&gdma 4>;
+			dma-names = "tx";
+
+			status = "disabled";
+		};
+
 		spi0: spi@b00 {
 			compatible = "ralink,rt3050-spi", "ralink,rt2880-spi";
 			reg = <0xb00 0x100>;

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -146,6 +146,22 @@
 			status = "disabled";
 		};
 
+		i2c@900 {
+			compatible = "ralink,rt2880-i2c";
+			reg = <0x900 0x100>;
+
+			resets = <&rstctrl 16>;
+			reset-names = "i2c";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c_pins>;
+		};
+
 		spi0: spi@b00 {
 			compatible = "ralink,rt3352-spi", "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
@@ -217,6 +233,13 @@
 		pinctrl-0 = <&state_default>;
 
 		state_default: pinctrl0 {
+		};
+
+		i2c_pins: i2c {
+			i2c {
+				ralink,group = "i2c";
+				ralink,function = "i2c";
+			};
 		};
 
 		spi_pins: spi {

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -162,6 +162,26 @@
 			pinctrl-0 = <&i2c_pins>;
 		};
 
+		i2s@a00 {
+			compatible = "ralink,rt3352-i2s";
+			reg = <0xa00 0x100>;
+
+			resets = <&rstctrl 17>;
+			reset-names = "i2s";
+
+			interrupt-parent = <&intc>;
+			interrupts = <10>;
+
+			txdma-req = <2>;
+			rxdma-req = <3>;
+
+			dmas = <&gdma 4>,
+				<&gdma 6>;
+			dma-names = "tx", "rx";
+
+			status = "disabled";
+		};
+
 		spi0: spi@b00 {
 			compatible = "ralink,rt3352-spi", "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -191,6 +191,23 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&uartlite_pins>;
 		};
+
+		gdma: gdma@2800 {
+			compatible = "ralink,rt3883-gdma";
+			reg = <0x2800 0x800>;
+
+			resets = <&rstctrl 14>;
+			reset-names = "dma";
+
+			interrupt-parent = <&intc>;
+			interrupts = <7>;
+
+			#dma-cells = <1>;
+			#dma-channels = <16>;
+			#dma-requests = <16>;
+
+			status = "disabled";
+		};
 	};
 
 	pinctrl: pinctrl {

--- a/target/linux/ramips/dts/rt3883.dtsi
+++ b/target/linux/ramips/dts/rt3883.dtsi
@@ -182,6 +182,26 @@
 			pinctrl-0 = <&i2c_pins>;
 		};
 
+		i2s@a00 {
+			compatible = "ralink,rt3883-i2s";
+			reg = <0xa00 0x100>;
+
+			resets = <&rstctrl 17>;
+			reset-names = "i2s";
+
+			interrupt-parent = <&intc>;
+			interrupts = <10>;
+
+			txdma-req = <2>;
+			rxdma-req = <3>;
+
+			dmas = <&gdma 4>,
+				<&gdma 6>;
+			dma-names = "tx", "rx";
+
+			status = "disabled";
+		};
+
 		spi0: spi@b00 {
 			compatible = "ralink,rt3883-spi", "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;

--- a/target/linux/ramips/dts/rt3883.dtsi
+++ b/target/linux/ramips/dts/rt3883.dtsi
@@ -166,6 +166,22 @@
 			status = "disabled";
 		};
 
+		i2c@900 {
+			compatible = "ralink,rt2880-i2c";
+			reg = <0x900 0x100>;
+
+			resets = <&rstctrl 16>;
+			reset-names = "i2c";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c_pins>;
+		};
+
 		spi0: spi@b00 {
 			compatible = "ralink,rt3883-spi", "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
@@ -237,6 +253,13 @@
 		pinctrl-0 = <&state_default>;
 
 		state_default: pinctrl0 {
+		};
+
+		i2c_pins: i2c {
+			i2c {
+				ralink,group = "i2c";
+				ralink,function = "i2c";
+			};
 		};
 
 		spi_pins: spi {

--- a/target/linux/ramips/dts/rt3883.dtsi
+++ b/target/linux/ramips/dts/rt3883.dtsi
@@ -211,6 +211,23 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&uartlite_pins>;
 		};
+
+		gdma: gdma@2800 {
+			compatible = "ralink,rt3883-gdma";
+			reg = <0x2800 0x800>;
+
+			resets = <&rstctrl 14>;
+			reset-names = "dma";
+
+			interrupt-parent = <&intc>;
+			interrupts = <7>;
+
+			#dma-cells = <1>;
+			#dma-channels = <16>;
+			#dma-requests = <16>;
+
+			status = "disabled";
+		};
 	};
 
 	pinctrl: pinctrl {

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -138,7 +138,7 @@
 		};
 
 		i2c: i2c@900 {
-			compatible = "link,rt5350-i2c", "ralink,rt2880-i2c";
+			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
 			resets = <&rstctrl 16>;
@@ -236,17 +236,17 @@
 		state_default: pinctrl0 {
 		};
 
-		spi_pins: spi {
-			spi {
-				ralink,group = "spi";
-				ralink,function = "spi";
-			};
-		};
-
 		i2c_pins: i2c {
 			i2c {
 				ralink,group = "i2c";
 				ralink,function = "i2c";
+			};
+		};
+
+		spi_pins: spi {
+			spi {
+				ralink,group = "spi";
+				ralink,function = "spi";
 			};
 		};
 

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -153,6 +153,26 @@
 			status = "disabled";
 		};
 
+		i2s@a00 {
+			compatible = "ralink,rt3352-i2s";
+			reg = <0xa00 0x100>;
+
+			resets = <&rstctrl 17>;
+			reset-names = "i2s";
+
+			interrupt-parent = <&intc>;
+			interrupts = <10>;
+
+			txdma-req = <2>;
+			rxdma-req = <3>;
+
+			dmas = <&gdma 4>,
+				<&gdma 6>;
+			dma-names = "tx", "rx";
+
+			status = "disabled";
+		};
+
 		spi0: spi@b00 {
 			compatible = "ralink,rt5350-spi", "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -208,6 +208,23 @@
 			interrupt-parent = <&cpuintc>;
 			interrupts = <7>;
 		};
+
+		gdma: gdma@2800 {
+			compatible = "ralink,rt3883-gdma";
+			reg = <0x2800 0x800>;
+
+			resets = <&rstctrl 14>;
+			reset-names = "dma";
+
+			interrupt-parent = <&intc>;
+			interrupts = <7>;
+
+			#dma-cells = <1>;
+			#dma-channels = <16>;
+			#dma-requests = <16>;
+
+			status = "disabled";
+		};
 	};
 
 	pinctrl: pinctrl {

--- a/target/linux/ramips/image/mt7628.mk
+++ b/target/linux/ramips/image/mt7628.mk
@@ -25,3 +25,11 @@ define Device/wrtnode2p
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-ledtrig-usbdev
 endef
 TARGET_DEVICES += wrtnode2p
+
+define Device/duzun-dm06
+  DTS := DUZUN-DM06
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  DEVICE_TITLE := DuZun DM06
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-ledtrig-usbdev
+endef
+TARGET_DEVICES += duzun-dm06

--- a/target/linux/ramips/patches-4.4/0044-i2c-MIPS-adds-ralink-I2C-driver.patch
+++ b/target/linux/ramips/patches-4.4/0044-i2c-MIPS-adds-ralink-I2C-driver.patch
@@ -45,12 +45,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +};
 --- a/drivers/i2c/busses/Kconfig
 +++ b/drivers/i2c/busses/Kconfig
-@@ -806,6 +806,10 @@ config I2C_RK3X
+@@ -806,6 +806,11 @@ config I2C_RK3X
  	  This driver can also be built as a module. If so, the module will
  	  be called i2c-rk3x.
  
 +config I2C_RALINK
 +	tristate "Ralink I2C Controller"
++	depends on RALINK && !SOC_MT7621
 +	select OF_I2C
 +
  config HAVE_S3C2410_I2C
@@ -68,11 +69,12 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-$(CONFIG_I2C_RK3X)		+= i2c-rk3x.o
 --- /dev/null
 +++ b/drivers/i2c/busses/i2c-ralink.c
-@@ -0,0 +1,327 @@
+@@ -0,0 +1,435 @@
 +/*
 + * drivers/i2c/busses/i2c-ralink.c
 + *
 + * Copyright (C) 2013 Steven Liu <steven_liu@mediatek.com>
++ * Copyright (C) 2016 Michael Lee <igvtee@gmail.com>
 + *
 + * Improve driver for i2cdetect from i2c-tools to detect i2c devices on the bus.
 + * (C) 2014 Sittisak <sittisaks@hotmail.com>
@@ -101,8 +103,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#include <linux/i2c.h>
 +#include <linux/io.h>
 +#include <linux/err.h>
-+
-+#include <asm/mach-ralink/ralink_regs.h>
++#include <linux/clk.h>
 +
 +#define REG_CONFIG_REG		0x00
 +#define REG_CLKDIV_REG		0x04
@@ -113,191 +114,250 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#define REG_STATUS_REG		0x18
 +#define REG_STARTXFR_REG	0x1C
 +#define REG_BYTECNT_REG		0x20
-+#define REG_SM0CFG2		0x28
-+#define REG_SM0CTL0		0x40
 +
++/* REG_CONFIG_REG */
++#define I2C_ADDRLEN_OFFSET	5
++#define I2C_DEVADLEN_OFFSET	2
++#define I2C_ADDRLEN_MASK	0x3
++#define I2C_ADDR_DIS		BIT(1)
++#define I2C_DEVADDR_DIS		BIT(0)
++#define I2C_ADDRLEN_8		(7 << I2C_ADDRLEN_OFFSET)
++#define I2C_DEVADLEN_7		(6 << I2C_DEVADLEN_OFFSET)
++#define I2C_CONF_DEFAULT	(I2C_ADDRLEN_8 | I2C_DEVADLEN_7)
++
++/* REG_CLKDIV_REG */
++#define I2C_CLKDIV_MASK		0xffff
++
++/* REG_DEVADDR_REG */
++#define I2C_DEVADDR_MASK	0x7f
++
++/* REG_ADDR_REG */
++#define I2C_ADDR_MASK		0xff
++
++/* REG_STATUS_REG */
 +#define I2C_STARTERR		BIT(4)
 +#define I2C_ACKERR		BIT(3)
 +#define I2C_DATARDY		BIT(2)
 +#define I2C_SDOEMPTY		BIT(1)
 +#define I2C_BUSY		BIT(0)
 +
-+#define I2C_DEVADLEN_7		(6 << 2)
-+#define I2C_ADDRDIS		BIT(1)
++/* REG_STARTXFR_REG */
++#define NOSTOP_CMD		BIT(2)
++#define NODATA_CMD		BIT(1)
++#define READ_CMD		BIT(0)
 +
-+#define CLKDIV_VALUE		200 // clock rate is 40M, 40M / (200*2) = 100k (standard i2c bus rate).
-+//#define CLKDIV_VALUE		50 // clock rate is 40M, 40M / (50*2) = 400k (fast i2c bus rate).
-+
-+#define READ_CMD		0x01
-+#define WRITE_CMD		0x00
-+#define READ_BLOCK              64
-+
-+#define SM0CTL0_OD		BIT(31)
-+#define SM0CTL0_VTRIG		BIT(28)
-+#define SM0CTL0_OUTHI		BIT(6)
-+#define SM0CTL0_STRETCH		BIT(1)
-+#define SM0CTL0_DEFAULT		(SM0CTL0_OD | SM0CTL0_VTRIG | SM0CTL0_OUTHI | SM0CTL0_STRETCH)
++/* REG_BYTECNT_REG */
++#define BYTECNT_MAX		64
++#define SET_BYTECNT(x)		(x - 1)
 +
 +/* timeout waiting for I2C devices to respond (clock streching) */
-+#define RT_I2C_TIMEOUT (msecs_to_jiffies(1000))
++#define TIMEOUT_MS              1000
++#define DELAY_INTERVAL_US       100
 +
-+enum {
-+	I2C_TYPE_RALINK,
-+	I2C_TYPE_MEDIATEK,
++struct rt_i2c {
++	void __iomem *base;
++	struct clk *clk;
++	struct device *dev;
++	struct i2c_adapter adap;
++	u32 cur_clk;
++	u32 clk_div;
++	u32 flags;
 +};
 +
-+static void __iomem *membase;
-+static struct i2c_adapter *adapter;
-+static int hw_type;
-+
-+static void rt_i2c_w32(u32 val, unsigned reg)
++static void rt_i2c_w32(struct rt_i2c *i2c, u32 val, unsigned reg)
 +{
-+	iowrite32(val, membase + reg);
++	iowrite32(val, i2c->base + reg);
 +}
 +
-+static u32 rt_i2c_r32(unsigned reg)
++static u32 rt_i2c_r32(struct rt_i2c *i2c, unsigned reg)
 +{
-+	return ioread32(membase + reg);
++	return ioread32(i2c->base + reg);
 +}
 +
-+static inline int rt_i2c_get_ack(void)
++static int poll_down_timeout(void __iomem *addr, u32 mask)
 +{
-+        return (rt_i2c_r32(REG_STATUS_REG) & I2C_ACKERR) ? -EIO : 0;
-+}
-+
-+static inline int rt_i2c_wait_rx_done(void)
-+{
-+	unsigned long timeout;
-+
-+	timeout = jiffies + RT_I2C_TIMEOUT;
++	unsigned long timeout = jiffies + msecs_to_jiffies(TIMEOUT_MS);
 +
 +	do {
-+		if (time_after(jiffies, timeout))
-+			return (-ETIMEDOUT);
++		if (!(readl_relaxed(addr) & mask))
++			return 0;
 +
-+	} while (!(rt_i2c_r32(REG_STATUS_REG) & I2C_DATARDY));
++		usleep_range(DELAY_INTERVAL_US, DELAY_INTERVAL_US + 50);
++	} while (time_before(jiffies, timeout));
 +
-+	return 0;
++	return (readl_relaxed(addr) & mask) ? -EAGAIN : 0;
 +}
 +
-+static inline int rt_i2c_wait_idle(void)
++static int rt_i2c_wait_idle(struct rt_i2c *i2c)
 +{
-+	unsigned long timeout;
++	int ret;
 +
-+	timeout = jiffies + RT_I2C_TIMEOUT;
-+
-+	do {
-+		if (time_after(jiffies, timeout)) {
-+			printk("i2c-read line busy\n");
-+			return 1;
-+		}
-+	} while (rt_i2c_r32(REG_STATUS_REG) & I2C_BUSY);
-+
-+	return 0;
-+}
-+
-+static inline int rt_i2c_wait_tx_done(void)
-+{
-+	unsigned long timeout;
-+
-+	timeout = jiffies + RT_I2C_TIMEOUT;
-+
-+	do {
-+		if (time_after(jiffies, timeout))
-+			return (-ETIMEDOUT);
-+
-+	} while (!(rt_i2c_r32(REG_STATUS_REG) & I2C_SDOEMPTY));
-+
-+	return 0;
-+}
-+
-+static int rt_i2c_handle_msg(struct i2c_adapter *a, struct i2c_msg* msg)
-+{
-+	int i = 0, j = 0, pos = 0;
-+	int nblock = msg->len / READ_BLOCK;
-+        int rem = msg->len % READ_BLOCK;
-+	int ret = 0;
-+
-+	if (msg->flags & I2C_M_TEN) {
-+		printk("10 bits addr not supported\n");
-+		return -EINVAL;
-+	}
-+
-+	if (msg->flags & I2C_M_RD) {
-+		for (i = 0; i < nblock; i++) {
-+	                if (rt_i2c_wait_idle())
-+				return -ETIMEDOUT;
-+			rt_i2c_w32(READ_BLOCK - 1, REG_BYTECNT_REG);
-+			rt_i2c_w32(READ_CMD, REG_STARTXFR_REG);
-+			for (j = 0; j < READ_BLOCK; j++) {
-+				if (rt_i2c_wait_rx_done() < 0)
-+					ret = rt_i2c_wait_rx_done();
-+                                if (rt_i2c_get_ack() < 0)
-+					ret = rt_i2c_get_ack();
-+				msg->buf[pos++] = rt_i2c_r32(REG_DATAIN_REG);
-+			}
-+		}
-+
-+		if (rt_i2c_wait_idle())
-+			return -ETIMEDOUT;
-+		if (rem) {
-+			rt_i2c_w32(rem - 1, REG_BYTECNT_REG);
-+			rt_i2c_w32(READ_CMD, REG_STARTXFR_REG);
-+		}
-+		for (i = 0; i < rem; i++) {
-+			if (rt_i2c_wait_rx_done() < 0)
-+				ret = rt_i2c_wait_rx_done();
-+                        if (rt_i2c_get_ack() < 0)
-+				ret = rt_i2c_get_ack();
-+
-+			msg->buf[pos++] = rt_i2c_r32(REG_DATAIN_REG);
-+		}
-+	} else {
-+		if (rt_i2c_wait_idle())
-+			return -ETIMEDOUT;
-+		rt_i2c_w32(msg->len - 1, REG_BYTECNT_REG);
-+		for (i = 0; i < msg->len; i++) {
-+			rt_i2c_w32(msg->buf[i], REG_DATAOUT_REG);
-+			rt_i2c_w32(WRITE_CMD, REG_STARTXFR_REG);
-+
-+			if (rt_i2c_wait_tx_done() < 0)
-+				ret = rt_i2c_wait_tx_done();
-+                        if (rt_i2c_get_ack() < 0)
-+				ret = rt_i2c_get_ack();
-+		}
-+	}
++	ret = poll_down_timeout(i2c->base + REG_STATUS_REG, I2C_BUSY);
++	if (ret < 0)
++		dev_dbg(i2c->dev, "idle err(%d)\n", ret);
 +
 +	return ret;
 +}
 +
-+static int rt_i2c_master_xfer(struct i2c_adapter *a, struct i2c_msg *m, int n)
++static int poll_up_timeout(void __iomem *addr, u32 mask)
 +{
-+	int i = 0;
-+	int ret = 0;
++	unsigned long timeout = jiffies + msecs_to_jiffies(TIMEOUT_MS);
++	u32 status;
 +
-+	if (rt_i2c_wait_idle())
-+		return -ETIMEDOUT;
++	do {
++		status = readl_relaxed(addr);
 +
-+	device_reset(a->dev.parent);
++		/* check error status */
++		if (status & I2C_STARTERR)
++			return -EAGAIN;
++		else if (status & I2C_ACKERR)
++			return -ENXIO;
++		else if (status & mask)
++			return 0;
 +
-+	rt_i2c_w32(m->addr, REG_DEVADDR_REG);
-+	rt_i2c_w32(I2C_DEVADLEN_7 | I2C_ADDRDIS, REG_CONFIG_REG);
-+	if (hw_type == I2C_TYPE_RALINK) {
-+		rt_i2c_w32(CLKDIV_VALUE, REG_CLKDIV_REG);
-+	} else {
-+		rt_i2c_w32((CLKDIV_VALUE << 16) | SM0CTL0_DEFAULT, REG_SM0CTL0);
-+		rt_i2c_w32(1, REG_SM0CFG2);
-+	}
++		usleep_range(DELAY_INTERVAL_US, DELAY_INTERVAL_US + 50);
++	} while (time_before(jiffies, timeout));
 +
-+	for (i = 0; i < n && !ret; i++) {
-+		ret = rt_i2c_handle_msg(a, &m[i]);
++	return -ETIMEDOUT;
++}
 +
-+		if (ret < 0) {
-+			return ret;
++static int rt_i2c_wait_rx_done(struct rt_i2c *i2c)
++{
++	int ret;
++
++	ret = poll_up_timeout(i2c->base + REG_STATUS_REG, I2C_DATARDY);
++	if (ret < 0)
++		dev_dbg(i2c->dev, "rx err(%d)\n", ret);
++
++	return ret;
++}
++
++static int rt_i2c_wait_tx_done(struct rt_i2c *i2c)
++{
++	int ret;
++
++	ret = poll_up_timeout(i2c->base + REG_STATUS_REG, I2C_SDOEMPTY);
++	if (ret < 0)
++		dev_dbg(i2c->dev, "tx err(%d)\n", ret);
++
++	return ret;
++}
++
++static void rt_i2c_reset(struct rt_i2c *i2c)
++{
++	device_reset(i2c->adap.dev.parent);
++	barrier();
++	rt_i2c_w32(i2c, i2c->clk_div, REG_CLKDIV_REG);
++}
++
++static void rt_i2c_dump_reg(struct rt_i2c *i2c)
++{
++	dev_dbg(i2c->dev, "conf %08x, clkdiv %08x, devaddr %08x, " \
++			"addr %08x, dataout %08x, datain %08x, " \
++			"status %08x, startxfr %08x, bytecnt %08x\n",
++			rt_i2c_r32(i2c, REG_CONFIG_REG),
++			rt_i2c_r32(i2c, REG_CLKDIV_REG),
++			rt_i2c_r32(i2c, REG_DEVADDR_REG),
++			rt_i2c_r32(i2c, REG_ADDR_REG),
++			rt_i2c_r32(i2c, REG_DATAOUT_REG),
++			rt_i2c_r32(i2c, REG_DATAIN_REG),
++			rt_i2c_r32(i2c, REG_STATUS_REG),
++			rt_i2c_r32(i2c, REG_STARTXFR_REG),
++			rt_i2c_r32(i2c, REG_BYTECNT_REG));
++}
++
++static int rt_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
++		int num)
++{
++	struct rt_i2c *i2c;
++	struct i2c_msg *pmsg;
++	unsigned char addr;
++	int i, j, ret;
++	u32 cmd;
++
++	i2c = i2c_get_adapdata(adap);
++
++	for (i = 0; i < num; i++) {
++		pmsg = &msgs[i];
++		if (i == (num - 1))
++			cmd = 0;
++		else
++			cmd = NOSTOP_CMD;
++
++		dev_dbg(i2c->dev, "addr: 0x%x, len: %d, flags: 0x%x, stop: %d\n",
++				pmsg->addr, pmsg->len, pmsg->flags,
++				(cmd == 0)? 1 : 0);
++
++		/* wait hardware idle */
++		if ((ret = rt_i2c_wait_idle(i2c)))
++			goto err_timeout;
++
++		if (pmsg->flags & I2C_M_TEN) {
++			rt_i2c_w32(i2c, I2C_CONF_DEFAULT, REG_CONFIG_REG);
++			/* 10 bits address */
++			addr = 0x78 | ((pmsg->addr >> 8) & 0x03);
++			rt_i2c_w32(i2c, addr & I2C_DEVADDR_MASK,
++					REG_DEVADDR_REG);
++			rt_i2c_w32(i2c, pmsg->addr & I2C_ADDR_MASK,
++					REG_ADDR_REG);
++		} else {
++			rt_i2c_w32(i2c, I2C_CONF_DEFAULT | I2C_ADDR_DIS,
++					REG_CONFIG_REG);
++			/* 7 bits address */
++			rt_i2c_w32(i2c, pmsg->addr & I2C_DEVADDR_MASK,
++					REG_DEVADDR_REG);
++		}
++
++		/* buffer length */
++		if (pmsg->len == 0)
++			cmd |= NODATA_CMD;
++		else
++			rt_i2c_w32(i2c, SET_BYTECNT(pmsg->len),
++					REG_BYTECNT_REG);
++
++		j = 0;
++		if (pmsg->flags & I2C_M_RD) {
++			cmd |= READ_CMD;
++			/* start transfer */
++			barrier();
++			rt_i2c_w32(i2c, cmd, REG_STARTXFR_REG);
++			do {
++				/* wait */
++				if ((ret = rt_i2c_wait_rx_done(i2c)))
++					goto err_timeout;
++				/* read data */
++				if (pmsg->len)
++					pmsg->buf[j] = rt_i2c_r32(i2c,
++							REG_DATAIN_REG);
++				j++;
++			} while (j < pmsg->len);
++		} else {
++			do {
++				/* write data */
++				if (pmsg->len)
++					rt_i2c_w32(i2c, pmsg->buf[j],
++							REG_DATAOUT_REG);
++				/* start transfer */
++				if (j == 0) {
++					barrier();
++					rt_i2c_w32(i2c, cmd, REG_STARTXFR_REG);
++				}
++				/* wait */
++				if ((ret = rt_i2c_wait_tx_done(i2c)))
++					goto err_timeout;
++				j++;
++			} while (j < pmsg->len);
 +		}
 +	}
++	/* the return value is number of executed messages */
++	ret = i;
 +
-+	return n;
++	return ret;
++
++err_timeout:
++	rt_i2c_dump_reg(i2c);
++	rt_i2c_reset(i2c);
++	return ret;
 +}
 +
 +static u32 rt_i2c_func(struct i2c_adapter *a)
@@ -311,60 +371,110 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +};
 +
 +static const struct of_device_id i2c_rt_dt_ids[] = {
-+	{ .compatible = "ralink,rt2880-i2c", .data = (void *) I2C_TYPE_RALINK },
-+	{ .compatible = "mediatek,mt7628-i2c", .data = (void *) I2C_TYPE_MEDIATEK },
++	{ .compatible = "ralink,rt2880-i2c" },
 +	{ /* sentinel */ }
 +};
 +
 +MODULE_DEVICE_TABLE(of, i2c_rt_dt_ids);
 +
++static struct i2c_adapter_quirks rt_i2c_quirks = {
++        .max_write_len = BYTECNT_MAX,
++        .max_read_len = BYTECNT_MAX,
++};
++
++static int rt_i2c_init(struct rt_i2c *i2c)
++{
++	u32 reg;
++
++	/* i2c_sclk = periph_clk / ((2 * clk_div) + 5) */
++	i2c->clk_div = (clk_get_rate(i2c->clk) - (5 * i2c->cur_clk)) /
++		(2 * i2c->cur_clk);
++	if (i2c->clk_div < 8)
++		i2c->clk_div = 8;
++	if (i2c->clk_div > I2C_CLKDIV_MASK)
++		i2c->clk_div = I2C_CLKDIV_MASK;
++
++	/* check support combinde/repeated start message */
++	rt_i2c_w32(i2c, NOSTOP_CMD, REG_STARTXFR_REG);
++	reg = rt_i2c_r32(i2c, REG_STARTXFR_REG) & NOSTOP_CMD;
++
++	rt_i2c_reset(i2c);
++
++	return reg;
++}
++
 +static int rt_i2c_probe(struct platform_device *pdev)
 +{
-+	struct resource *res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
++	struct resource *res;
++	struct rt_i2c *i2c;
++	struct i2c_adapter *adap;
 +	const struct of_device_id *match;
-+	int ret;
++	int ret, restart;
 +
 +	match = of_match_device(i2c_rt_dt_ids, &pdev->dev);
-+	hw_type = (int) match->data;
 +
++	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 +	if (!res) {
 +		dev_err(&pdev->dev, "no memory resource found\n");
 +		return -ENODEV;
 +	}
 +
-+	adapter = devm_kzalloc(&pdev->dev, sizeof(struct i2c_adapter), GFP_KERNEL);
-+	if (!adapter) {
++	i2c = devm_kzalloc(&pdev->dev, sizeof(struct rt_i2c), GFP_KERNEL);
++	if (!i2c) {
 +		dev_err(&pdev->dev, "failed to allocate i2c_adapter\n");
 +		return -ENOMEM;
 +	}
 +
-+	membase = devm_ioremap_resource(&pdev->dev, res);
-+	if (IS_ERR(membase))
-+		return PTR_ERR(membase);
++	i2c->base = devm_ioremap_resource(&pdev->dev, res);
++	if (IS_ERR(i2c->base))
++		return PTR_ERR(i2c->base);
 +
-+	strlcpy(adapter->name, dev_name(&pdev->dev), sizeof(adapter->name));
-+	adapter->owner = THIS_MODULE;
-+	adapter->nr = pdev->id;
-+	adapter->timeout = HZ;
-+	adapter->algo = &rt_i2c_algo;
-+	adapter->class = I2C_CLASS_HWMON | I2C_CLASS_SPD;
-+	adapter->dev.parent = &pdev->dev;
-+	adapter->dev.of_node = pdev->dev.of_node;
++	i2c->clk = devm_clk_get(&pdev->dev, NULL);
++	if (IS_ERR(i2c->clk)) {
++		dev_err(&pdev->dev, "no clock defined\n");
++		return -ENODEV;
++	}
++	clk_prepare_enable(i2c->clk);
++	i2c->dev = &pdev->dev;
 +
-+	ret = i2c_add_numbered_adapter(adapter);
-+	if (ret)
++	if (of_property_read_u32(pdev->dev.of_node,
++				"clock-frequency", &i2c->cur_clk))
++		i2c->cur_clk = 100000;
++
++	adap = &i2c->adap;
++	adap->owner = THIS_MODULE;
++	adap->class = I2C_CLASS_HWMON | I2C_CLASS_SPD;
++	adap->algo = &rt_i2c_algo;
++	adap->retries = 3;
++	adap->dev.parent = &pdev->dev;
++	i2c_set_adapdata(adap, i2c);
++	adap->dev.of_node = pdev->dev.of_node;
++	strlcpy(adap->name, dev_name(&pdev->dev), sizeof(adap->name));
++	adap->quirks = &rt_i2c_quirks;
++
++	platform_set_drvdata(pdev, i2c);
++
++	restart = rt_i2c_init(i2c);
++
++	ret = i2c_add_adapter(adap);
++	if (ret < 0) {
++		dev_err(&pdev->dev, "failed to add adapter\n");
++		clk_disable_unprepare(i2c->clk);
 +		return ret;
++	}
 +
-+	platform_set_drvdata(pdev, adapter);
++	dev_info(&pdev->dev, "clock %uKHz, re-start %ssupport\n",
++			i2c->cur_clk/1000, restart ? "" : "not ");
 +
-+	dev_info(&pdev->dev, "loaded\n");
-+
-+	return 0;
++	return ret;
 +}
 +
 +static int rt_i2c_remove(struct platform_device *pdev)
 +{
-+	platform_set_drvdata(pdev, NULL);
++	struct rt_i2c *i2c = platform_get_drvdata(pdev);
++
++	i2c_del_adapter(&i2c->adap);
++	clk_disable_unprepare(i2c->clk);
 +
 +	return 0;
 +}
@@ -389,8 +499,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +{
 +	platform_driver_unregister(&rt_i2c_driver);
 +}
-+
-+module_exit (i2c_rt_exit);
++module_exit(i2c_rt_exit);
 +
 +MODULE_AUTHOR("Steven Liu <steven_liu@mediatek.com>");
 +MODULE_DESCRIPTION("Ralink I2c host driver");

--- a/target/linux/ramips/patches-4.4/0045-i2c-add-mt7621-driver.patch
+++ b/target/linux/ramips/patches-4.4/0045-i2c-add-mt7621-driver.patch
@@ -13,12 +13,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 
 --- a/drivers/i2c/busses/Kconfig
 +++ b/drivers/i2c/busses/Kconfig
-@@ -810,6 +810,10 @@ config I2C_RALINK
- 	tristate "Ralink I2C Controller"
+@@ -811,6 +811,11 @@ config I2C_RALINK
+ 	depends on RALINK && !SOC_MT7621
  	select OF_I2C
  
 +config I2C_MT7621
-+	tristate "MT7621 I2C Controller"
++	tristate "MT7621/MT7628 I2C Controller"
++	depends on RALINK && (SOC_MT7620 || SOC_MT7621)
 +	select OF_I2C
 +
  config HAVE_S3C2410_I2C
@@ -36,11 +37,12 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-$(CONFIG_I2C_RK3X)		+= i2c-rk3x.o
 --- /dev/null
 +++ b/drivers/i2c/busses/i2c-mt7621.c
-@@ -0,0 +1,303 @@
+@@ -0,0 +1,433 @@
 +/*
 + * drivers/i2c/busses/i2c-mt7621.c
 + *
 + * Copyright (C) 2013 Steven Liu <steven_liu@mediatek.com>
++ * Copyright (C) 2016 Michael Lee <igvtee@gmail.com>
 + *
 + * Improve driver for i2cdetect from i2c-tools to detect i2c devices on the bus.
 + * (C) 2014 Sittisak <sittisaks@hotmail.com>
@@ -65,276 +67,405 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#include <linux/init.h>
 +#include <linux/errno.h>
 +#include <linux/platform_device.h>
++#include <linux/of_platform.h>
 +#include <linux/i2c.h>
 +#include <linux/io.h>
 +#include <linux/err.h>
++#include <linux/clk.h>
 +
-+#include <asm/mach-ralink/ralink_regs.h>
++#define REG_SM0CFG0		0x08
++#define REG_SM0DOUT		0x10
++#define REG_SM0DIN		0x14
++#define REG_SM0ST		0x18
++#define REG_SM0AUTO		0x1C
++#define REG_SM0CFG1		0x20
++#define REG_SM0CFG2		0x28
++#define REG_SM0CTL0		0x40
++#define REG_SM0CTL1		0x44
++#define REG_SM0D0		0x50
++#define REG_SM0D1		0x54
++#define REG_PINTEN		0x5C
++#define REG_PINTST		0x60
++#define REG_PINTCL		0x64
 +
-+#define REG_CONFIG_REG                       0x00
-+#define REG_CLKDIV_REG                       0x04
-+#define REG_DEVADDR_REG                      0x08
-+#define REG_ADDR_REG                         0x0C
-+#define REG_DATAOUT_REG                      0x10
-+#define REG_DATAIN_REG                       0x14
-+#define REG_STATUS_REG                       0x18
-+#define REG_STARTXFR_REG                     0x1C
-+#define REG_BYTECNT_REG                      0x20
-+#define REG_SM0_IS_AUTOMODE                  0x28
-+#define REG_SM0CTL0                          0x40
++/* REG_SM0CFG0 */
++#define I2C_DEVADDR_MASK	0x7f
 +
++/* REG_SM0ST */
++#define I2C_DATARDY		BIT(2)
++#define I2C_SDOEMPTY		BIT(1)
++#define I2C_BUSY		BIT(0)
 +
-+#define I2C_STARTERR                         0x10
-+#define I2C_ACKERR                           0x08
-+#define I2C_DATARDY                          0x04
-+#define I2C_SDOEMPTY                         0x02
-+#define I2C_BUSY                             0x01
++/* REG_SM0AUTO */
++#define READ_CMD		BIT(0)
 +
-+/* I2C_CFG register bit field */
-+#define I2C_CFG_ADDRLEN_8                    (7<<5)	/* 8 bits */
-+#define I2C_CFG_DEVADLEN_7                   (6<<2)
-+#define I2C_CFG_ADDRDIS                      BIT(1)
-+#define I2C_CFG_DEVADDIS                     BIT(0)
++/* REG_SM0CFG1 */
++#define BYTECNT_MAX		64
++#define SET_BYTECNT(x)		(x - 1)
 +
-+#define I2C_CFG_DEFAULT	(I2C_CFG_ADDRLEN_8 | \
-+		I2C_CFG_DEVADLEN_7 | \
-+		I2C_CFG_ADDRDIS)
++/* REG_SM0CFG2 */
++#define AUTOMODE_EN		BIT(0)
 +
-+#define I2C_RETRY                            0x1000
++/* REG_SM0CTL0 */
++#define ODRAIN_HIGH_SM0		BIT(31)
++#define VSYNC_SHIFT		28
++#define VSYNC_MASK		0x3
++#define VSYNC_PULSE		(0x1 << VSYNC_SHIFT)
++#define VSYNC_RISING		(0x2 << VSYNC_SHIFT)
++#define CLK_DIV_SHIFT		16
++#define CLK_DIV_MASK		0xfff
++#define DEG_CNT_SHIFT		8
++#define DEG_CNT_MASK		0xff
++#define WAIT_HIGH		BIT(6)
++#define DEG_EN			BIT(5)
++#define CS_STATUA		BIT(4)
++#define SCL_STATUS		BIT(3)
++#define SDA_STATUS		BIT(2)
++#define SM0_EN			BIT(1)
++#define SCL_STRECH		BIT(0)
 +
-+#define CLKDIV_VALUE                         333
-+#define i2c_busy_loop                        (CLKDIV_VALUE*30)
++/* REG_SM0CTL1 */
++#define ACK_SHIFT		16
++#define ACK_MASK		0xff
++#define PGLEN_SHIFT		8
++#define PGLEN_MASK		0x7
++#define SM0_MODE_SHIFT		4
++#define SM0_MODE_MASK		0x7
++#define SM0_MODE_START		0x1
++#define SM0_MODE_WRITE		0x2
++#define SM0_MODE_STOP		0x3
++#define SM0_MODE_READ_NACK	0x4
++#define SM0_MODE_READ_ACK	0x5
++#define SM0_TRI_BUSY		BIT(0)
 +
-+#define READ_CMD                             0x01
-+#define WRITE_CMD                            0x00
-+#define READ_BLOCK                           16
++/* timeout waiting for I2C devices to respond (clock streching) */
++#define TIMEOUT_MS              1000
++#define DELAY_INTERVAL_US       100
 +
-+#define SM0_ODRAIN                           BIT(31)
-+#define SM0_VSYNC_MODE                       BIT(28)
-+#define SM0_CLK_DIV                          (CLKDIV_VALUE << 16)
-+#define SM0_WAIT_LEVEL                       BIT(6)
-+#define SM0_EN                               BIT(1)
++struct mtk_i2c {
++	void __iomem *base;
++	struct clk *clk;
++	struct device *dev;
++	struct i2c_adapter adap;
++	u32 cur_clk;
++	u32 clk_div;
++	u32 flags;
++};
 +
-+#define SM0_CFG_DEFUALT (SM0_ODRAIN | SM0_VSYNC_MODE | \
-+                        SM0_CLK_DIV | SM0_WAIT_LEVEL | \
-+                        SM0_EN) 
-+/***********************************************************/
-+
-+static void __iomem *membase;
-+static struct i2c_adapter *adapter;
-+
-+static void rt_i2c_w32(u32 val, unsigned reg)
++static void mtk_i2c_w32(struct mtk_i2c *i2c, u32 val, unsigned reg)
 +{
-+	iowrite32(val, membase + reg);
++	iowrite32(val, i2c->base + reg);
 +}
 +
-+static u32 rt_i2c_r32(unsigned reg)
++static u32 mtk_i2c_r32(struct mtk_i2c *i2c, unsigned reg)
 +{
-+	return ioread32(membase + reg);
++	return ioread32(i2c->base + reg);
 +}
 +
-+static void mt7621_i2c_reset(struct i2c_adapter *a)
++static int poll_down_timeout(void __iomem *addr, u32 mask)
 +{
-+	device_reset(a->dev.parent);
-+}
-+static void mt7621_i2c_enable(struct i2c_msg *msg)
-+{
-+	rt_i2c_w32(msg->addr,REG_DEVADDR_REG);
-+	rt_i2c_w32(0,REG_ADDR_REG);
-+}
++	unsigned long timeout = jiffies + msecs_to_jiffies(TIMEOUT_MS);
 +
-+static void i2c_master_init(struct i2c_adapter *a)
-+{
-+	mt7621_i2c_reset(a); 
-+	rt_i2c_w32(I2C_CFG_DEFAULT,REG_CONFIG_REG);    
-+	rt_i2c_w32(SM0_CFG_DEFUALT,REG_SM0CTL0);
-+	rt_i2c_w32(1,REG_SM0_IS_AUTOMODE);//auto mode
++	do {
++		if (!(readl_relaxed(addr) & mask))
++			return 0;
++
++		usleep_range(DELAY_INTERVAL_US, DELAY_INTERVAL_US + 50);
++	} while (time_before(jiffies, timeout));
++
++	return (readl_relaxed(addr) & mask) ? -EAGAIN : 0;
 +}
 +
-+
-+static inline int rt_i2c_wait_rx_done(void)
++static int mtk_i2c_wait_idle(struct mtk_i2c *i2c)
 +{
-+	int i=0;
-+	while((!(rt_i2c_r32(REG_STATUS_REG) & I2C_DATARDY)) && (i<i2c_busy_loop))
-+		i++;
-+	if(i>=i2c_busy_loop){
-+		pr_err("err,wait for idle timeout");
-+		return -ETIMEDOUT;
-+	}
-+	return 0;
++	int ret;
++
++	ret = poll_down_timeout(i2c->base + REG_SM0ST, I2C_BUSY);
++	if (ret < 0)
++		dev_dbg(i2c->dev, "idle err(%d)\n", ret);
++
++	return ret;
 +}
 +
-+static inline int rt_i2c_wait_idle(void)
++static int poll_up_timeout(void __iomem *addr, u32 mask)
 +{
-+	int i=0;
-+	while((rt_i2c_r32(REG_STATUS_REG) & I2C_BUSY) && (i<i2c_busy_loop))
-+		i++;
-+	if(i>=i2c_busy_loop){
-+		pr_err("err,wait for idle timeout");
-+		return -ETIMEDOUT;
-+	}
-+	return 0;
-+}
++	unsigned long timeout = jiffies + msecs_to_jiffies(TIMEOUT_MS);
++	u32 status;
 +
-+static inline int rt_i2c_wait_tx_done(void)
-+{
-+	int i=0;
-+	while((!(rt_i2c_r32(REG_STATUS_REG) & I2C_SDOEMPTY)) && (i<i2c_busy_loop))
-+		i++;
-+	if(i>=i2c_busy_loop){
-+		pr_err("err,wait for idle timeout");
-+		return -ETIMEDOUT;
-+	}
-+	return 0;
-+}
++	do {
++		status = readl_relaxed(addr);
++		if (status & mask)
++			return 0;
++		usleep_range(DELAY_INTERVAL_US, DELAY_INTERVAL_US + 50);
++	} while (time_before(jiffies, timeout));
 +
-+static int rt_i2c_handle_msg(struct i2c_adapter *a, struct i2c_msg* msg)
-+{
-+	int i = 0, j = 0, pos = 0;
-+	int nblock = msg->len / READ_BLOCK;
-+	int rem = msg->len % READ_BLOCK;
-+
-+	if (msg->flags & I2C_M_TEN) {
-+		printk("10 bits addr not supported\n");
-+		return -EINVAL;
-+	}
-+
-+	if (msg->flags & I2C_M_RD) {
-+		for (i = 0; i < nblock; i++) {
-+			if (rt_i2c_wait_idle())
-+				goto err_timeout;
-+			rt_i2c_w32(READ_BLOCK - 1, REG_BYTECNT_REG);
-+			rt_i2c_w32(READ_CMD, REG_STARTXFR_REG);
-+			for (j = 0; j < READ_BLOCK; j++) {
-+				if (rt_i2c_wait_rx_done())
-+					goto err_timeout;
-+				msg->buf[pos++] = rt_i2c_r32(REG_DATAIN_REG);
-+			}
-+		}
-+
-+		if (rt_i2c_wait_idle())
-+		    goto err_timeout;
-+		rt_i2c_w32(rem - 1, REG_BYTECNT_REG);
-+		rt_i2c_w32(READ_CMD, REG_STARTXFR_REG);
-+		
-+		for (i = 0; i < rem; i++) {
-+			if (rt_i2c_wait_rx_done())
-+				goto err_timeout;
-+			msg->buf[pos++] = rt_i2c_r32(REG_DATAIN_REG);
-+		}
-+	} else {
-+		if (rt_i2c_wait_idle())
-+	        	goto err_timeout;
-+		rt_i2c_w32(msg->len - 1, REG_BYTECNT_REG);
-+		for (i = 0; i < msg->len; i++) {
-+			rt_i2c_w32(msg->buf[i], REG_DATAOUT_REG);
-+			if(i == 0)
-+				rt_i2c_w32(WRITE_CMD, REG_STARTXFR_REG);
-+
-+			if (rt_i2c_wait_tx_done())
-+				goto err_timeout;
-+		}
-+	}
-+
-+	return 0;
-+err_timeout:
 +	return -ETIMEDOUT;
 +}
 +
-+static int rt_i2c_master_xfer(struct i2c_adapter *a, struct i2c_msg *m, int n)
++static int mtk_i2c_wait_rx_done(struct mtk_i2c *i2c)
 +{
-+	int i = 0;
-+	int ret = 0;
-+	i2c_master_init(a);
-+	mt7621_i2c_enable(m);
++	int ret;
 +
-+	for (i = 0; i != n && ret==0; i++) {
-+		ret = rt_i2c_handle_msg(a, &m[i]);
-+		if (ret) 
-+			return ret;	
-+	}
-+	return i;
++	ret = poll_up_timeout(i2c->base + REG_SM0ST, I2C_DATARDY);
++	if (ret < 0)
++		dev_dbg(i2c->dev, "rx err(%d)\n", ret);
++
++	return ret;
 +}
 +
-+static u32 rt_i2c_func(struct i2c_adapter *a)
++static int mtk_i2c_wait_tx_done(struct mtk_i2c *i2c)
++{
++	int ret;
++
++	ret = poll_up_timeout(i2c->base + REG_SM0ST, I2C_SDOEMPTY);
++	if (ret < 0)
++		dev_dbg(i2c->dev, "tx err(%d)\n", ret);
++
++	return ret;
++}
++
++static void mtk_i2c_reset(struct mtk_i2c *i2c)
++{
++	u32 reg;
++	device_reset(i2c->adap.dev.parent);
++	barrier();
++
++	/* ctrl0 */
++	reg = ODRAIN_HIGH_SM0 | VSYNC_PULSE | (i2c->clk_div << CLK_DIV_SHIFT) |
++		WAIT_HIGH | SM0_EN;
++	mtk_i2c_w32(i2c, reg, REG_SM0CTL0);
++
++	/* auto mode */
++	mtk_i2c_w32(i2c, AUTOMODE_EN, REG_SM0CFG2);
++}
++
++static void mtk_i2c_dump_reg(struct mtk_i2c *i2c)
++{
++	dev_dbg(i2c->dev, "cfg0 %08x, dout %08x, din %08x, " \
++			"status %08x, auto %08x, cfg1 %08x, " \
++			"cfg2 %08x, ctl0 %08x, ctl1 %08x\n",
++			mtk_i2c_r32(i2c, REG_SM0CFG0),
++			mtk_i2c_r32(i2c, REG_SM0DOUT),
++			mtk_i2c_r32(i2c, REG_SM0DIN),
++			mtk_i2c_r32(i2c, REG_SM0ST),
++			mtk_i2c_r32(i2c, REG_SM0AUTO),
++			mtk_i2c_r32(i2c, REG_SM0CFG1),
++			mtk_i2c_r32(i2c, REG_SM0CFG2),
++			mtk_i2c_r32(i2c, REG_SM0CTL0),
++			mtk_i2c_r32(i2c, REG_SM0CTL1));
++}
++
++static int mtk_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
++		int num)
++{
++	struct mtk_i2c *i2c;
++	struct i2c_msg *pmsg;
++	int i, j, ret;
++	u32 cmd;
++
++	i2c = i2c_get_adapdata(adap);
++
++	for (i = 0; i < num; i++) {
++		pmsg = &msgs[i];
++		cmd = 0;
++
++		dev_dbg(i2c->dev, "addr: 0x%x, len: %d, flags: 0x%x\n",
++				pmsg->addr, pmsg->len, pmsg->flags);
++
++		/* wait hardware idle */
++		if ((ret = mtk_i2c_wait_idle(i2c)))
++			goto err_timeout;
++
++		if (pmsg->flags & I2C_M_TEN) {
++			dev_dbg(i2c->dev, "10 bits addr not supported\n");
++			return -EINVAL;
++		} else {
++			/* 7 bits address */
++			mtk_i2c_w32(i2c, pmsg->addr & I2C_DEVADDR_MASK,
++					REG_SM0CFG0);
++		}
++
++		/* buffer length */
++		if (pmsg->len == 0) {
++			dev_dbg(i2c->dev, "length is 0\n");
++			return -EINVAL;
++		} else
++			mtk_i2c_w32(i2c, SET_BYTECNT(pmsg->len),
++					REG_SM0CFG1);
++
++		j = 0;
++		if (pmsg->flags & I2C_M_RD) {
++			cmd |= READ_CMD;
++			/* start transfer */
++			barrier();
++			mtk_i2c_w32(i2c, cmd, REG_SM0AUTO);
++			do {
++				/* wait */
++				if ((ret = mtk_i2c_wait_rx_done(i2c)))
++					goto err_timeout;
++				/* read data */
++				if (pmsg->len)
++					pmsg->buf[j] = mtk_i2c_r32(i2c,
++							REG_SM0DIN);
++				j++;
++			} while (j < pmsg->len);
++		} else {
++			do {
++				/* write data */
++				if (pmsg->len)
++					mtk_i2c_w32(i2c, pmsg->buf[j],
++							REG_SM0DOUT);
++				/* start transfer */
++				if (j == 0) {
++					barrier();
++					mtk_i2c_w32(i2c, cmd, REG_SM0AUTO);
++				}
++				/* wait */
++				if ((ret = mtk_i2c_wait_tx_done(i2c)))
++					goto err_timeout;
++				j++;
++			} while (j < pmsg->len);
++		}
++	}
++	/* the return value is number of executed messages */
++	ret = i;
++
++	return ret;
++
++err_timeout:
++	mtk_i2c_dump_reg(i2c);
++	mtk_i2c_reset(i2c);
++	return ret;
++}
++
++static u32 mtk_i2c_func(struct i2c_adapter *a)
 +{
 +	return I2C_FUNC_I2C | I2C_FUNC_SMBUS_EMUL;
 +}
 +
-+static const struct i2c_algorithm rt_i2c_algo = {
-+	.master_xfer	= rt_i2c_master_xfer,
-+	.functionality	= rt_i2c_func,
++static const struct i2c_algorithm mtk_i2c_algo = {
++	.master_xfer	= mtk_i2c_master_xfer,
++	.functionality	= mtk_i2c_func,
 +};
 +
-+static int rt_i2c_probe(struct platform_device *pdev)
-+{
-+	struct resource *res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-+	int ret;
-+
-+	adapter = devm_kzalloc(&pdev->dev,sizeof(struct i2c_adapter), GFP_KERNEL);
-+	if (!adapter) {
-+		dev_err(&pdev->dev, "failed to allocate i2c_adapter\n");
-+		return -ENOMEM;
-+	}
-+	membase = devm_ioremap_resource(&pdev->dev, res);
-+	if (IS_ERR(membase))
-+		return PTR_ERR(membase);
-+
-+	strlcpy(adapter->name, dev_name(&pdev->dev), sizeof(adapter->name));
-+
-+	adapter->owner = THIS_MODULE;
-+	adapter->nr = pdev->id;
-+	adapter->timeout = HZ;
-+	adapter->algo = &rt_i2c_algo;
-+	adapter->class = I2C_CLASS_HWMON | I2C_CLASS_SPD;
-+	adapter->dev.parent = &pdev->dev;
-+	adapter->dev.of_node = pdev->dev.of_node;
-+
-+	platform_set_drvdata(pdev, adapter);
-+	
-+	ret = i2c_add_numbered_adapter(adapter);
-+	if (ret)
-+		return ret;
-+
-+	dev_info(&pdev->dev,"loaded");
-+
-+	return 0;
-+}
-+
-+static int rt_i2c_remove(struct platform_device *pdev)
-+{
-+	platform_set_drvdata(pdev, NULL);
-+	return 0;
-+}
-+
-+static const struct of_device_id i2c_rt_dt_ids[] = {
-+	{ .compatible = "ralink,i2c-mt7621", },
++static const struct of_device_id i2c_mtk_dt_ids[] = {
++	{ .compatible = "mediatek,mt7621-i2c" },
 +	{ /* sentinel */ }
 +};
 +
-+MODULE_DEVICE_TABLE(of, i2c_rt_dt_ids);
++MODULE_DEVICE_TABLE(of, i2c_mtk_dt_ids);
 +
-+static struct platform_driver rt_i2c_driver = {
-+	.probe		= rt_i2c_probe,
-+	.remove		= rt_i2c_remove,
++static struct i2c_adapter_quirks mtk_i2c_quirks = {
++        .max_write_len = BYTECNT_MAX,
++        .max_read_len = BYTECNT_MAX,
++};
++
++static void mtk_i2c_init(struct mtk_i2c *i2c)
++{
++	i2c->clk_div = clk_get_rate(i2c->clk) / i2c->cur_clk;
++	if (i2c->clk_div > CLK_DIV_MASK)
++		i2c->clk_div = CLK_DIV_MASK;
++
++	mtk_i2c_reset(i2c);
++}
++
++static int mtk_i2c_probe(struct platform_device *pdev)
++{
++	struct resource *res;
++	struct mtk_i2c *i2c;
++	struct i2c_adapter *adap;
++	const struct of_device_id *match;
++	int ret;
++
++	match = of_match_device(i2c_mtk_dt_ids, &pdev->dev);
++
++	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
++	if (!res) {
++		dev_err(&pdev->dev, "no memory resource found\n");
++		return -ENODEV;
++	}
++
++	i2c = devm_kzalloc(&pdev->dev, sizeof(struct mtk_i2c), GFP_KERNEL);
++	if (!i2c) {
++		dev_err(&pdev->dev, "failed to allocate i2c_adapter\n");
++		return -ENOMEM;
++	}
++
++	i2c->base = devm_ioremap_resource(&pdev->dev, res);
++	if (IS_ERR(i2c->base))
++		return PTR_ERR(i2c->base);
++
++	i2c->clk = devm_clk_get(&pdev->dev, NULL);
++	if (IS_ERR(i2c->clk)) {
++		dev_err(&pdev->dev, "no clock defined\n");
++		return -ENODEV;
++	}
++	clk_prepare_enable(i2c->clk);
++	i2c->dev = &pdev->dev;
++
++	if (of_property_read_u32(pdev->dev.of_node,
++				"clock-frequency", &i2c->cur_clk))
++		i2c->cur_clk = 100000;
++
++	adap = &i2c->adap;
++	adap->owner = THIS_MODULE;
++	adap->class = I2C_CLASS_HWMON | I2C_CLASS_SPD;
++	adap->algo = &mtk_i2c_algo;
++	adap->retries = 3;
++	adap->dev.parent = &pdev->dev;
++	i2c_set_adapdata(adap, i2c);
++	adap->dev.of_node = pdev->dev.of_node;
++	strlcpy(adap->name, dev_name(&pdev->dev), sizeof(adap->name));
++	adap->quirks = &mtk_i2c_quirks;
++
++	platform_set_drvdata(pdev, i2c);
++
++	mtk_i2c_init(i2c);
++
++	ret = i2c_add_adapter(adap);
++	if (ret < 0) {
++		dev_err(&pdev->dev, "failed to add adapter\n");
++		clk_disable_unprepare(i2c->clk);
++		return ret;
++	}
++
++	dev_info(&pdev->dev, "clock %uKHz, re-start not support\n",
++			i2c->cur_clk/1000);
++
++	return ret;
++}
++
++static int mtk_i2c_remove(struct platform_device *pdev)
++{
++	struct mtk_i2c *i2c = platform_get_drvdata(pdev);
++
++	i2c_del_adapter(&i2c->adap);
++	clk_disable_unprepare(i2c->clk);
++
++	return 0;
++}
++
++static struct platform_driver mtk_i2c_driver = {
++	.probe		= mtk_i2c_probe,
++	.remove		= mtk_i2c_remove,
 +	.driver		= {
 +		.owner	= THIS_MODULE,
 +		.name	= "i2c-mt7621",
-+		.of_match_table = i2c_rt_dt_ids,
++		.of_match_table = i2c_mtk_dt_ids,
 +	},
 +};
 +
-+static int __init i2c_rt_init (void)
++static int __init i2c_mtk_init (void)
 +{
-+	return platform_driver_register(&rt_i2c_driver);
++	return platform_driver_register(&mtk_i2c_driver);
 +}
++subsys_initcall(i2c_mtk_init);
 +
-+static void __exit i2c_rt_exit (void)
++static void __exit i2c_mtk_exit (void)
 +{
-+	platform_driver_unregister(&rt_i2c_driver);
++	platform_driver_unregister(&mtk_i2c_driver);
 +}
-+module_init (i2c_rt_init);
-+module_exit (i2c_rt_exit);
++module_exit(i2c_mtk_exit);
 +
 +MODULE_AUTHOR("Steven Liu <steven_liu@mediatek.com>");
 +MODULE_DESCRIPTION("MT7621 I2c host driver");

--- a/target/linux/ramips/patches-4.4/0047-DMA-ralink-add-rt2880-dma-engine.patch
+++ b/target/linux/ramips/patches-4.4/0047-DMA-ralink-add-rt2880-dma-engine.patch
@@ -14,13 +14,19 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 
 --- a/drivers/dma/Kconfig
 +++ b/drivers/dma/Kconfig
-@@ -40,6 +40,12 @@ config ASYNC_TX_ENABLE_CHANNEL_SWITCH
+@@ -40,6 +40,18 @@ config ASYNC_TX_ENABLE_CHANNEL_SWITCH
  config ARCH_HAS_ASYNC_TX_FIND_CHANNEL
  	bool
  
 +config DMA_RALINK
 +	tristate "RALINK DMA support"
-+	depends on RALINK && SOC_MT7620
++	depends on RALINK && !SOC_RT288X
++	select DMA_ENGINE
++	select DMA_VIRTUAL_CHANNELS
++
++config MTK_HSDMA
++	tristate "MTK HSDMA support"
++	depends on RALINK && SOC_MT7621
 +	select DMA_ENGINE
 +	select DMA_VIRTUAL_CHANNELS
 +
@@ -29,16 +35,17 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
 --- a/drivers/dma/Makefile
 +++ b/drivers/dma/Makefile
-@@ -65,5 +65,6 @@ obj-$(CONFIG_TI_DMA_CROSSBAR) += ti-dma-
+@@ -65,5 +65,7 @@ obj-$(CONFIG_TI_DMA_CROSSBAR) += ti-dma-
  obj-$(CONFIG_TI_EDMA) += edma.o
  obj-$(CONFIG_XGENE_DMA) += xgene-dma.o
  obj-$(CONFIG_ZX_DMA) += zx296702_dma.o
 +obj-$(CONFIG_DMA_RALINK) += ralink-gdma.o
++obj-$(CONFIG_MTK_HSDMA) += mtk-hsdma.o
  
  obj-y += xilinx/
 --- /dev/null
 +++ b/drivers/dma/ralink-gdma.c
-@@ -0,0 +1,577 @@
+@@ -0,0 +1,928 @@
 +/*
 + *  Copyright (C) 2013, Lars-Peter Clausen <lars@metafoo.de>
 + *  GDMA4740 DMAC support
@@ -47,10 +54,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 + *  under  the terms of the GNU General	 Public License as published by the
 + *  Free Software Foundation;  either version 2 of the License, or (at your
 + *  option) any later version.
-+ *
-+ *  You should have received a copy of the GNU General Public License along
-+ *  with this program; if not, write to the Free Software Foundation, Inc.,
-+ *  675 Mass Ave, Cambridge, MA 02139, USA.
 + *
 + */
 +
@@ -65,10 +68,10 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#include <linux/spinlock.h>
 +#include <linux/irq.h>
 +#include <linux/of_dma.h>
++#include <linux/reset.h>
++#include <linux/of_device.h>
 +
 +#include "virt-dma.h"
-+
-+#define GDMA_NR_CHANS			16
 +
 +#define GDMA_REG_SRC_ADDR(x)		(0x00 + (x) * 0x10)
 +#define GDMA_REG_DST_ADDR(x)		(0x04 + (x) * 0x10)
@@ -84,7 +87,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#define GDMA_REG_CTRL0_BURST_SHIFT	3
 +#define	GDMA_REG_CTRL0_DONE_INT		BIT(2)
 +#define	GDMA_REG_CTRL0_ENABLE		BIT(1)
-+#define	GDMA_REG_CTRL0_HW_MODE		0
++#define GDMA_REG_CTRL0_SW_MODE          BIT(0)
 +
 +#define GDMA_REG_CTRL1(x)		(0x0c + (x) * 0x10)
 +#define GDMA_REG_CTRL1_SEG_MASK		0xf
@@ -109,16 +112,39 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#define GDMA_REG_GCT_VER_SHIFT		1
 +#define GDMA_REG_GCT_ARBIT_RR		BIT(0)
 +
++#define GDMA_REG_REQSTS			0x2a0
++#define GDMA_REG_ACKSTS			0x2a4
++#define GDMA_REG_FINSTS			0x2a8
++
++/* for RT305X gdma registers */
++#define GDMA_RT305X_CTRL0_REQ_MASK	0xf
++#define GDMA_RT305X_CTRL0_SRC_REQ_SHIFT	12
++#define GDMA_RT305X_CTRL0_DST_REQ_SHIFT	8
++
++#define GDMA_RT305X_CTRL1_FAIL		BIT(4)
++#define GDMA_RT305X_CTRL1_NEXT_MASK	0x7
++#define GDMA_RT305X_CTRL1_NEXT_SHIFT	1
++
++#define GDMA_RT305X_STATUS_INT		0x80
++#define GDMA_RT305X_STATUS_SIGNAL	0x84
++#define GDMA_RT305X_GCT			0x88
++
++/* for MT7621 gdma registers */
++#define GDMA_REG_PERF_START(x)		(0x230 + (x) * 0x8)
++#define GDMA_REG_PERF_END(x)		(0x234 + (x) * 0x8)
++
 +enum gdma_dma_transfer_size {
 +	GDMA_TRANSFER_SIZE_4BYTE	= 0,
 +	GDMA_TRANSFER_SIZE_8BYTE	= 1,
 +	GDMA_TRANSFER_SIZE_16BYTE	= 2,
 +	GDMA_TRANSFER_SIZE_32BYTE	= 3,
++	GDMA_TRANSFER_SIZE_64BYTE	= 4,
 +};
 +
 +struct gdma_dma_sg {
-+	dma_addr_t addr;
-+	unsigned int len;
++	dma_addr_t src_addr;
++	dma_addr_t dst_addr;
++	u32 len;
 +};
 +
 +struct gdma_dma_desc {
@@ -127,6 +153,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	enum dma_transfer_direction direction;
 +	bool cyclic;
 +
++	u32 residue;
 +	unsigned int num_sgs;
 +	struct gdma_dma_sg sg[];
 +};
@@ -134,9 +161,10 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +struct gdma_dmaengine_chan {
 +	struct virt_dma_chan vchan;
 +	unsigned int id;
++	unsigned int slave_id;
 +
 +	dma_addr_t fifo_addr;
-+	unsigned int transfer_shift;
++	enum gdma_dma_transfer_size burst_size;
 +
 +	struct gdma_dma_desc *desc;
 +	unsigned int next_sg;
@@ -144,10 +172,22 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +struct gdma_dma_dev {
 +	struct dma_device ddev;
++	struct device_dma_parameters dma_parms;
++	struct gdma_data *data;
 +	void __iomem *base;
-+	struct clk *clk;
++	struct tasklet_struct task;
++	volatile unsigned long chan_issued;
++	atomic_t cnt;
 +
-+	struct gdma_dmaengine_chan chan[GDMA_NR_CHANS];
++	struct gdma_dmaengine_chan chan[];
++};
++
++struct gdma_data
++{
++	int chancnt;
++	u32 done_int_reg;
++	void (*init)(struct gdma_dma_dev *dma_dev);
++	int (*start_transfer)(struct gdma_dmaengine_chan *chan);
 +};
 +
 +static struct gdma_dma_dev *gdma_dma_chan_get_dev(
@@ -176,19 +216,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static inline void gdma_dma_write(struct gdma_dma_dev *dma_dev,
 +	unsigned reg, uint32_t val)
 +{
-+	//printk("gdma --> %p = 0x%08X\n", dma_dev->base + reg, val);
 +	writel(val, dma_dev->base + reg);
-+}
-+
-+static inline void gdma_dma_write_mask(struct gdma_dma_dev *dma_dev,
-+	unsigned int reg, uint32_t val, uint32_t mask)
-+{
-+	uint32_t tmp;
-+
-+	tmp = gdma_dma_read(dma_dev, reg);
-+	tmp &= ~mask;
-+	tmp |= val;
-+	gdma_dma_write(dma_dev, reg, tmp);
 +}
 +
 +static struct gdma_dma_desc *gdma_dma_alloc_desc(unsigned int num_sgs)
@@ -199,57 +227,53 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +static enum gdma_dma_transfer_size gdma_dma_maxburst(u32 maxburst)
 +{
-+	if (maxburst <= 7)
++	if (maxburst < 2)
 +		return GDMA_TRANSFER_SIZE_4BYTE;
-+	else if (maxburst <= 15)
++	else if (maxburst < 4)
 +		return GDMA_TRANSFER_SIZE_8BYTE;
-+	else if (maxburst <= 31)
++	else if (maxburst < 8)
 +		return GDMA_TRANSFER_SIZE_16BYTE;
-+
-+	return GDMA_TRANSFER_SIZE_32BYTE;
++	else if (maxburst < 16)
++		return GDMA_TRANSFER_SIZE_32BYTE;
++	else
++		return GDMA_TRANSFER_SIZE_64BYTE;
 +}
 +
-+static int gdma_dma_slave_config(struct dma_chan *c,
-+	const struct dma_slave_config *config)
++static int gdma_dma_config(struct dma_chan *c,
++		struct dma_slave_config *config)
 +{
 +	struct gdma_dmaengine_chan *chan = to_gdma_dma_chan(c);
 +	struct gdma_dma_dev *dma_dev = gdma_dma_chan_get_dev(chan);
-+	enum gdma_dma_transfer_size transfer_size;
-+	uint32_t flags;
-+	uint32_t ctrl0, ctrl1;
 +
-+	switch (config->direction) {
-+	case DMA_MEM_TO_DEV:
-+		ctrl1 = 32 << GDMA_REG_CTRL1_SRC_REQ_SHIFT;
-+		ctrl1 |= config->slave_id << GDMA_REG_CTRL1_DST_REQ_SHIFT;
-+		flags = GDMA_REG_CTRL0_DST_ADDR_FIXED;
-+		transfer_size = gdma_dma_maxburst(config->dst_maxburst);
-+		chan->fifo_addr = config->dst_addr;
-+		break;
-+
-+	case DMA_DEV_TO_MEM:
-+		ctrl1 = config->slave_id << GDMA_REG_CTRL1_SRC_REQ_SHIFT;
-+		ctrl1 |= 32 << GDMA_REG_CTRL1_DST_REQ_SHIFT;
-+		flags = GDMA_REG_CTRL0_SRC_ADDR_FIXED;
-+		transfer_size = gdma_dma_maxburst(config->src_maxburst);
-+		chan->fifo_addr = config->src_addr;
-+		break;
-+
-+	default:
++	if (config->device_fc) {
++		dev_err(dma_dev->ddev.dev, "not support flow controller\n");
 +		return -EINVAL;
 +	}
 +
-+	chan->transfer_shift = 1 + transfer_size;
-+
-+	ctrl0 = flags | GDMA_REG_CTRL0_HW_MODE;
-+	ctrl0 |= GDMA_REG_CTRL0_DONE_INT;
-+
-+	ctrl1 &= ~(GDMA_REG_CTRL1_NEXT_MASK << GDMA_REG_CTRL1_NEXT_SHIFT);
-+	ctrl1 |= chan->id << GDMA_REG_CTRL1_NEXT_SHIFT;
-+	ctrl1 |= GDMA_REG_CTRL1_FAIL;
-+	ctrl1 &= ~GDMA_REG_CTRL1_CONTINOUS;
-+	gdma_dma_write(dma_dev, GDMA_REG_CTRL0(chan->id), ctrl0);
-+	gdma_dma_write(dma_dev, GDMA_REG_CTRL1(chan->id), ctrl1);
++	switch (config->direction) {
++	case DMA_MEM_TO_DEV:
++		if (config->dst_addr_width != DMA_SLAVE_BUSWIDTH_4_BYTES) {
++			dev_err(dma_dev->ddev.dev, "only support 4 byte buswidth\n");
++			return -EINVAL;
++		}
++		chan->slave_id = config->slave_id;
++		chan->fifo_addr = config->dst_addr;
++		chan->burst_size = gdma_dma_maxburst(config->dst_maxburst);
++		break;
++	case DMA_DEV_TO_MEM:
++		if (config->src_addr_width != DMA_SLAVE_BUSWIDTH_4_BYTES) {
++			dev_err(dma_dev->ddev.dev, "only support 4 byte buswidth\n");
++			return -EINVAL;
++		}
++		chan->slave_id = config->slave_id;
++		chan->fifo_addr = config->src_addr;
++		chan->burst_size = gdma_dma_maxburst(config->src_maxburst);
++		break;
++	default:
++		dev_err(dma_dev->ddev.dev, "direction type %d error\n",
++				config->direction);
++		return -EINVAL;
++	}
 +
 +	return 0;
 +}
@@ -258,108 +282,271 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +{
 +	struct gdma_dmaengine_chan *chan = to_gdma_dma_chan(c);
 +	struct gdma_dma_dev *dma_dev = gdma_dma_chan_get_dev(chan);
-+	unsigned long flags;
++	unsigned long flags, timeout;
 +	LIST_HEAD(head);
++	int i = 0;
 +
 +	spin_lock_irqsave(&chan->vchan.lock, flags);
-+	gdma_dma_write_mask(dma_dev, GDMA_REG_CTRL0(chan->id), 0,
-+			GDMA_REG_CTRL0_ENABLE);
 +	chan->desc = NULL;
++	clear_bit(chan->id, &dma_dev->chan_issued);
 +	vchan_get_all_descriptors(&chan->vchan, &head);
 +	spin_unlock_irqrestore(&chan->vchan.lock, flags);
 +
 +	vchan_dma_desc_free_list(&chan->vchan, &head);
 +
++	/* wait dma transfer complete */
++	timeout = jiffies + msecs_to_jiffies(5000);
++	while (gdma_dma_read(dma_dev, GDMA_REG_CTRL0(chan->id)) &
++			GDMA_REG_CTRL0_ENABLE) {
++		if (time_after_eq(jiffies, timeout)) {
++			dev_err(dma_dev->ddev.dev, "chan %d wait timeout\n",
++					chan->id);
++			/* restore to init value */
++			gdma_dma_write(dma_dev, GDMA_REG_CTRL0(chan->id), 0);
++			break;
++		}
++		cpu_relax();
++		i++;
++	}
++
++	if (i)
++		dev_dbg(dma_dev->ddev.dev, "terminate chan %d loops %d\n",
++				chan->id, i);
++
 +	return 0;
 +}
 +
-+static int gdma_dma_control(struct dma_chan *chan, enum dma_ctrl_cmd cmd,
-+	unsigned long arg)
++static void rt305x_dump_reg(struct gdma_dma_dev *dma_dev, int id)
 +{
-+	struct dma_slave_config *config = (struct dma_slave_config *)arg;
-+
-+	switch (cmd) {
-+	case DMA_SLAVE_CONFIG:
-+		return gdma_dma_slave_config(chan, config);
-+	case DMA_TERMINATE_ALL:
-+		return gdma_dma_terminate_all(chan);
-+	default:
-+		return -ENOSYS;
-+	}
++	dev_dbg(dma_dev->ddev.dev, "chan %d, src %08x, dst %08x, ctr0 %08x, " \
++			"ctr1 %08x, intr %08x, signal %08x\n", id,
++			gdma_dma_read(dma_dev, GDMA_REG_SRC_ADDR(id)),
++			gdma_dma_read(dma_dev, GDMA_REG_DST_ADDR(id)),
++			gdma_dma_read(dma_dev, GDMA_REG_CTRL0(id)),
++			gdma_dma_read(dma_dev, GDMA_REG_CTRL1(id)),
++			gdma_dma_read(dma_dev, GDMA_RT305X_STATUS_INT),
++			gdma_dma_read(dma_dev, GDMA_RT305X_STATUS_SIGNAL));
 +}
 +
-+static int gdma_dma_start_transfer(struct gdma_dmaengine_chan *chan)
++static int rt305x_gdma_start_transfer(struct gdma_dmaengine_chan *chan)
 +{
 +	struct gdma_dma_dev *dma_dev = gdma_dma_chan_get_dev(chan);
 +	dma_addr_t src_addr, dst_addr;
-+	struct virt_dma_desc *vdesc;
 +	struct gdma_dma_sg *sg;
++	uint32_t ctrl0, ctrl1;
 +
-+	gdma_dma_write_mask(dma_dev, GDMA_REG_CTRL0(chan->id), 0,
-+			GDMA_REG_CTRL0_ENABLE);
-+
-+	if (!chan->desc) {
-+		vdesc = vchan_next_desc(&chan->vchan);
-+		if (!vdesc)
-+			return 0;
-+		chan->desc = to_gdma_dma_desc(vdesc);
-+		chan->next_sg = 0;
++	/* verify chan is already stopped */
++	ctrl0 = gdma_dma_read(dma_dev, GDMA_REG_CTRL0(chan->id));
++	if (unlikely(ctrl0 & GDMA_REG_CTRL0_ENABLE)) {
++		dev_err(dma_dev->ddev.dev, "chan %d is start(%08x).\n",
++				chan->id, ctrl0);
++		rt305x_dump_reg(dma_dev, chan->id);
++		return -EINVAL;
 +	}
-+
-+	if (chan->next_sg == chan->desc->num_sgs)
-+		chan->next_sg = 0;
 +
 +	sg = &chan->desc->sg[chan->next_sg];
-+
 +	if (chan->desc->direction == DMA_MEM_TO_DEV) {
-+		src_addr = sg->addr;
++		src_addr = sg->src_addr;
 +		dst_addr = chan->fifo_addr;
-+	} else {
++		ctrl0 = GDMA_REG_CTRL0_DST_ADDR_FIXED | \
++			(8 << GDMA_RT305X_CTRL0_SRC_REQ_SHIFT) | \
++			(chan->slave_id << GDMA_RT305X_CTRL0_DST_REQ_SHIFT);
++	} else if (chan->desc->direction == DMA_DEV_TO_MEM) {
 +		src_addr = chan->fifo_addr;
-+		dst_addr = sg->addr;
++		dst_addr = sg->dst_addr;
++		ctrl0 = GDMA_REG_CTRL0_SRC_ADDR_FIXED | \
++			(chan->slave_id << GDMA_RT305X_CTRL0_SRC_REQ_SHIFT) | \
++			(8 << GDMA_RT305X_CTRL0_DST_REQ_SHIFT);
++	} else if (chan->desc->direction == DMA_MEM_TO_MEM) {
++		/*
++		 * TODO: memcpy function have bugs. sometime it will copy
++		 * more 8 bytes data when using dmatest verify.
++		 */
++		src_addr = sg->src_addr;
++		dst_addr = sg->dst_addr;
++		ctrl0 = GDMA_REG_CTRL0_SW_MODE | \
++			(8 << GDMA_REG_CTRL1_SRC_REQ_SHIFT) | \
++			(8 << GDMA_REG_CTRL1_DST_REQ_SHIFT);
++	} else {
++		dev_err(dma_dev->ddev.dev, "direction type %d error\n",
++				chan->desc->direction);
++		return -EINVAL;
 +	}
++
++	ctrl0 |= (sg->len << GDMA_REG_CTRL0_TX_SHIFT) | \
++		 (chan->burst_size << GDMA_REG_CTRL0_BURST_SHIFT) | \
++		 GDMA_REG_CTRL0_DONE_INT | GDMA_REG_CTRL0_ENABLE;
++	ctrl1 = chan->id << GDMA_REG_CTRL1_NEXT_SHIFT;
++
++	chan->next_sg++;
 +	gdma_dma_write(dma_dev, GDMA_REG_SRC_ADDR(chan->id), src_addr);
 +	gdma_dma_write(dma_dev, GDMA_REG_DST_ADDR(chan->id), dst_addr);
-+	gdma_dma_write_mask(dma_dev, GDMA_REG_CTRL0(chan->id),
-+			(sg->len << GDMA_REG_CTRL0_TX_SHIFT) | GDMA_REG_CTRL0_ENABLE,
-+			GDMA_REG_CTRL0_TX_MASK << GDMA_REG_CTRL0_TX_SHIFT);
-+	chan->next_sg++;
-+	gdma_dma_write_mask(dma_dev, GDMA_REG_CTRL1(chan->id), 0, GDMA_REG_CTRL1_MASK);
++	gdma_dma_write(dma_dev, GDMA_REG_CTRL1(chan->id), ctrl1);
++
++	/* make sure next_sg is update */
++	wmb();
++	gdma_dma_write(dma_dev, GDMA_REG_CTRL0(chan->id), ctrl0);
 +
 +	return 0;
 +}
 +
-+static void gdma_dma_chan_irq(struct gdma_dmaengine_chan *chan)
++static void rt3883_dump_reg(struct gdma_dma_dev *dma_dev, int id)
 +{
-+	spin_lock(&chan->vchan.lock);
-+	if (chan->desc) {
-+		if (chan->desc && chan->desc->cyclic) {
-+			vchan_cyclic_callback(&chan->desc->vdesc);
-+		} else {
-+			if (chan->next_sg == chan->desc->num_sgs) {
-+				chan->desc = NULL;
-+				vchan_cookie_complete(&chan->desc->vdesc);
-+			}
-+		}
++	dev_dbg(dma_dev->ddev.dev, "chan %d, src %08x, dst %08x, ctr0 %08x, " \
++			"ctr1 %08x, unmask %08x, done %08x, " \
++			"req %08x, ack %08x, fin %08x\n", id,
++			gdma_dma_read(dma_dev, GDMA_REG_SRC_ADDR(id)),
++			gdma_dma_read(dma_dev, GDMA_REG_DST_ADDR(id)),
++			gdma_dma_read(dma_dev, GDMA_REG_CTRL0(id)),
++			gdma_dma_read(dma_dev, GDMA_REG_CTRL1(id)),
++			gdma_dma_read(dma_dev, GDMA_REG_UNMASK_INT),
++			gdma_dma_read(dma_dev, GDMA_REG_DONE_INT),
++			gdma_dma_read(dma_dev, GDMA_REG_REQSTS),
++			gdma_dma_read(dma_dev, GDMA_REG_ACKSTS),
++			gdma_dma_read(dma_dev, GDMA_REG_FINSTS));
++}
++
++static int rt3883_gdma_start_transfer(struct gdma_dmaengine_chan *chan)
++{
++	struct gdma_dma_dev *dma_dev = gdma_dma_chan_get_dev(chan);
++	dma_addr_t src_addr, dst_addr;
++	struct gdma_dma_sg *sg;
++	uint32_t ctrl0, ctrl1;
++
++	/* verify chan is already stopped */
++	ctrl0 = gdma_dma_read(dma_dev, GDMA_REG_CTRL0(chan->id));
++	if (unlikely(ctrl0 & GDMA_REG_CTRL0_ENABLE)) {
++		dev_err(dma_dev->ddev.dev, "chan %d is start(%08x).\n",
++				chan->id, ctrl0);
++		rt3883_dump_reg(dma_dev, chan->id);
++		return -EINVAL;
 +	}
-+	gdma_dma_start_transfer(chan);
-+	spin_unlock(&chan->vchan.lock);
++
++	sg = &chan->desc->sg[chan->next_sg];
++	if (chan->desc->direction == DMA_MEM_TO_DEV) {
++		src_addr = sg->src_addr;
++		dst_addr = chan->fifo_addr;
++		ctrl0 = GDMA_REG_CTRL0_DST_ADDR_FIXED;
++		ctrl1 = (32 << GDMA_REG_CTRL1_SRC_REQ_SHIFT) | \
++			(chan->slave_id << GDMA_REG_CTRL1_DST_REQ_SHIFT);
++	} else if (chan->desc->direction == DMA_DEV_TO_MEM) {
++		src_addr = chan->fifo_addr;
++		dst_addr = sg->dst_addr;
++		ctrl0 = GDMA_REG_CTRL0_SRC_ADDR_FIXED;
++		ctrl1 = (chan->slave_id << GDMA_REG_CTRL1_SRC_REQ_SHIFT) | \
++			(32 << GDMA_REG_CTRL1_DST_REQ_SHIFT) | \
++			GDMA_REG_CTRL1_COHERENT;
++	} else if (chan->desc->direction == DMA_MEM_TO_MEM) {
++		src_addr = sg->src_addr;
++		dst_addr = sg->dst_addr;
++		ctrl0 = GDMA_REG_CTRL0_SW_MODE;
++		ctrl1 = (32 << GDMA_REG_CTRL1_SRC_REQ_SHIFT) | \
++			(32 << GDMA_REG_CTRL1_DST_REQ_SHIFT) | \
++			GDMA_REG_CTRL1_COHERENT;
++	} else {
++		dev_err(dma_dev->ddev.dev, "direction type %d error\n",
++				chan->desc->direction);
++		return -EINVAL;
++	}
++
++	ctrl0 |= (sg->len << GDMA_REG_CTRL0_TX_SHIFT) | \
++		 (chan->burst_size << GDMA_REG_CTRL0_BURST_SHIFT) | \
++		 GDMA_REG_CTRL0_DONE_INT | GDMA_REG_CTRL0_ENABLE;
++	ctrl1 |= chan->id << GDMA_REG_CTRL1_NEXT_SHIFT;
++
++	chan->next_sg++;
++	gdma_dma_write(dma_dev, GDMA_REG_SRC_ADDR(chan->id), src_addr);
++	gdma_dma_write(dma_dev, GDMA_REG_DST_ADDR(chan->id), dst_addr);
++	gdma_dma_write(dma_dev, GDMA_REG_CTRL1(chan->id), ctrl1);
++
++	/* make sure next_sg is update */
++	wmb();
++	gdma_dma_write(dma_dev, GDMA_REG_CTRL0(chan->id), ctrl0);
++
++	return 0;
++}
++
++static inline int gdma_start_transfer(struct gdma_dma_dev *dma_dev,
++		struct gdma_dmaengine_chan *chan)
++{
++	return dma_dev->data->start_transfer(chan);
++}
++
++static int gdma_next_desc(struct gdma_dmaengine_chan *chan)
++{
++	struct virt_dma_desc *vdesc;
++
++	vdesc = vchan_next_desc(&chan->vchan);
++	if (!vdesc) {
++		chan->desc = NULL;
++		return 0;
++	}
++	chan->desc = to_gdma_dma_desc(vdesc);
++	chan->next_sg = 0;
++
++	return 1;
++}
++
++static void gdma_dma_chan_irq(struct gdma_dma_dev *dma_dev,
++		struct gdma_dmaengine_chan *chan)
++{
++	struct gdma_dma_desc *desc;
++	unsigned long flags;
++	int chan_issued;
++
++	chan_issued = 0;
++	spin_lock_irqsave(&chan->vchan.lock, flags);
++	desc = chan->desc;
++	if (desc) {
++		if (desc->cyclic) {
++			vchan_cyclic_callback(&desc->vdesc);
++			if (chan->next_sg == desc->num_sgs)
++				chan->next_sg = 0;
++			chan_issued = 1;
++		} else {
++			desc->residue -= desc->sg[chan->next_sg - 1].len;
++			if (chan->next_sg == desc->num_sgs) {
++				list_del(&desc->vdesc.node);
++				vchan_cookie_complete(&desc->vdesc);
++				chan_issued = gdma_next_desc(chan);
++			} else
++				chan_issued = 1;
++		}
++	} else
++		dev_dbg(dma_dev->ddev.dev, "chan %d no desc to complete\n",
++				chan->id);
++	if (chan_issued)
++		set_bit(chan->id, &dma_dev->chan_issued);
++	spin_unlock_irqrestore(&chan->vchan.lock, flags);
 +}
 +
 +static irqreturn_t gdma_dma_irq(int irq, void *devid)
 +{
 +	struct gdma_dma_dev *dma_dev = devid;
-+	uint32_t unmask, done;
++	u32 done, done_reg;
 +	unsigned int i;
 +
-+	unmask = gdma_dma_read(dma_dev, GDMA_REG_UNMASK_INT);
-+	gdma_dma_write(dma_dev, GDMA_REG_UNMASK_INT, unmask);
-+	done = gdma_dma_read(dma_dev, GDMA_REG_DONE_INT);
++	done_reg = dma_dev->data->done_int_reg;
++	done = gdma_dma_read(dma_dev, done_reg);
++	if (unlikely(!done))
++		return IRQ_NONE;
 +
-+	for (i = 0; i < GDMA_NR_CHANS; ++i)
-+		if (done & BIT(i))
-+			gdma_dma_chan_irq(&dma_dev->chan[i]);
-+	gdma_dma_write(dma_dev, GDMA_REG_DONE_INT, done);
++	/* clean done bits */
++	gdma_dma_write(dma_dev, done_reg, done);
++
++	i = 0;
++	while (done) {
++		if (done & 0x1) {
++			gdma_dma_chan_irq(dma_dev, &dma_dev->chan[i]);
++			atomic_dec(&dma_dev->cnt);
++		}
++		done >>= 1;
++		i++;
++	}
++
++	/* start only have work to do */
++	if (dma_dev->chan_issued)
++		tasklet_schedule(&dma_dev->task);
 +
 +	return IRQ_HANDLED;
 +}
@@ -367,18 +554,25 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static void gdma_dma_issue_pending(struct dma_chan *c)
 +{
 +	struct gdma_dmaengine_chan *chan = to_gdma_dma_chan(c);
++	struct gdma_dma_dev *dma_dev = gdma_dma_chan_get_dev(chan);
 +	unsigned long flags;
 +
 +	spin_lock_irqsave(&chan->vchan.lock, flags);
-+	if (vchan_issue_pending(&chan->vchan) && !chan->desc)
-+		gdma_dma_start_transfer(chan);
++	if (vchan_issue_pending(&chan->vchan) && !chan->desc) {
++		if (gdma_next_desc(chan)) {
++			set_bit(chan->id, &dma_dev->chan_issued);
++			tasklet_schedule(&dma_dev->task);
++		} else
++			dev_dbg(dma_dev->ddev.dev, "chan %d no desc to issue\n",
++					chan->id);
++	}
 +	spin_unlock_irqrestore(&chan->vchan.lock, flags);
 +}
 +
 +static struct dma_async_tx_descriptor *gdma_dma_prep_slave_sg(
-+	struct dma_chan *c, struct scatterlist *sgl,
-+	unsigned int sg_len, enum dma_transfer_direction direction,
-+	unsigned long flags, void *context)
++		struct dma_chan *c, struct scatterlist *sgl,
++		unsigned int sg_len, enum dma_transfer_direction direction,
++		unsigned long flags, void *context)
 +{
 +	struct gdma_dmaengine_chan *chan = to_gdma_dma_chan(c);
 +	struct gdma_dma_desc *desc;
@@ -386,16 +580,82 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	unsigned int i;
 +
 +	desc = gdma_dma_alloc_desc(sg_len);
-+	if (!desc)
++	if (!desc) {
++		dev_err(c->device->dev, "alloc sg decs error\n");
 +		return NULL;
++	}
++	desc->residue = 0;
 +
 +	for_each_sg(sgl, sg, sg_len, i) {
-+		desc->sg[i].addr = sg_dma_address(sg);
++		if (direction == DMA_MEM_TO_DEV)
++			desc->sg[i].src_addr = sg_dma_address(sg);
++		else if (direction == DMA_DEV_TO_MEM)
++			desc->sg[i].dst_addr = sg_dma_address(sg);
++		else {
++			dev_err(c->device->dev, "direction type %d error\n",
++					direction);
++			goto free_desc;
++		}
++
++		if (unlikely(sg_dma_len(sg) > GDMA_REG_CTRL0_TX_MASK)) {
++			dev_err(c->device->dev, "sg len too large %d\n",
++					sg_dma_len(sg));
++			goto free_desc;
++		}
 +		desc->sg[i].len = sg_dma_len(sg);
++		desc->residue += sg_dma_len(sg);
 +	}
 +
 +	desc->num_sgs = sg_len;
 +	desc->direction = direction;
++	desc->cyclic = false;
++
++	return vchan_tx_prep(&chan->vchan, &desc->vdesc, flags);
++
++free_desc:
++	kfree(desc);
++	return NULL;
++}
++
++static struct dma_async_tx_descriptor * gdma_dma_prep_dma_memcpy(
++		struct dma_chan *c, dma_addr_t dest, dma_addr_t src,
++		size_t len, unsigned long flags)
++{
++	struct gdma_dmaengine_chan *chan = to_gdma_dma_chan(c);
++	struct gdma_dma_desc *desc;
++	unsigned int num_periods, i;
++	size_t xfer_count;
++
++	if (len <= 0)
++		return NULL;
++
++	chan->burst_size = gdma_dma_maxburst(len >> 2);
++
++	xfer_count = GDMA_REG_CTRL0_TX_MASK;
++	num_periods = DIV_ROUND_UP(len, xfer_count);
++
++	desc = gdma_dma_alloc_desc(num_periods);
++	if (!desc) {
++		dev_err(c->device->dev, "alloc memcpy decs error\n");
++		return NULL;
++	}
++	desc->residue = len;
++
++	for (i = 0; i < num_periods; i++) {
++		desc->sg[i].src_addr = src;
++		desc->sg[i].dst_addr = dest;
++		if (len > xfer_count) {
++			desc->sg[i].len = xfer_count;
++		} else {
++			desc->sg[i].len = len;
++		}
++		src += desc->sg[i].len;
++		dest += desc->sg[i].len;
++		len -= desc->sg[i].len;
++	}
++
++	desc->num_sgs = num_periods;
++	desc->direction = DMA_MEM_TO_MEM;
 +	desc->cyclic = false;
 +
 +	return vchan_tx_prep(&chan->vchan, &desc->vdesc, flags);
@@ -404,7 +664,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static struct dma_async_tx_descriptor *gdma_dma_prep_dma_cyclic(
 +	struct dma_chan *c, dma_addr_t buf_addr, size_t buf_len,
 +	size_t period_len, enum dma_transfer_direction direction,
-+	unsigned long flags, void *context)
++	unsigned long flags)
 +{
 +	struct gdma_dmaengine_chan *chan = to_gdma_dma_chan(c);
 +	struct gdma_dma_desc *desc;
@@ -413,14 +673,30 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	if (buf_len % period_len)
 +		return NULL;
 +
-+	num_periods = buf_len / period_len;
-+
-+	desc = gdma_dma_alloc_desc(num_periods);
-+	if (!desc)
++	if (period_len > GDMA_REG_CTRL0_TX_MASK) {
++		dev_err(c->device->dev, "cyclic len too large %d\n",
++				period_len);
 +		return NULL;
++	}
++
++	num_periods = buf_len / period_len;
++	desc = gdma_dma_alloc_desc(num_periods);
++	if (!desc) {
++		dev_err(c->device->dev, "alloc cyclic decs error\n");
++		return NULL;
++	}
++	desc->residue = buf_len;
 +
 +	for (i = 0; i < num_periods; i++) {
-+		desc->sg[i].addr = buf_addr;
++		if (direction == DMA_MEM_TO_DEV)
++			desc->sg[i].src_addr = buf_addr;
++		else if (direction == DMA_DEV_TO_MEM)
++			desc->sg[i].dst_addr = buf_addr;
++		else {
++			dev_err(c->device->dev, "direction type %d error\n",
++					direction);
++			goto free_desc;
++		}
 +		desc->sg[i].len = period_len;
 +		buf_addr += period_len;
 +	}
@@ -430,28 +706,10 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	desc->cyclic = true;
 +
 +	return vchan_tx_prep(&chan->vchan, &desc->vdesc, flags);
-+}
 +
-+static size_t gdma_dma_desc_residue(struct gdma_dmaengine_chan *chan,
-+	struct gdma_dma_desc *desc, unsigned int next_sg)
-+{
-+	struct gdma_dma_dev *dma_dev = gdma_dma_chan_get_dev(chan);
-+	unsigned int residue, count;
-+	unsigned int i;
-+
-+	residue = 0;
-+
-+	for (i = next_sg; i < desc->num_sgs; i++)
-+		residue += desc->sg[i].len;
-+
-+	if (next_sg != 0) {
-+		count = gdma_dma_read(dma_dev, GDMA_REG_CTRL0(chan->id));
-+		count >>= GDMA_REG_CTRL0_CURR_SHIFT;
-+		count &= GDMA_REG_CTRL0_CURR_MASK;
-+		residue += count << chan->transfer_shift;
-+	}
-+
-+	return residue;
++free_desc:
++	kfree(desc);
++	return NULL;
 +}
 +
 +static enum dma_status gdma_dma_tx_status(struct dma_chan *c,
@@ -461,30 +719,32 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	struct virt_dma_desc *vdesc;
 +	enum dma_status status;
 +	unsigned long flags;
++	struct gdma_dma_desc *desc;
 +
 +	status = dma_cookie_status(c, cookie, state);
-+	if (status == DMA_SUCCESS || !state)
++	if (status == DMA_COMPLETE || !state)
 +		return status;
 +
 +	spin_lock_irqsave(&chan->vchan.lock, flags);
-+	vdesc = vchan_find_desc(&chan->vchan, cookie);
-+	if (cookie == chan->desc->vdesc.tx.cookie) {
-+		state->residue = gdma_dma_desc_residue(chan, chan->desc,
-+				chan->next_sg);
-+	} else if (vdesc) {
-+		state->residue = gdma_dma_desc_residue(chan,
-+				to_gdma_dma_desc(vdesc), 0);
-+	} else {
-+		state->residue = 0;
-+	}
++	desc = chan->desc;
++	if (desc && (cookie == desc->vdesc.tx.cookie)) {
++		/*
++		 * We never update edesc->residue in the cyclic case, so we
++		 * can tell the remaining room to the end of the circular
++		 * buffer.
++		 */
++		if (desc->cyclic)
++			state->residue = desc->residue -
++				((chan->next_sg - 1) * desc->sg[0].len);
++		else
++			state->residue = desc->residue;
++	} else if ((vdesc = vchan_find_desc(&chan->vchan, cookie)))
++		state->residue = to_gdma_dma_desc(vdesc)->residue;
 +	spin_unlock_irqrestore(&chan->vchan.lock, flags);
 +
-+	return status;
-+}
++	dev_dbg(c->device->dev, "tx residue %d bytes\n", state->residue);
 +
-+static int gdma_dma_alloc_chan_resources(struct dma_chan *c)
-+{
-+	return 0;
++	return status;
 +}
 +
 +static void gdma_dma_free_chan_resources(struct dma_chan *c)
@@ -497,86 +757,191 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	kfree(container_of(vdesc, struct gdma_dma_desc, vdesc));
 +}
 +
-+static struct dma_chan *
-+of_dma_xlate_by_chan_id(struct of_phandle_args *dma_spec,
-+			struct of_dma *ofdma)
++static void gdma_dma_tasklet(unsigned long arg)
 +{
-+	struct gdma_dma_dev *dma_dev = ofdma->of_dma_data;
-+	unsigned int request = dma_spec->args[0];
++	struct gdma_dma_dev *dma_dev = (struct gdma_dma_dev *)arg;
++	struct gdma_dmaengine_chan *chan;
++	static unsigned int last_chan;
++	unsigned int i, chan_mask;
 +
-+	if (request >= GDMA_NR_CHANS)
-+		return NULL;
++	/* record last chan to round robin all chans */
++	i = last_chan;
++	chan_mask = dma_dev->data->chancnt - 1;
++	do {
++		/*
++		 * on mt7621. when verify with dmatest with all
++		 * channel is enable. we need to limit only two
++		 * channel is working at the same time. otherwise the
++		 * data will have problem.
++		 */
++		if (atomic_read(&dma_dev->cnt) >= 2) {
++			last_chan = i;
++			break;
++		}
 +
-+	return dma_get_slave_channel(&(dma_dev->chan[request].vchan.chan));
++		if (test_and_clear_bit(i, &dma_dev->chan_issued)) {
++			chan = &dma_dev->chan[i];
++			if (chan->desc) {
++				atomic_inc(&dma_dev->cnt);
++				gdma_start_transfer(dma_dev, chan);
++			} else
++				dev_dbg(dma_dev->ddev.dev, "chan %d no desc to issue\n", chan->id);
++
++			if (!dma_dev->chan_issued)
++				break;
++		}
++
++		i = (i + 1) & chan_mask;
++	} while (i != last_chan);
 +}
++
++static void rt305x_gdma_init(struct gdma_dma_dev *dma_dev)
++{
++	uint32_t gct;
++
++	/* all chans round robin */
++	gdma_dma_write(dma_dev, GDMA_RT305X_GCT, GDMA_REG_GCT_ARBIT_RR);
++
++	gct = gdma_dma_read(dma_dev, GDMA_RT305X_GCT);
++	dev_info(dma_dev->ddev.dev, "revision: %d, channels: %d\n",
++			(gct >> GDMA_REG_GCT_VER_SHIFT) & GDMA_REG_GCT_VER_MASK,
++			8 << ((gct >> GDMA_REG_GCT_CHAN_SHIFT) &
++				GDMA_REG_GCT_CHAN_MASK));
++}
++
++static void rt3883_gdma_init(struct gdma_dma_dev *dma_dev)
++{
++	uint32_t gct;
++
++	/* all chans round robin */
++	gdma_dma_write(dma_dev, GDMA_REG_GCT, GDMA_REG_GCT_ARBIT_RR);
++
++	gct = gdma_dma_read(dma_dev, GDMA_REG_GCT);
++	dev_info(dma_dev->ddev.dev, "revision: %d, channels: %d\n",
++			(gct >> GDMA_REG_GCT_VER_SHIFT) & GDMA_REG_GCT_VER_MASK,
++			8 << ((gct >> GDMA_REG_GCT_CHAN_SHIFT) &
++				GDMA_REG_GCT_CHAN_MASK));
++}
++
++static struct gdma_data rt305x_gdma_data = {
++	.chancnt = 8,
++	.done_int_reg = GDMA_RT305X_STATUS_INT,
++	.init = rt305x_gdma_init,
++	.start_transfer = rt305x_gdma_start_transfer,
++};
++
++static struct gdma_data rt3883_gdma_data = {
++	.chancnt = 16,
++	.done_int_reg = GDMA_REG_DONE_INT,
++	.init = rt3883_gdma_init,
++	.start_transfer = rt3883_gdma_start_transfer,
++};
++
++static const struct of_device_id gdma_of_match_table[] = {
++	{ .compatible = "ralink,rt305x-gdma", .data = &rt305x_gdma_data },
++	{ .compatible = "ralink,rt3883-gdma", .data = &rt3883_gdma_data },
++	{ },
++};
 +
 +static int gdma_dma_probe(struct platform_device *pdev)
 +{
++	const struct of_device_id *match;
 +	struct gdma_dmaengine_chan *chan;
 +	struct gdma_dma_dev *dma_dev;
 +	struct dma_device *dd;
 +	unsigned int i;
 +	struct resource *res;
-+	uint32_t gct;
 +	int ret;
 +	int irq;
++	void __iomem *base;
++	struct gdma_data *data;
 +
++	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
++	if (ret)
++		return ret;
 +
-+	dma_dev = devm_kzalloc(&pdev->dev, sizeof(*dma_dev), GFP_KERNEL);
-+	if (!dma_dev)
++	match = of_match_device(gdma_of_match_table, &pdev->dev);
++	if (!match)
 +		return -EINVAL;
++	data = (struct gdma_data *) match->data;
 +
-+	dd = &dma_dev->ddev;
++	dma_dev = devm_kzalloc(&pdev->dev, sizeof(*dma_dev) +
++			(sizeof(struct gdma_dmaengine_chan) * data->chancnt),
++			GFP_KERNEL);
++	if (!dma_dev) {
++		dev_err(&pdev->dev, "alloc dma device failed\n");
++		return -EINVAL;
++	}
++	dma_dev->data = data;
 +
 +	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-+	dma_dev->base = devm_ioremap_resource(&pdev->dev, res);
-+	if (IS_ERR(dma_dev->base))
-+		return PTR_ERR(dma_dev->base);
++	base = devm_ioremap_resource(&pdev->dev, res);
++	if (IS_ERR(base))
++		return PTR_ERR(base);
++	dma_dev->base = base;
++	tasklet_init(&dma_dev->task, gdma_dma_tasklet, (unsigned long)dma_dev);
 +
++	irq = platform_get_irq(pdev, 0);
++	if (irq < 0) {
++		dev_err(&pdev->dev, "failed to get irq\n");
++		return -EINVAL;
++	}
++	ret = devm_request_irq(&pdev->dev, irq, gdma_dma_irq,
++			0, dev_name(&pdev->dev), dma_dev);
++	if (ret) {
++		dev_err(&pdev->dev, "failed to request irq\n");
++		return ret;
++	}
++
++	device_reset(&pdev->dev);
++
++	dd = &dma_dev->ddev;
++	dma_cap_set(DMA_MEMCPY, dd->cap_mask);
 +	dma_cap_set(DMA_SLAVE, dd->cap_mask);
 +	dma_cap_set(DMA_CYCLIC, dd->cap_mask);
-+	dd->device_alloc_chan_resources = gdma_dma_alloc_chan_resources;
 +	dd->device_free_chan_resources = gdma_dma_free_chan_resources;
-+	dd->device_tx_status = gdma_dma_tx_status;
-+	dd->device_issue_pending = gdma_dma_issue_pending;
++	dd->device_prep_dma_memcpy = gdma_dma_prep_dma_memcpy;
 +	dd->device_prep_slave_sg = gdma_dma_prep_slave_sg;
 +	dd->device_prep_dma_cyclic = gdma_dma_prep_dma_cyclic;
-+	dd->device_control = gdma_dma_control;
++	dd->device_config = gdma_dma_config;
++	dd->device_terminate_all = gdma_dma_terminate_all;
++	dd->device_tx_status = gdma_dma_tx_status;
++	dd->device_issue_pending = gdma_dma_issue_pending;
++
++	dd->src_addr_widths = BIT(DMA_SLAVE_BUSWIDTH_4_BYTES);
++	dd->dst_addr_widths = BIT(DMA_SLAVE_BUSWIDTH_4_BYTES);
++	dd->directions = BIT(DMA_DEV_TO_MEM) | BIT(DMA_MEM_TO_DEV);
++	dd->residue_granularity = DMA_RESIDUE_GRANULARITY_SEGMENT;
++
 +	dd->dev = &pdev->dev;
-+	dd->chancnt = GDMA_NR_CHANS;
++	dd->dev->dma_parms = &dma_dev->dma_parms;
++	dma_set_max_seg_size(dd->dev, GDMA_REG_CTRL0_TX_MASK);
 +	INIT_LIST_HEAD(&dd->channels);
 +
-+	for (i = 0; i < dd->chancnt; i++) {
++	for (i = 0; i < data->chancnt; i++) {
 +		chan = &dma_dev->chan[i];
 +		chan->id = i;
 +		chan->vchan.desc_free = gdma_dma_desc_free;
 +		vchan_init(&chan->vchan, dd);
 +	}
 +
++	/* init hardware */
++	data->init(dma_dev);
++
 +	ret = dma_async_device_register(dd);
-+	if (ret)
++	if (ret) {
++		dev_err(&pdev->dev, "failed to register dma device\n");
 +		return ret;
++	}
 +
 +	ret = of_dma_controller_register(pdev->dev.of_node,
 +		of_dma_xlate_by_chan_id, dma_dev);
-+	if (ret)
++	if (ret) {
++		dev_err(&pdev->dev, "failed to register of dma controller\n");
 +		goto err_unregister;
++	}
 +
-+	irq = platform_get_irq(pdev, 0);
-+	ret = request_irq(irq, gdma_dma_irq, 0, dev_name(&pdev->dev), dma_dev);
-+	if (ret)
-+		goto err_unregister;
-+
-+	gdma_dma_write(dma_dev, GDMA_REG_UNMASK_INT, 0);
-+	gdma_dma_write(dma_dev, GDMA_REG_DONE_INT, BIT(dd->chancnt) - 1);
-+
-+	gct = gdma_dma_read(dma_dev, GDMA_REG_GCT);
-+	dev_info(&pdev->dev, "revision: %d, channels: %d\n",
-+		(gct >> GDMA_REG_GCT_VER_SHIFT) & GDMA_REG_GCT_VER_MASK,
-+		8 << ((gct >> GDMA_REG_GCT_CHAN_SHIFT) & GDMA_REG_GCT_CHAN_MASK));
 +	platform_set_drvdata(pdev, dma_dev);
-+
-+	gdma_dma_write(dma_dev, GDMA_REG_GCT, GDMA_REG_GCT_ARBIT_RR);
 +
 +	return 0;
 +
@@ -588,34 +953,27 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static int gdma_dma_remove(struct platform_device *pdev)
 +{
 +	struct gdma_dma_dev *dma_dev = platform_get_drvdata(pdev);
-+	int irq = platform_get_irq(pdev, 0);
 +
-+	free_irq(irq, dma_dev);
++	tasklet_kill(&dma_dev->task);
 +        of_dma_controller_free(pdev->dev.of_node);
 +	dma_async_device_unregister(&dma_dev->ddev);
 +
 +	return 0;
 +}
 +
-+static const struct of_device_id gdma_of_match_table[] = {
-+	{ .compatible = "ralink,rt2880-gdma" },
-+	{ },
-+};
-+
 +static struct platform_driver gdma_dma_driver = {
 +	.probe = gdma_dma_probe,
 +	.remove = gdma_dma_remove,
 +	.driver = {
 +		.name = "gdma-rt2880",
-+		.owner = THIS_MODULE,
 +		.of_match_table = gdma_of_match_table,
 +	},
 +};
 +module_platform_driver(gdma_dma_driver);
 +
 +MODULE_AUTHOR("Lars-Peter Clausen <lars@metafoo.de>");
-+MODULE_DESCRIPTION("GDMA4740 DMA driver");
-+MODULE_LICENSE("GPLv2");
++MODULE_DESCRIPTION("Ralink/MTK DMA driver");
++MODULE_LICENSE("GPL v2");
 --- a/include/linux/dmaengine.h
 +++ b/include/linux/dmaengine.h
 @@ -496,6 +496,7 @@ static inline void dma_set_unmap(struct
@@ -626,3 +984,773 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  #else
  static inline void dma_set_unmap(struct dma_async_tx_descriptor *tx,
  				 struct dmaengine_unmap_data *unmap)
+--- /dev/null
++++ b/drivers/dma/mtk-hsdma.c
+@@ -0,0 +1,767 @@
++/*
++ *  Copyright (C) 2015, Michael Lee <igvtee@gmail.com>
++ *  MTK HSDMA support
++ *
++ *  This program is free software; you can redistribute it and/or modify it
++ *  under  the terms of the GNU General	 Public License as published by the
++ *  Free Software Foundation;  either version 2 of the License, or (at your
++ *  option) any later version.
++ *
++ */
++
++#include <linux/dmaengine.h>
++#include <linux/dma-mapping.h>
++#include <linux/err.h>
++#include <linux/init.h>
++#include <linux/list.h>
++#include <linux/module.h>
++#include <linux/platform_device.h>
++#include <linux/slab.h>
++#include <linux/spinlock.h>
++#include <linux/irq.h>
++#include <linux/of_dma.h>
++#include <linux/reset.h>
++#include <linux/of_device.h>
++
++#include "virt-dma.h"
++
++#define HSDMA_BASE_OFFSET		0x800
++
++#define HSDMA_REG_TX_BASE		0x00
++#define HSDMA_REG_TX_CNT		0x04
++#define HSDMA_REG_TX_CTX		0x08
++#define HSDMA_REG_TX_DTX		0x0c
++#define HSDMA_REG_RX_BASE		0x100
++#define HSDMA_REG_RX_CNT		0x104
++#define HSDMA_REG_RX_CRX		0x108
++#define HSDMA_REG_RX_DRX		0x10c
++#define HSDMA_REG_INFO			0x200
++#define HSDMA_REG_GLO_CFG		0x204
++#define HSDMA_REG_RST_CFG		0x208
++#define HSDMA_REG_DELAY_INT		0x20c
++#define HSDMA_REG_FREEQ_THRES		0x210
++#define HSDMA_REG_INT_STATUS		0x220
++#define HSDMA_REG_INT_MASK		0x228
++#define HSDMA_REG_SCH_Q01		0x280
++#define HSDMA_REG_SCH_Q23		0x284
++
++#define HSDMA_DESCS_MAX			0xfff
++#define HSDMA_DESCS_NUM			8
++#define HSDMA_DESCS_MASK		(HSDMA_DESCS_NUM - 1)
++#define HSDMA_NEXT_DESC(x)		(((x) + 1) & HSDMA_DESCS_MASK)
++
++/* HSDMA_REG_INFO */
++#define HSDMA_INFO_INDEX_MASK		0xf
++#define HSDMA_INFO_INDEX_SHIFT		24
++#define HSDMA_INFO_BASE_MASK		0xff
++#define HSDMA_INFO_BASE_SHIFT		16
++#define HSDMA_INFO_RX_MASK		0xff
++#define HSDMA_INFO_RX_SHIFT		8
++#define HSDMA_INFO_TX_MASK		0xff
++#define HSDMA_INFO_TX_SHIFT		0
++
++/* HSDMA_REG_GLO_CFG */
++#define HSDMA_GLO_TX_2B_OFFSET		BIT(31)
++#define HSDMA_GLO_CLK_GATE		BIT(30)
++#define HSDMA_GLO_BYTE_SWAP		BIT(29)
++#define HSDMA_GLO_MULTI_DMA		BIT(10)
++#define HSDMA_GLO_TWO_BUF		BIT(9)
++#define HSDMA_GLO_32B_DESC		BIT(8)
++#define HSDMA_GLO_BIG_ENDIAN		BIT(7)
++#define HSDMA_GLO_TX_DONE		BIT(6)
++#define HSDMA_GLO_BT_MASK		0x3
++#define HSDMA_GLO_BT_SHIFT		4
++#define HSDMA_GLO_RX_BUSY		BIT(3)
++#define HSDMA_GLO_RX_DMA		BIT(2)
++#define HSDMA_GLO_TX_BUSY		BIT(1)
++#define HSDMA_GLO_TX_DMA		BIT(0)
++
++#define HSDMA_BT_SIZE_16BYTES		(0 << HSDMA_GLO_BT_SHIFT)
++#define HSDMA_BT_SIZE_32BYTES		(1 << HSDMA_GLO_BT_SHIFT)
++#define HSDMA_BT_SIZE_64BYTES		(2 << HSDMA_GLO_BT_SHIFT)
++#define HSDMA_BT_SIZE_128BYTES		(3 << HSDMA_GLO_BT_SHIFT)
++
++#define HSDMA_GLO_DEFAULT		(HSDMA_GLO_MULTI_DMA | \
++		HSDMA_GLO_RX_DMA | HSDMA_GLO_TX_DMA | HSDMA_BT_SIZE_32BYTES)
++
++/* HSDMA_REG_RST_CFG */
++#define HSDMA_RST_RX_SHIFT		16
++#define HSDMA_RST_TX_SHIFT		0
++
++/* HSDMA_REG_DELAY_INT */
++#define HSDMA_DELAY_INT_EN		BIT(15)
++#define HSDMA_DELAY_PEND_OFFSET		8
++#define HSDMA_DELAY_TIME_OFFSET		0
++#define HSDMA_DELAY_TX_OFFSET		16
++#define HSDMA_DELAY_RX_OFFSET		0
++
++#define HSDMA_DELAY_INIT(x)		(HSDMA_DELAY_INT_EN | \
++		((x) << HSDMA_DELAY_PEND_OFFSET))
++#define HSDMA_DELAY(x)			((HSDMA_DELAY_INIT(x) << \
++		HSDMA_DELAY_TX_OFFSET) | HSDMA_DELAY_INIT(x))
++
++/* HSDMA_REG_INT_STATUS */
++#define HSDMA_INT_DELAY_RX_COH		BIT(31)
++#define HSDMA_INT_DELAY_RX_INT		BIT(30)
++#define HSDMA_INT_DELAY_TX_COH		BIT(29)
++#define HSDMA_INT_DELAY_TX_INT		BIT(28)
++#define HSDMA_INT_RX_MASK		0x3
++#define HSDMA_INT_RX_SHIFT		16
++#define HSDMA_INT_RX_Q0			BIT(16)
++#define HSDMA_INT_TX_MASK		0xf
++#define HSDMA_INT_TX_SHIFT		0
++#define HSDMA_INT_TX_Q0			BIT(0)
++
++/* tx/rx dma desc flags */
++#define HSDMA_PLEN_MASK			0x3fff
++#define HSDMA_DESC_DONE			BIT(31)
++#define HSDMA_DESC_LS0			BIT(30)
++#define HSDMA_DESC_PLEN0(_x)		(((_x) & HSDMA_PLEN_MASK) << 16)
++#define HSDMA_DESC_TAG			BIT(15)
++#define HSDMA_DESC_LS1			BIT(14)
++#define HSDMA_DESC_PLEN1(_x)		((_x) & HSDMA_PLEN_MASK)
++
++/* align 4 bytes */
++#define HSDMA_ALIGN_SIZE		3
++/* align size 128bytes */
++#define HSDMA_MAX_PLEN			0x3f80
++
++struct hsdma_desc {
++	u32 addr0;
++	u32 flags;
++	u32 addr1;
++	u32 unused;
++};
++
++struct mtk_hsdma_sg {
++	dma_addr_t src_addr;
++	dma_addr_t dst_addr;
++	u32 len;
++};
++
++struct mtk_hsdma_desc {
++	struct virt_dma_desc vdesc;
++	unsigned int num_sgs;
++	struct mtk_hsdma_sg sg[1];
++};
++
++struct mtk_hsdma_chan {
++	struct virt_dma_chan vchan;
++	unsigned int id;
++	dma_addr_t desc_addr;
++	int tx_idx;
++	int rx_idx;
++	struct hsdma_desc *tx_ring;
++	struct hsdma_desc *rx_ring;
++	struct mtk_hsdma_desc *desc;
++	unsigned int next_sg;
++};
++
++struct mtk_hsdam_engine {
++	struct dma_device ddev;
++	struct device_dma_parameters dma_parms;
++	void __iomem *base;
++	struct tasklet_struct task;
++	volatile unsigned long chan_issued;
++
++	struct mtk_hsdma_chan chan[1];
++};
++
++static inline struct mtk_hsdam_engine *mtk_hsdma_chan_get_dev(
++		struct mtk_hsdma_chan *chan)
++{
++	return container_of(chan->vchan.chan.device, struct mtk_hsdam_engine,
++			ddev);
++}
++
++static inline struct mtk_hsdma_chan *to_mtk_hsdma_chan(struct dma_chan *c)
++{
++	return container_of(c, struct mtk_hsdma_chan, vchan.chan);
++}
++
++static inline struct mtk_hsdma_desc *to_mtk_hsdma_desc(
++		struct virt_dma_desc *vdesc)
++{
++	return container_of(vdesc, struct mtk_hsdma_desc, vdesc);
++}
++
++static inline u32 mtk_hsdma_read(struct mtk_hsdam_engine *hsdma, u32 reg)
++{
++	return readl(hsdma->base + reg);
++}
++
++static inline void mtk_hsdma_write(struct mtk_hsdam_engine *hsdma,
++		unsigned reg, u32 val)
++{
++	writel(val, hsdma->base + reg);
++}
++
++static void mtk_hsdma_reset_chan(struct mtk_hsdam_engine *hsdma,
++		struct mtk_hsdma_chan *chan)
++{
++	chan->tx_idx = 0;
++	chan->rx_idx = HSDMA_DESCS_NUM - 1;
++
++	mtk_hsdma_write(hsdma, HSDMA_REG_TX_CTX, chan->tx_idx);
++	mtk_hsdma_write(hsdma, HSDMA_REG_RX_CRX, chan->rx_idx);
++
++	mtk_hsdma_write(hsdma, HSDMA_REG_RST_CFG,
++			0x1 << (chan->id + HSDMA_RST_TX_SHIFT));
++	mtk_hsdma_write(hsdma, HSDMA_REG_RST_CFG,
++			0x1 << (chan->id + HSDMA_RST_RX_SHIFT));
++}
++
++static void hsdma_dump_reg(struct mtk_hsdam_engine *hsdma)
++{
++	dev_dbg(hsdma->ddev.dev, "tbase %08x, tcnt %08x, " \
++			"tctx %08x, tdtx: %08x, rbase %08x, " \
++			"rcnt %08x, rctx %08x, rdtx %08x\n",
++			mtk_hsdma_read(hsdma, HSDMA_REG_TX_BASE),
++			mtk_hsdma_read(hsdma, HSDMA_REG_TX_CNT),
++			mtk_hsdma_read(hsdma, HSDMA_REG_TX_CTX),
++			mtk_hsdma_read(hsdma, HSDMA_REG_TX_DTX),
++			mtk_hsdma_read(hsdma, HSDMA_REG_RX_BASE),
++			mtk_hsdma_read(hsdma, HSDMA_REG_RX_CNT),
++			mtk_hsdma_read(hsdma, HSDMA_REG_RX_CRX),
++			mtk_hsdma_read(hsdma, HSDMA_REG_RX_DRX));
++
++	dev_dbg(hsdma->ddev.dev, "info %08x, glo %08x, delay %08x, " \
++			"intr_stat %08x, intr_mask %08x\n",
++			mtk_hsdma_read(hsdma, HSDMA_REG_INFO),
++			mtk_hsdma_read(hsdma, HSDMA_REG_GLO_CFG),
++			mtk_hsdma_read(hsdma, HSDMA_REG_DELAY_INT),
++			mtk_hsdma_read(hsdma, HSDMA_REG_INT_STATUS),
++			mtk_hsdma_read(hsdma, HSDMA_REG_INT_MASK));
++}
++
++static void hsdma_dump_desc(struct mtk_hsdam_engine *hsdma,
++		struct mtk_hsdma_chan *chan)
++{
++	struct hsdma_desc *tx_desc;
++	struct hsdma_desc *rx_desc;
++	int i;
++
++	dev_dbg(hsdma->ddev.dev, "tx idx: %d, rx idx: %d\n",
++			chan->tx_idx, chan->rx_idx);
++
++	for (i = 0; i < HSDMA_DESCS_NUM; i++) {
++		tx_desc = &chan->tx_ring[i];
++		rx_desc = &chan->rx_ring[i];
++
++		dev_dbg(hsdma->ddev.dev, "%d tx addr0: %08x, flags %08x, " \
++				"tx addr1: %08x, rx addr0 %08x, flags %08x\n",
++				i, tx_desc->addr0, tx_desc->flags, \
++				tx_desc->addr1, rx_desc->addr0, rx_desc->flags);
++	}
++}
++
++static void mtk_hsdma_reset(struct mtk_hsdam_engine *hsdma,
++		struct mtk_hsdma_chan *chan)
++{
++	int i;
++
++	/* disable dma */
++	mtk_hsdma_write(hsdma, HSDMA_REG_GLO_CFG, 0);
++
++	/* disable intr */
++	mtk_hsdma_write(hsdma, HSDMA_REG_INT_MASK, 0);
++
++	/* init desc value */
++	for (i = 0; i < HSDMA_DESCS_NUM; i++) {
++		chan->tx_ring[i].addr0 = 0;
++		chan->tx_ring[i].flags = HSDMA_DESC_LS0 |
++			HSDMA_DESC_DONE;
++	}
++	for (i = 0; i < HSDMA_DESCS_NUM; i++) {
++		chan->rx_ring[i].addr0 = 0;
++		chan->rx_ring[i].flags = 0;
++	}
++
++	/* reset */
++	mtk_hsdma_reset_chan(hsdma, chan);
++
++	/* enable intr */
++	mtk_hsdma_write(hsdma, HSDMA_REG_INT_MASK, HSDMA_INT_RX_Q0);
++
++	/* enable dma */
++	mtk_hsdma_write(hsdma, HSDMA_REG_GLO_CFG, HSDMA_GLO_DEFAULT);
++}
++
++static int mtk_hsdma_terminate_all(struct dma_chan *c)
++{
++	struct mtk_hsdma_chan *chan = to_mtk_hsdma_chan(c);
++	struct mtk_hsdam_engine *hsdma = mtk_hsdma_chan_get_dev(chan);
++	unsigned long timeout;
++	LIST_HEAD(head);
++
++	spin_lock_bh(&chan->vchan.lock);
++	chan->desc = NULL;
++	clear_bit(chan->id, &hsdma->chan_issued);
++	vchan_get_all_descriptors(&chan->vchan, &head);
++	spin_unlock_bh(&chan->vchan.lock);
++
++	vchan_dma_desc_free_list(&chan->vchan, &head);
++
++	/* wait dma transfer complete */
++	timeout = jiffies + msecs_to_jiffies(2000);
++	while (mtk_hsdma_read(hsdma, HSDMA_REG_GLO_CFG) &
++			(HSDMA_GLO_RX_BUSY | HSDMA_GLO_TX_BUSY)) {
++		if (time_after_eq(jiffies, timeout)) {
++			hsdma_dump_desc(hsdma, chan);
++			mtk_hsdma_reset(hsdma, chan);
++			dev_err(hsdma->ddev.dev, "timeout, reset it\n");
++			break;
++		}
++		cpu_relax();
++	}
++
++	return 0;
++}
++
++static int mtk_hsdma_start_transfer(struct mtk_hsdam_engine *hsdma,
++		struct mtk_hsdma_chan *chan)
++{
++	dma_addr_t src, dst;
++	size_t len, tlen;
++	struct hsdma_desc *tx_desc, *rx_desc;
++	struct mtk_hsdma_sg *sg;
++	unsigned int i;
++	int rx_idx;
++
++	sg = &chan->desc->sg[0];
++	len = sg->len;
++	chan->desc->num_sgs = DIV_ROUND_UP(len, HSDMA_MAX_PLEN);
++
++	/* tx desc */
++	src = sg->src_addr;
++	for (i = 0; i < chan->desc->num_sgs; i++) {
++		if (len > HSDMA_MAX_PLEN)
++			tlen = HSDMA_MAX_PLEN;
++		else
++			tlen = len;
++
++		if (i & 0x1) {
++			tx_desc->addr1 = src;
++			tx_desc->flags |= HSDMA_DESC_PLEN1(tlen);
++		} else {
++			tx_desc = &chan->tx_ring[chan->tx_idx];
++			tx_desc->addr0 = src;
++			tx_desc->flags = HSDMA_DESC_PLEN0(tlen);
++
++			/* update index */
++			chan->tx_idx = HSDMA_NEXT_DESC(chan->tx_idx);
++		}
++
++		src += tlen;
++		len -= tlen;
++	}
++	if (i & 0x1)
++		tx_desc->flags |= HSDMA_DESC_LS0;
++	else
++		tx_desc->flags |= HSDMA_DESC_LS1;
++
++	/* rx desc */
++	rx_idx = HSDMA_NEXT_DESC(chan->rx_idx);
++	len = sg->len;
++	dst = sg->dst_addr;
++	for (i = 0; i < chan->desc->num_sgs; i++) {
++		rx_desc = &chan->rx_ring[rx_idx];
++		if (len > HSDMA_MAX_PLEN)
++			tlen = HSDMA_MAX_PLEN;
++		else
++			tlen = len;
++
++		rx_desc->addr0 = dst;
++		rx_desc->flags = HSDMA_DESC_PLEN0(tlen);
++
++		dst += tlen;
++		len -= tlen;
++
++		/* update index */
++		rx_idx = HSDMA_NEXT_DESC(rx_idx);
++	}
++
++	/* make sure desc and index all up to date */
++	wmb();
++	mtk_hsdma_write(hsdma, HSDMA_REG_TX_CTX, chan->tx_idx);
++
++	return 0;
++}
++
++static int gdma_next_desc(struct mtk_hsdma_chan *chan)
++{
++	struct virt_dma_desc *vdesc;
++
++	vdesc = vchan_next_desc(&chan->vchan);
++	if (!vdesc) {
++		chan->desc = NULL;
++		return 0;
++	}
++	chan->desc = to_mtk_hsdma_desc(vdesc);
++	chan->next_sg = 0;
++
++	return 1;
++}
++
++static void mtk_hsdma_chan_done(struct mtk_hsdam_engine *hsdma,
++		struct mtk_hsdma_chan *chan)
++{
++	struct mtk_hsdma_desc *desc;
++	int chan_issued;
++
++	chan_issued = 0;
++	spin_lock_bh(&chan->vchan.lock);
++	desc = chan->desc;
++	if (likely(desc)) {
++		if (chan->next_sg == desc->num_sgs) {
++			list_del(&desc->vdesc.node);
++			vchan_cookie_complete(&desc->vdesc);
++			chan_issued = gdma_next_desc(chan);
++		}
++	} else
++		dev_dbg(hsdma->ddev.dev, "no desc to complete\n");
++
++	if (chan_issued)
++		set_bit(chan->id, &hsdma->chan_issued);
++	spin_unlock_bh(&chan->vchan.lock);
++}
++
++static irqreturn_t mtk_hsdma_irq(int irq, void *devid)
++{
++	struct mtk_hsdam_engine *hsdma = devid;
++	u32 status;
++
++	status = mtk_hsdma_read(hsdma, HSDMA_REG_INT_STATUS);
++	if (unlikely(!status))
++		return IRQ_NONE;
++
++	if (likely(status & HSDMA_INT_RX_Q0))
++		tasklet_schedule(&hsdma->task);
++	else
++		dev_dbg(hsdma->ddev.dev, "unhandle irq status %08x\n",
++				status);
++	/* clean intr bits */
++	mtk_hsdma_write(hsdma, HSDMA_REG_INT_STATUS, status);
++
++	return IRQ_HANDLED;
++}
++
++static void mtk_hsdma_issue_pending(struct dma_chan *c)
++{
++	struct mtk_hsdma_chan *chan = to_mtk_hsdma_chan(c);
++	struct mtk_hsdam_engine *hsdma = mtk_hsdma_chan_get_dev(chan);
++
++	spin_lock_bh(&chan->vchan.lock);
++	if (vchan_issue_pending(&chan->vchan) && !chan->desc) {
++		if (gdma_next_desc(chan)) {
++			set_bit(chan->id, &hsdma->chan_issued);
++			tasklet_schedule(&hsdma->task);
++		} else
++			dev_dbg(hsdma->ddev.dev, "no desc to issue\n");
++	}
++	spin_unlock_bh(&chan->vchan.lock);
++}
++
++static struct dma_async_tx_descriptor * mtk_hsdma_prep_dma_memcpy(
++		struct dma_chan *c, dma_addr_t dest, dma_addr_t src,
++		size_t len, unsigned long flags)
++{
++	struct mtk_hsdma_chan *chan = to_mtk_hsdma_chan(c);
++	struct mtk_hsdma_desc *desc;
++
++	if (len <= 0)
++		return NULL;
++
++	desc = kzalloc(sizeof(struct mtk_hsdma_desc), GFP_ATOMIC);
++	if (!desc) {
++		dev_err(c->device->dev, "alloc memcpy decs error\n");
++		return NULL;
++	}
++
++	desc->sg[0].src_addr = src;
++	desc->sg[0].dst_addr = dest;
++	desc->sg[0].len = len;
++
++	return vchan_tx_prep(&chan->vchan, &desc->vdesc, flags);
++}
++
++static enum dma_status mtk_hsdma_tx_status(struct dma_chan *c,
++		dma_cookie_t cookie, struct dma_tx_state *state)
++{
++	return dma_cookie_status(c, cookie, state);
++}
++
++static void mtk_hsdma_free_chan_resources(struct dma_chan *c)
++{
++	vchan_free_chan_resources(to_virt_chan(c));
++}
++
++static void mtk_hsdma_desc_free(struct virt_dma_desc *vdesc)
++{
++	kfree(container_of(vdesc, struct mtk_hsdma_desc, vdesc));
++}
++
++static void mtk_hsdma_tx(struct mtk_hsdam_engine *hsdma)
++{
++	struct mtk_hsdma_chan *chan;
++
++	if (test_and_clear_bit(0, &hsdma->chan_issued)) {
++		chan = &hsdma->chan[0];
++		if (chan->desc) {
++			mtk_hsdma_start_transfer(hsdma, chan);
++		} else
++			dev_dbg(hsdma->ddev.dev,"chan 0 no desc to issue\n");
++	}
++}
++
++static void mtk_hsdma_rx(struct mtk_hsdam_engine *hsdma)
++{
++	struct mtk_hsdma_chan *chan;
++	int next_idx, drx_idx, cnt;
++
++	chan = &hsdma->chan[0];
++	next_idx = HSDMA_NEXT_DESC(chan->rx_idx);
++	drx_idx = mtk_hsdma_read(hsdma, HSDMA_REG_RX_DRX);
++
++	cnt = (drx_idx - next_idx) & HSDMA_DESCS_MASK;
++	if (!cnt)
++		return;
++
++	chan->next_sg += cnt;
++	chan->rx_idx = (chan->rx_idx + cnt) & HSDMA_DESCS_MASK;
++
++	/* update rx crx */
++	wmb();
++	mtk_hsdma_write(hsdma, HSDMA_REG_RX_CRX, chan->rx_idx);
++
++	mtk_hsdma_chan_done(hsdma, chan);
++}
++
++static void mtk_hsdma_tasklet(unsigned long arg)
++{
++	struct mtk_hsdam_engine *hsdma = (struct mtk_hsdam_engine *)arg;
++
++	mtk_hsdma_rx(hsdma);
++	mtk_hsdma_tx(hsdma);
++}
++
++static int mtk_hsdam_alloc_desc(struct mtk_hsdam_engine *hsdma,
++		struct mtk_hsdma_chan *chan)
++{
++	int i;
++
++	chan->tx_ring = dma_alloc_coherent(hsdma->ddev.dev,
++			2 * HSDMA_DESCS_NUM * sizeof(*chan->tx_ring),
++			&chan->desc_addr, GFP_ATOMIC | __GFP_ZERO);
++	if (!chan->tx_ring)
++		goto no_mem;
++
++	chan->rx_ring = &chan->tx_ring[HSDMA_DESCS_NUM];
++
++	/* init tx ring value */
++	for (i = 0; i < HSDMA_DESCS_NUM; i++)
++		chan->tx_ring[i].flags = HSDMA_DESC_LS0 | HSDMA_DESC_DONE;
++
++	return 0;
++no_mem:
++	return -ENOMEM;
++}
++
++static void mtk_hsdam_free_desc(struct mtk_hsdam_engine *hsdma,
++		struct mtk_hsdma_chan *chan)
++{
++	if (chan->tx_ring) {
++		dma_free_coherent(hsdma->ddev.dev,
++				2 * HSDMA_DESCS_NUM * sizeof(*chan->tx_ring),
++				chan->tx_ring, chan->desc_addr);
++		chan->tx_ring = NULL;
++		chan->rx_ring = NULL;
++	}
++}
++
++static int mtk_hsdma_init(struct mtk_hsdam_engine *hsdma)
++{
++	struct mtk_hsdma_chan *chan;
++	int ret;
++	u32 reg;
++
++	/* init desc */
++	chan = &hsdma->chan[0];
++	ret = mtk_hsdam_alloc_desc(hsdma, chan);
++	if (ret)
++		return ret;
++
++	/* tx */
++	mtk_hsdma_write(hsdma, HSDMA_REG_TX_BASE, chan->desc_addr);
++	mtk_hsdma_write(hsdma, HSDMA_REG_TX_CNT, HSDMA_DESCS_NUM);
++	/* rx */
++	mtk_hsdma_write(hsdma, HSDMA_REG_RX_BASE, chan->desc_addr +
++			(sizeof(struct hsdma_desc) * HSDMA_DESCS_NUM));
++	mtk_hsdma_write(hsdma, HSDMA_REG_RX_CNT, HSDMA_DESCS_NUM);
++	/* reset */
++	mtk_hsdma_reset_chan(hsdma, chan);
++
++	/* enable rx intr */
++	mtk_hsdma_write(hsdma, HSDMA_REG_INT_MASK, HSDMA_INT_RX_Q0);
++
++	/* enable dma */
++	mtk_hsdma_write(hsdma, HSDMA_REG_GLO_CFG, HSDMA_GLO_DEFAULT);
++
++	/* hardware info */
++	reg = mtk_hsdma_read(hsdma, HSDMA_REG_INFO);
++	dev_info(hsdma->ddev.dev, "rx: %d, tx: %d\n",
++			(reg >> HSDMA_INFO_RX_SHIFT) & HSDMA_INFO_RX_MASK,
++			(reg >> HSDMA_INFO_TX_SHIFT) & HSDMA_INFO_TX_MASK);
++
++	hsdma_dump_reg(hsdma);
++
++	return ret;
++}
++
++static void mtk_hsdma_uninit(struct mtk_hsdam_engine *hsdma)
++{
++	struct mtk_hsdma_chan *chan;
++
++	/* disable dma */
++	mtk_hsdma_write(hsdma, HSDMA_REG_GLO_CFG, 0);
++
++	/* disable intr */
++	mtk_hsdma_write(hsdma, HSDMA_REG_INT_MASK, 0);
++
++	/* free desc */
++	chan = &hsdma->chan[0];
++	mtk_hsdam_free_desc(hsdma, chan);
++
++	/* tx */
++	mtk_hsdma_write(hsdma, HSDMA_REG_TX_BASE, 0);
++	mtk_hsdma_write(hsdma, HSDMA_REG_TX_CNT, 0);
++	/* rx */
++	mtk_hsdma_write(hsdma, HSDMA_REG_RX_BASE, 0);
++	mtk_hsdma_write(hsdma, HSDMA_REG_RX_CNT, 0);
++	/* reset */
++	mtk_hsdma_reset_chan(hsdma, chan);
++}
++
++static const struct of_device_id mtk_hsdma_of_match[] = {
++	{ .compatible = "mediatek,mt7621-hsdma" },
++	{ },
++};
++
++static int mtk_hsdma_probe(struct platform_device *pdev)
++{
++	const struct of_device_id *match;
++	struct mtk_hsdma_chan *chan;
++	struct mtk_hsdam_engine *hsdma;
++	struct dma_device *dd;
++	struct resource *res;
++	int ret;
++	int irq;
++	void __iomem *base;
++
++	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
++	if (ret)
++		return ret;
++
++	match = of_match_device(mtk_hsdma_of_match, &pdev->dev);
++	if (!match)
++		return -EINVAL;
++
++	hsdma = devm_kzalloc(&pdev->dev, sizeof(*hsdma), GFP_KERNEL);
++	if (!hsdma) {
++		dev_err(&pdev->dev, "alloc dma device failed\n");
++		return -EINVAL;
++	}
++
++	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
++	base = devm_ioremap_resource(&pdev->dev, res);
++	if (IS_ERR(base))
++		return PTR_ERR(base);
++	hsdma->base = base + HSDMA_BASE_OFFSET;
++	tasklet_init(&hsdma->task, mtk_hsdma_tasklet, (unsigned long)hsdma);
++
++	irq = platform_get_irq(pdev, 0);
++	if (irq < 0) {
++		dev_err(&pdev->dev, "failed to get irq\n");
++		return -EINVAL;
++	}
++	ret = devm_request_irq(&pdev->dev, irq, mtk_hsdma_irq,
++			0, dev_name(&pdev->dev), hsdma);
++	if (ret) {
++		dev_err(&pdev->dev, "failed to request irq\n");
++		return ret;
++	}
++
++	device_reset(&pdev->dev);
++
++	dd = &hsdma->ddev;
++	dma_cap_set(DMA_MEMCPY, dd->cap_mask);
++	dd->copy_align = HSDMA_ALIGN_SIZE;
++	dd->device_free_chan_resources = mtk_hsdma_free_chan_resources;
++	dd->device_prep_dma_memcpy = mtk_hsdma_prep_dma_memcpy;
++	dd->device_terminate_all = mtk_hsdma_terminate_all;
++	dd->device_tx_status = mtk_hsdma_tx_status;
++	dd->device_issue_pending = mtk_hsdma_issue_pending;
++	dd->dev = &pdev->dev;
++	dd->dev->dma_parms = &hsdma->dma_parms;
++	dma_set_max_seg_size(dd->dev, HSDMA_MAX_PLEN);
++	INIT_LIST_HEAD(&dd->channels);
++
++	chan = &hsdma->chan[0];
++	chan->id = 0;
++	chan->vchan.desc_free = mtk_hsdma_desc_free;
++	vchan_init(&chan->vchan, dd);
++
++	/* init hardware */
++	ret = mtk_hsdma_init(hsdma);
++	if (ret) {
++		dev_err(&pdev->dev, "failed to alloc ring descs\n");
++		return ret;
++	}
++
++	ret = dma_async_device_register(dd);
++	if (ret) {
++		dev_err(&pdev->dev, "failed to register dma device\n");
++		return ret;
++	}
++
++	ret = of_dma_controller_register(pdev->dev.of_node,
++			of_dma_xlate_by_chan_id, hsdma);
++	if (ret) {
++		dev_err(&pdev->dev, "failed to register of dma controller\n");
++		goto err_unregister;
++	}
++
++	platform_set_drvdata(pdev, hsdma);
++
++	return 0;
++
++err_unregister:
++	dma_async_device_unregister(dd);
++	return ret;
++}
++
++static int mtk_hsdma_remove(struct platform_device *pdev)
++{
++	struct mtk_hsdam_engine *hsdma = platform_get_drvdata(pdev);
++
++	mtk_hsdma_uninit(hsdma);
++
++	of_dma_controller_free(pdev->dev.of_node);
++	dma_async_device_unregister(&hsdma->ddev);
++
++	return 0;
++}
++
++static struct platform_driver mtk_hsdma_driver = {
++	.probe = mtk_hsdma_probe,
++	.remove = mtk_hsdma_remove,
++	.driver = {
++		.name = "hsdma-mt7621",
++		.of_match_table = mtk_hsdma_of_match,
++	},
++};
++module_platform_driver(mtk_hsdma_driver);
++
++MODULE_AUTHOR("Michael Lee <igvtee@gmail.com>");
++MODULE_DESCRIPTION("MTK HSDMA driver");
++MODULE_LICENSE("GPL v2");

--- a/target/linux/ramips/patches-4.4/0048-asoc-add-mt7620-support.patch
+++ b/target/linux/ramips/patches-4.4/0048-asoc-add-mt7620-support.patch
@@ -58,41 +58,30 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-$(CONFIG_SND_SOC)	+= sirf/
 --- /dev/null
 +++ b/sound/soc/ralink/Kconfig
-@@ -0,0 +1,15 @@
-+config SND_MT7620_SOC_I2S
-+	depends on SOC_MT7620 && SND_SOC
+@@ -0,0 +1,8 @@
++config SND_RALINK_SOC_I2S
++	depends on RALINK && SND_SOC && !SOC_RT288X
 +	select SND_SOC_GENERIC_DMAENGINE_PCM
-+	tristate "SoC Audio (I2S protocol) for Ralink MT7620 SoC"
++	select REGMAP_MMIO
++	tristate "SoC Audio (I2S protocol) for Ralink SoC"
 +	help
-+	  Say Y if you want to use I2S protocol and I2S codec on Ingenic MT7620
++	  Say Y if you want to use I2S protocol and I2S codec on Ralink/MediaTek
 +	  based boards.
-+
-+config SND_MT7620_SOC_WM8960
-+	tristate "SoC Audio support for Ralink WM8960"
-+	select SND_MT7620_SOC_I2S
-+	select SND_SOC_WM8960
-+	help
-+	  Say Y if you want to add support for ASoC audio on the Qi LB60 board
-+	  a.k.a Qi Ben NanoNote.
 --- /dev/null
 +++ b/sound/soc/ralink/Makefile
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,6 @@
 +#
-+# Jz4740 Platform Support
++# Ralink/MediaTek Platform Support
 +#
-+snd-soc-mt7620-i2s-objs := mt7620-i2s.o
++snd-soc-ralink-i2s-objs := ralink-i2s.o
 +
-+obj-$(CONFIG_SND_MT7620_SOC_I2S) += snd-soc-mt7620-i2s.o
-+
-+# Jz4740 Machine Support
-+snd-soc-mt7620-wm8960-objs := mt7620-wm8960.o
-+
-+obj-$(CONFIG_SND_MT7620_SOC_WM8960) += snd-soc-mt7620-wm8960.o
++obj-$(CONFIG_SND_RALINK_SOC_I2S) += snd-soc-ralink-i2s.o
 --- /dev/null
-+++ b/sound/soc/ralink/mt7620-i2s.c
-@@ -0,0 +1,436 @@
++++ b/sound/soc/ralink/ralink-i2s.c
+@@ -0,0 +1,965 @@
 +/*
 + *  Copyright (C) 2010, Lars-Peter Clausen <lars@metafoo.de>
++ *  Copyright (C) 2016 Michael Lee <igvtee@gmail.com>
 + *
 + *  This program is free software; you can redistribute it and/or modify it
 + *  under  the terms of the GNU General  Public License as published by the
@@ -105,27 +94,31 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 + *
 + */
 +
-+#include <linux/init.h>
-+#include <linux/io.h>
-+#include <linux/kernel.h>
 +#include <linux/module.h>
 +#include <linux/platform_device.h>
-+#include <linux/slab.h>
-+
-+#include <linux/delay.h>
-+
-+#include <linux/dma-mapping.h>
-+
-+#include <sound/core.h>
-+#include <sound/pcm.h>
++#include <linux/clk.h>
++#include <linux/regmap.h>
++#include <linux/reset.h>
++#include <linux/debugfs.h>
++#include <linux/of_device.h>
 +#include <sound/pcm_params.h>
-+#include <sound/soc.h>
-+#include <sound/initval.h>
 +#include <sound/dmaengine_pcm.h>
 +
-+#include <ralink_regs.h>
++#include <asm/mach-ralink/ralink_regs.h>
++
++#define DRV_NAME "ralink-i2s"
 +
 +#define I2S_REG_CFG0		0x00
++#define I2S_REG_INT_STATUS	0x04
++#define I2S_REG_INT_EN		0x08
++#define I2S_REG_FF_STATUS	0x0c
++#define I2S_REG_WREG		0x10
++#define I2S_REG_RREG		0x14
++#define I2S_REG_CFG1		0x18
++#define I2S_REG_DIVCMP		0x20
++#define I2S_REG_DIVINT		0x24
++
++/* I2S_REG_CFG0 */
 +#define I2S_REG_CFG0_EN		BIT(31)
 +#define I2S_REG_CFG0_DMA_EN	BIT(30)
 +#define I2S_REG_CFG0_BYTE_SWAP	BIT(28)
@@ -134,143 +127,235 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#define I2S_REG_CFG0_SLAVE	BIT(16)
 +#define I2S_REG_CFG0_RX_THRES	12
 +#define I2S_REG_CFG0_TX_THRES	4
++#define I2S_REG_CFG0_THRES_MASK	(0xf << I2S_REG_CFG0_RX_THRES) | \
++	(4 << I2S_REG_CFG0_TX_THRES)
 +#define I2S_REG_CFG0_DFT_THRES	(4 << I2S_REG_CFG0_RX_THRES) | \
-+					(4 << I2S_REG_CFG0_TX_THRES)
++	(4 << I2S_REG_CFG0_TX_THRES)
++/* RT305x */
++#define I2S_REG_CFG0_CLK_DIS	BIT(8)
++#define I2S_REG_CFG0_TXCH_SWAP	BIT(3)
++#define I2S_REG_CFG0_TXCH1_OFF	BIT(2)
++#define I2S_REG_CFG0_TXCH0_OFF	BIT(1)
++#define I2S_REG_CFG0_SLAVE_EN	BIT(0)
++/* RT3883 */
++#define I2S_REG_CFG0_RXCH_SWAP	BIT(11)
++#define I2S_REG_CFG0_RXCH1_OFF	BIT(10)
++#define I2S_REG_CFG0_RXCH0_OFF	BIT(9)
++#define I2S_REG_CFG0_WS_INV	BIT(0)
++/* MT7628 */
++#define I2S_REG_CFG0_FMT_LE	BIT(29)
++#define I2S_REG_CFG0_SYS_BE	BIT(28)
++#define I2S_REG_CFG0_NORM_24	BIT(18)
++#define I2S_REG_CFG0_DATA_24	BIT(17)
 +
-+#define I2S_REG_INT_STATUS	0x04
-+#define I2S_REG_INT_EN		0x08
-+#define I2S_REG_FF_STATUS	0x0c
-+#define I2S_REG_WREG		0x10
-+#define I2S_REG_RREG		0x14
-+#define I2S_REG_CFG1		0x18
++/* I2S_REG_INT_STATUS */
++#define I2S_REG_INT_RX_FAULT	BIT(7)
++#define I2S_REG_INT_RX_OVRUN	BIT(6)
++#define I2S_REG_INT_RX_UNRUN	BIT(5)
++#define I2S_REG_INT_RX_THRES	BIT(4)
++#define I2S_REG_INT_TX_FAULT	BIT(3)
++#define I2S_REG_INT_TX_OVRUN	BIT(2)
++#define I2S_REG_INT_TX_UNRUN	BIT(1)
++#define I2S_REG_INT_TX_THRES	BIT(0)
++#define I2S_REG_INT_TX_MASK	0xf
++#define I2S_REG_INT_RX_MASK	0xf0
 +
-+#define I2S_REG_DIVCMP		0x20
-+#define I2S_REG_DIVINT		0x24
-+#define I2S_REG_CLK_EN		BIT(31)
++/* I2S_REG_INT_STATUS */
++#define I2S_RX_AVCNT(x)		((x >> 4) & 0xf)
++#define I2S_TX_AVCNT(x)		(x & 0xf)
++/* MT7628 */
++#define MT7628_I2S_RX_AVCNT(x)	((x >> 8) & 0x1f)
++#define MT7628_I2S_TX_AVCNT(x)	(x & 0x1f)
 +
-+struct mt7620_i2s {
-+	struct resource *mem;
-+	void __iomem *base;
-+	dma_addr_t phys_base;
++/* I2S_REG_CFG1 */
++#define I2S_REG_CFG1_LBK	BIT(31)
++#define I2S_REG_CFG1_EXTLBK	BIT(30)
++/* RT3883 */
++#define I2S_REG_CFG1_LEFT_J	BIT(0)
++#define I2S_REG_CFG1_RIGHT_J	BIT(1)
++#define I2S_REG_CFG1_FMT_MASK	0x3
++
++/* I2S_REG_DIVCMP */
++#define I2S_REG_DIVCMP_CLKEN	BIT(31)
++#define I2S_REG_DIVCMP_DIVCOMP_MASK	0x1ff
++
++/* I2S_REG_DIVINT */
++#define I2S_REG_DIVINT_MASK	0x3ff
++
++/* BCLK dividers */
++#define RALINK_I2S_DIVCMP	0
++#define RALINK_I2S_DIVINT	1
++
++/* FIFO */
++#define RALINK_I2S_FIFO_SIZE	32
++
++/* feature flags */
++#define RALINK_FLAGS_TXONLY	BIT(0)
++#define RALINK_FLAGS_LEFT_J	BIT(1)
++#define RALINK_FLAGS_RIGHT_J	BIT(2)
++#define RALINK_FLAGS_ENDIAN	BIT(3)
++#define RALINK_FLAGS_24BIT	BIT(4)
++
++#define RALINK_I2S_INT_EN	0
++
++struct ralink_i2s_stats {
++	u32 dmafault;
++	u32 overrun;
++	u32 underrun;
++	u32 belowthres;
++};
++
++struct ralink_i2s {
++	struct device *dev;
++	void __iomem *regs;
++	struct clk *clk;
++	struct regmap *regmap;
++	u32 flags;
++	unsigned int fmt;
++	u16 txdma_req;
++	u16 rxdma_req;
 +
 +	struct snd_dmaengine_dai_dma_data playback_dma_data;
 +	struct snd_dmaengine_dai_dma_data capture_dma_data;
++
++	struct dentry *dbg_dir;
++        struct dentry *dbg_stats;
++	struct ralink_i2s_stats txstats;
++	struct ralink_i2s_stats rxstats;
 +};
 +
-+static inline uint32_t mt7620_i2s_read(const struct mt7620_i2s *i2s,
-+	unsigned int reg)
++static void ralink_i2s_dump_regs(struct ralink_i2s *i2s)
 +{
-+	return readl(i2s->base + reg);
++	u32 buf[10];
++	int ret;
++
++	ret = regmap_bulk_read(i2s->regmap, I2S_REG_CFG0,
++			buf, ARRAY_SIZE(buf));
++
++	dev_dbg(i2s->dev, "CFG0: %08x, INTSTAT: %08x, INTEN: %08x, " \
++			"FFSTAT: %08x, WREG: %08x, RREG: %08x, " \
++			"CFG1: %08x, DIVCMP: %08x, DIVINT: %08x\n",
++			buf[0], buf[1], buf[2], buf[3], buf[4],
++			buf[5], buf[6], buf[8], buf[9]);
 +}
 +
-+static inline void mt7620_i2s_write(const struct mt7620_i2s *i2s,
-+	unsigned int reg, uint32_t value)
++static int ralink_i2s_set_sysclk(struct snd_soc_dai *dai,
++                              int clk_id, unsigned int freq, int dir)
 +{
-+	//printk("i2s --> %p = 0x%08X\n", i2s->base + reg, value);
-+	writel(value, i2s->base + reg);
++	return 0;
 +}
 +
-+static int mt7620_i2s_startup(struct snd_pcm_substream *substream,
-+	struct snd_soc_dai *dai)
++static int ralink_i2s_set_sys_bclk(struct snd_soc_dai *dai, int width, int rate)
 +{
-+	struct mt7620_i2s *i2s = snd_soc_dai_get_drvdata(dai);
-+	uint32_t cfg;
++	struct ralink_i2s *i2s = snd_soc_dai_get_drvdata(dai);
++	unsigned long clk = clk_get_rate(i2s->clk);
++	int div;
++	uint32_t data;
 +
-+	if (dai->active)
++	/* disable clock at slave mode */
++	if ((i2s->fmt & SND_SOC_DAIFMT_MASTER_MASK) ==
++			SND_SOC_DAIFMT_CBM_CFM) {
++		regmap_update_bits(i2s->regmap, I2S_REG_CFG0,
++				I2S_REG_CFG0_CLK_DIS,
++				I2S_REG_CFG0_CLK_DIS);
 +		return 0;
-+
-+	cfg = mt7620_i2s_read(i2s, I2S_REG_CFG0);
-+	cfg |= I2S_REG_CFG0_EN;
-+	mt7620_i2s_write(i2s, I2S_REG_CFG0, cfg);
-+
-+	return 0;
-+}
-+
-+static void mt7620_i2s_shutdown(struct snd_pcm_substream *substream,
-+	struct snd_soc_dai *dai)
-+{
-+	struct mt7620_i2s *i2s = snd_soc_dai_get_drvdata(dai);
-+	uint32_t cfg;
-+
-+	if (dai->active)
-+		return;
-+
-+	cfg = mt7620_i2s_read(i2s, I2S_REG_CFG0);
-+	cfg &= ~I2S_REG_CFG0_EN;
-+	mt7620_i2s_write(i2s, I2S_REG_CFG0, cfg);
-+}
-+
-+static int mt7620_i2s_trigger(struct snd_pcm_substream *substream, int cmd,
-+	struct snd_soc_dai *dai)
-+{
-+	struct mt7620_i2s *i2s = snd_soc_dai_get_drvdata(dai);
-+
-+	uint32_t cfg;
-+	uint32_t mask;
-+
-+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
-+		mask = I2S_REG_CFG0_TX_EN;
-+	else
-+		mask = I2S_REG_CFG0_RX_EN;
-+
-+	cfg = mt7620_i2s_read(i2s, I2S_REG_CFG0);
-+
-+	switch (cmd) {
-+	case SNDRV_PCM_TRIGGER_START:
-+	case SNDRV_PCM_TRIGGER_RESUME:
-+	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
-+		cfg |= mask;
-+		break;
-+	case SNDRV_PCM_TRIGGER_STOP:
-+	case SNDRV_PCM_TRIGGER_SUSPEND:
-+	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
-+		cfg &= ~mask;
-+		break;
-+	default:
-+		return -EINVAL;
 +	}
 +
-+	if (cfg & (I2S_REG_CFG0_TX_EN | I2S_REG_CFG0_RX_EN))
-+		cfg |= I2S_REG_CFG0_DMA_EN;
-+	else
-+		cfg &= ~I2S_REG_CFG0_DMA_EN;
++	/* FREQOUT = FREQIN / (I2S_CLK_DIV + 1) */
++	div = (clk / rate ) - 1;
 +
-+	mt7620_i2s_write(i2s, I2S_REG_CFG0, cfg);
++	data = rt_sysc_r32(0x30);
++	data &= (0xff << 8);
++	data |= (0x1 << 15) | (div << 8);
++	rt_sysc_w32(data, 0x30);
++
++	/* enable clock */
++	regmap_update_bits(i2s->regmap, I2S_REG_CFG0, I2S_REG_CFG0_CLK_DIS, 0);
++
++	dev_dbg(i2s->dev, "clk: %lu, rate: %u, div: %d\n",
++			clk, rate, div);
 +
 +	return 0;
 +}
 +
-+static int mt7620_i2s_set_fmt(struct snd_soc_dai *dai, unsigned int fmt)
++static int ralink_i2s_set_bclk(struct snd_soc_dai *dai, int width, int rate)
 +{
-+	struct mt7620_i2s *i2s = snd_soc_dai_get_drvdata(dai);
-+	uint32_t cfg;
++	struct ralink_i2s *i2s = snd_soc_dai_get_drvdata(dai);
++	unsigned long clk = clk_get_rate(i2s->clk);
++	int divint, divcomp;
 +
-+	cfg = mt7620_i2s_read(i2s, I2S_REG_CFG0);
++	/* disable clock at slave mode */
++	if ((i2s->fmt & SND_SOC_DAIFMT_MASTER_MASK) ==
++			SND_SOC_DAIFMT_CBM_CFM) {
++		regmap_update_bits(i2s->regmap, I2S_REG_DIVCMP,
++				I2S_REG_DIVCMP_CLKEN, 0);
++		return 0;
++	}
 +
++	/* FREQOUT = FREQIN * (1/2) * (1/(DIVINT + DIVCOMP/512)) */
++	clk = clk / (2 * 2 * width);
++	divint = clk / rate;
++	divcomp = ((clk % rate) * 512) / rate;
++
++	if ((divint > I2S_REG_DIVINT_MASK) ||
++			(divcomp > I2S_REG_DIVCMP_DIVCOMP_MASK))
++		return -EINVAL;
++
++	regmap_update_bits(i2s->regmap, I2S_REG_DIVINT,
++			I2S_REG_DIVINT_MASK, divint);
++	regmap_update_bits(i2s->regmap, I2S_REG_DIVCMP,
++			I2S_REG_DIVCMP_DIVCOMP_MASK, divcomp);
++
++	/* enable clock */
++	regmap_update_bits(i2s->regmap, I2S_REG_DIVCMP, I2S_REG_DIVCMP_CLKEN,
++			I2S_REG_DIVCMP_CLKEN);
++
++	dev_dbg(i2s->dev, "clk: %lu, rate: %u, int: %d, comp: %d\n",
++			clk_get_rate(i2s->clk), rate, divint, divcomp);
++
++	return 0;
++}
++
++static int ralink_i2s_set_fmt(struct snd_soc_dai *dai, unsigned int fmt)
++{
++	struct ralink_i2s *i2s = snd_soc_dai_get_drvdata(dai);
++	unsigned int cfg0 = 0, cfg1 = 0;
++
++	/* set master/slave audio interface */
 +	switch (fmt & SND_SOC_DAIFMT_MASTER_MASK) {
-+	case SND_SOC_DAIFMT_CBS_CFS:
-+		cfg |= I2S_REG_CFG0_SLAVE;
-+		break;
 +	case SND_SOC_DAIFMT_CBM_CFM:
-+		cfg &= ~I2S_REG_CFG0_SLAVE;
++		if (i2s->flags & RALINK_FLAGS_TXONLY)
++			cfg0 |= I2S_REG_CFG0_SLAVE_EN;
++		else
++			cfg0 |= I2S_REG_CFG0_SLAVE;
 +		break;
-+	case SND_SOC_DAIFMT_CBM_CFS:
++	case SND_SOC_DAIFMT_CBS_CFS:
++		break;
 +	default:
 +		return -EINVAL;
 +	}
 +
++	/* interface format */
 +	switch (fmt & SND_SOC_DAIFMT_FORMAT_MASK) {
 +	case SND_SOC_DAIFMT_I2S:
-+	case SND_SOC_DAIFMT_MSB:
-+		cfg &= ~I2S_REG_CFG0_BYTE_SWAP;
 +		break;
-+	case SND_SOC_DAIFMT_LSB:
-+		cfg |= I2S_REG_CFG0_BYTE_SWAP;
-+		break;
++	case SND_SOC_DAIFMT_RIGHT_J:
++		if (i2s->flags & RALINK_FLAGS_RIGHT_J) {
++			cfg1 |= I2S_REG_CFG1_RIGHT_J;
++			break;
++		}
++		return -EINVAL;
++	case SND_SOC_DAIFMT_LEFT_J:
++		if (i2s->flags & RALINK_FLAGS_LEFT_J) {
++			cfg1 |= I2S_REG_CFG1_LEFT_J;
++			break;
++		}
++		return -EINVAL;
 +	default:
 +		return -EINVAL;
 +	}
 +
++	/* clock inversion */
 +	switch (fmt & SND_SOC_DAIFMT_INV_MASK) {
 +	case SND_SOC_DAIFMT_NB_NF:
 +		break;
@@ -278,488 +363,684 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		return -EINVAL;
 +	}
 +
-+	mt7620_i2s_write(i2s, I2S_REG_CFG0, cfg);
++	if (i2s->flags & RALINK_FLAGS_TXONLY) {
++		regmap_update_bits(i2s->regmap, I2S_REG_CFG0,
++				I2S_REG_CFG0_SLAVE_EN, cfg0);
++	} else {
++		regmap_update_bits(i2s->regmap, I2S_REG_CFG0,
++				I2S_REG_CFG0_SLAVE, cfg0);
++	}
++	regmap_update_bits(i2s->regmap, I2S_REG_CFG1,
++			I2S_REG_CFG1_FMT_MASK, cfg1);
++	i2s->fmt = fmt;
 +
 +	return 0;
 +}
 +
-+static int mt7620_i2s_hw_params(struct snd_pcm_substream *substream,
-+	struct snd_pcm_hw_params *params, struct snd_soc_dai *dai)
++static int ralink_i2s_startup(struct snd_pcm_substream *substream,
++		struct snd_soc_dai *dai)
 +{
++	struct ralink_i2s *i2s = snd_soc_dai_get_drvdata(dai);
++
++	if (dai->active)
++		return 0;
++
++	/* setup status interrupt */
++#if (RALINK_I2S_INT_EN)
++	regmap_write(i2s->regmap, I2S_REG_INT_EN, 0xff);
++#else
++	regmap_write(i2s->regmap, I2S_REG_INT_EN, 0x0);
++#endif
++
++	/* enable */
++	regmap_update_bits(i2s->regmap, I2S_REG_CFG0,
++			I2S_REG_CFG0_EN | I2S_REG_CFG0_DMA_EN |
++			I2S_REG_CFG0_THRES_MASK,
++			I2S_REG_CFG0_EN | I2S_REG_CFG0_DMA_EN |
++			I2S_REG_CFG0_DFT_THRES);
 +
 +	return 0;
 +}
 +
-+unsigned long i2sMaster_inclk_int[11] = {
-+	78,     56,     52,     39,     28,     26,     19,     14,     13,     9,      6};
-+unsigned long i2sMaster_inclk_comp[11] = {
-+	64,     352,    42,     32,     176,    21,     272,    88,     10,     455,    261};
-+
-+
-+static int mt7620_i2s_set_sysclk(struct snd_soc_dai *dai, int clk_id,
-+	unsigned int freq, int dir)
++static void ralink_i2s_shutdown(struct snd_pcm_substream *substream,
++		struct snd_soc_dai *dai)
 +{
-+        struct mt7620_i2s *i2s = snd_soc_dai_get_drvdata(dai);
++	struct ralink_i2s *i2s = snd_soc_dai_get_drvdata(dai);
 +
-+	printk("Internal REFCLK with fractional division\n");
++	/* If both streams are stopped, disable module and clock */
++	if (dai->active)
++		return;
 +
-+	mt7620_i2s_write(i2s, I2S_REG_DIVINT, i2sMaster_inclk_int[7]);
-+	mt7620_i2s_write(i2s, I2S_REG_DIVCMP,
-+		i2sMaster_inclk_comp[7] | I2S_REG_CLK_EN);
++	/*
++	 * datasheet mention when disable all control regs are cleared
++	 * to initial values. need reinit at startup.
++	 */
++	regmap_update_bits(i2s->regmap, I2S_REG_CFG0, I2S_REG_CFG0_EN, 0);
++}
 +
-+/*	struct mt7620_i2s *i2s = snd_soc_dai_get_drvdata(dai);
-+	struct clk *parent;
-+	int ret = 0;
++static int ralink_i2s_hw_params(struct snd_pcm_substream *substream,
++		struct snd_pcm_hw_params *params, struct snd_soc_dai *dai)
++{
++	struct ralink_i2s *i2s = snd_soc_dai_get_drvdata(dai);
++	int width;
++	int ret;
 +
-+	switch (clk_id) {
-+	case JZ4740_I2S_CLKSRC_EXT:
-+		parent = clk_get(NULL, "ext");
-+		clk_set_parent(i2s->clk_i2s, parent);
++	width = params_width(params);
++	switch (width) {
++	case 16:
++		if (i2s->flags & RALINK_FLAGS_24BIT)
++			regmap_update_bits(i2s->regmap, I2S_REG_CFG0,
++					I2S_REG_CFG0_DATA_24, 0);
 +		break;
-+	case JZ4740_I2S_CLKSRC_PLL:
-+		parent = clk_get(NULL, "pll half");
-+		clk_set_parent(i2s->clk_i2s, parent);
-+		ret = clk_set_rate(i2s->clk_i2s, freq);
++	case 24:
++		if (i2s->flags & RALINK_FLAGS_24BIT) {
++			regmap_update_bits(i2s->regmap, I2S_REG_CFG0,
++					I2S_REG_CFG0_DATA_24,
++					I2S_REG_CFG0_DATA_24);
++			break;
++		}
++		return -EINVAL;
++	default:
++		return -EINVAL;
++	}
++
++	switch (params_channels(params)) {
++	case 2:
 +		break;
 +	default:
 +		return -EINVAL;
 +	}
-+	clk_put(parent);
 +
-+	return ret;*/
++	if (i2s->flags & RALINK_FLAGS_ENDIAN) {
++		/* system endian */
++#ifdef SNDRV_LITTLE_ENDIAN
++		regmap_update_bits(i2s->regmap, I2S_REG_CFG0,
++				I2S_REG_CFG0_SYS_BE, 0);
++#else
++		regmap_update_bits(i2s->regmap, I2S_REG_CFG0,
++				I2S_REG_CFG0_SYS_BE,
++				I2S_REG_CFG0_SYS_BE);
++#endif
++
++		/* data endian */
++		switch (params_format(params)) {
++		case SNDRV_PCM_FORMAT_S16_LE:
++		case SNDRV_PCM_FORMAT_S24_LE:
++			regmap_update_bits(i2s->regmap, I2S_REG_CFG0,
++					I2S_REG_CFG0_FMT_LE,
++					I2S_REG_CFG0_FMT_LE);
++			break;
++		case SNDRV_PCM_FORMAT_S16_BE:
++		case SNDRV_PCM_FORMAT_S24_BE:
++			regmap_update_bits(i2s->regmap, I2S_REG_CFG0,
++					I2S_REG_CFG0_FMT_LE, 0);
++			break;
++		default:
++			return -EINVAL;
++		}
++	}
++
++	/* setup bclk rate */
++	if (i2s->flags & RALINK_FLAGS_TXONLY)
++		ret = ralink_i2s_set_sys_bclk(dai, width, params_rate(params));
++	else
++		ret = ralink_i2s_set_bclk(dai, width, params_rate(params));
++
++	return ret;
++}
++
++static int ralink_i2s_trigger(struct snd_pcm_substream *substream, int cmd,
++		struct snd_soc_dai *dai)
++{
++	struct ralink_i2s *i2s = snd_soc_dai_get_drvdata(dai);
++	unsigned int mask, val;
++
++	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
++		mask = I2S_REG_CFG0_TX_EN;
++	else
++		mask = I2S_REG_CFG0_RX_EN;
++
++	switch (cmd) {
++	case SNDRV_PCM_TRIGGER_START:
++	case SNDRV_PCM_TRIGGER_RESUME:
++	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
++		val = mask;
++		break;
++	case SNDRV_PCM_TRIGGER_STOP:
++	case SNDRV_PCM_TRIGGER_SUSPEND:
++	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
++		val = 0;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	regmap_update_bits(i2s->regmap, I2S_REG_CFG0, mask, val);
++
 +	return 0;
 +}
 +
-+static void mt7620_i2c_init_pcm_config(struct mt7620_i2s *i2s)
++static void ralink_i2s_init_dma_data(struct ralink_i2s *i2s,
++		struct resource *res)
 +{
 +	struct snd_dmaengine_dai_dma_data *dma_data;
 +
 +	/* Playback */
 +	dma_data = &i2s->playback_dma_data;
-+	dma_data->maxburst = 16;
-+	dma_data->slave_id = 2; //JZ4740_DMA_TYPE_AIC_TRANSMIT;
-+	dma_data->addr = i2s->phys_base + I2S_REG_WREG;
++	dma_data->addr = res->start + I2S_REG_WREG;
++	dma_data->addr_width = DMA_SLAVE_BUSWIDTH_4_BYTES;
++	dma_data->maxburst = 1;
++	dma_data->slave_id = i2s->txdma_req;
++
++	if (i2s->flags & RALINK_FLAGS_TXONLY)
++		return;
 +
 +	/* Capture */
 +	dma_data = &i2s->capture_dma_data;
-+	dma_data->maxburst = 16;
-+	dma_data->slave_id = 3; //JZ4740_DMA_TYPE_AIC_RECEIVE;
-+	dma_data->addr = i2s->phys_base + I2S_REG_RREG;
++	dma_data->addr = res->start + I2S_REG_RREG;
++	dma_data->addr_width = DMA_SLAVE_BUSWIDTH_4_BYTES;
++	dma_data->maxburst = 1;
++	dma_data->slave_id = i2s->rxdma_req;
 +}
 +
-+static int mt7620_i2s_dai_probe(struct snd_soc_dai *dai)
++static int ralink_i2s_dai_probe(struct snd_soc_dai *dai)
 +{
-+	struct mt7620_i2s *i2s = snd_soc_dai_get_drvdata(dai);
-+	uint32_t data;
++	struct ralink_i2s *i2s = snd_soc_dai_get_drvdata(dai);
 +
-+	mt7620_i2c_init_pcm_config(i2s);
-+	dai->playback_dma_data = &i2s->playback_dma_data;
-+	dai->capture_dma_data = &i2s->capture_dma_data;
-+
-+	/* set share pins to i2s/gpio mode and i2c mode */
-+	data = rt_sysc_r32(0x60);
-+	data &= 0xFFFFFFE2;
-+	data |= 0x00000018;
-+	rt_sysc_w32(data, 0x60);
-+
-+	printk("Internal REFCLK with fractional division\n");
-+
-+	mt7620_i2s_write(i2s, I2S_REG_CFG0, I2S_REG_CFG0_DFT_THRES);
-+	mt7620_i2s_write(i2s, I2S_REG_CFG1, 0);
-+	mt7620_i2s_write(i2s, I2S_REG_INT_EN, 0);
-+
-+	mt7620_i2s_write(i2s, I2S_REG_DIVINT, i2sMaster_inclk_int[7]);
-+	mt7620_i2s_write(i2s, I2S_REG_DIVCMP,
-+		i2sMaster_inclk_comp[7] | I2S_REG_CLK_EN);
++	snd_soc_dai_init_dma_data(dai, &i2s->playback_dma_data,
++			&i2s->capture_dma_data);
 +
 +	return 0;
 +}
 +
-+static int mt7620_i2s_dai_remove(struct snd_soc_dai *dai)
++static int ralink_i2s_dai_remove(struct snd_soc_dai *dai)
 +{
 +	return 0;
 +}
 +
-+static const struct snd_soc_dai_ops mt7620_i2s_dai_ops = {
-+	.startup = mt7620_i2s_startup,
-+	.shutdown = mt7620_i2s_shutdown,
-+	.trigger = mt7620_i2s_trigger,
-+	.hw_params = mt7620_i2s_hw_params,
-+	.set_fmt = mt7620_i2s_set_fmt,
-+	.set_sysclk = mt7620_i2s_set_sysclk,
++static const struct snd_soc_dai_ops ralink_i2s_dai_ops = {
++	.set_sysclk = ralink_i2s_set_sysclk,
++	.set_fmt = ralink_i2s_set_fmt,
++	.startup = ralink_i2s_startup,
++	.shutdown = ralink_i2s_shutdown,
++	.hw_params = ralink_i2s_hw_params,
++	.trigger = ralink_i2s_trigger,
 +};
 +
-+#define JZ4740_I2S_FMTS (SNDRV_PCM_FMTBIT_S16_LE | SNDRV_PCM_FMTBIT_S20_3LE | \
-+			 SNDRV_PCM_FMTBIT_S24_LE)
-+
-+static struct snd_soc_dai_driver mt7620_i2s_dai = {
-+	.probe = mt7620_i2s_dai_probe,
-+	.remove = mt7620_i2s_dai_remove,
-+	.playback = {
-+		.channels_min = 1,
-+		.channels_max = 2,
-+		.rates = SNDRV_PCM_RATE_8000_48000,
-+		.formats = JZ4740_I2S_FMTS,
-+	},
++static struct snd_soc_dai_driver ralink_i2s_dai = {
++	.name = DRV_NAME,
++	.probe = ralink_i2s_dai_probe,
++	.remove = ralink_i2s_dai_remove,
++	.ops = &ralink_i2s_dai_ops,
 +	.capture = {
++		.stream_name = "I2S Capture",
 +		.channels_min = 2,
 +		.channels_max = 2,
-+		.rates = SNDRV_PCM_RATE_8000_48000,
-+		.formats = JZ4740_I2S_FMTS,
++		.rate_min = 5512,
++		.rate_max = 192000,
++		.rates = SNDRV_PCM_RATE_CONTINUOUS,
++		.formats = SNDRV_PCM_FMTBIT_S16_LE,
++	},
++	.playback = {
++		.stream_name = "I2S Playback",
++		.channels_min = 2,
++		.channels_max = 2,
++		.rate_min = 5512,
++		.rate_max = 192000,
++		.rates = SNDRV_PCM_RATE_CONTINUOUS,
++		.formats = SNDRV_PCM_FMTBIT_S16_LE,
 +	},
 +	.symmetric_rates = 1,
-+	.ops = &mt7620_i2s_dai_ops,
 +};
 +
-+static const struct snd_pcm_hardware mt7620_pcm_hardware = {
++static struct snd_pcm_hardware ralink_pcm_hardware = {
 +	.info = SNDRV_PCM_INFO_MMAP |
 +		SNDRV_PCM_INFO_MMAP_VALID |
 +		SNDRV_PCM_INFO_INTERLEAVED |
 +		SNDRV_PCM_INFO_BLOCK_TRANSFER,
-+	.formats = SNDRV_PCM_FMTBIT_S16_LE | SNDRV_PCM_FMTBIT_S8,
++	.formats = SNDRV_PCM_FMTBIT_S16_LE,
++	.channels_min		= 2,
++	.channels_max		= 2,
 +	.period_bytes_min	= PAGE_SIZE,
-+	.period_bytes_max	= 64 * 1024,
++	.period_bytes_max	= PAGE_SIZE * 2,
 +	.periods_min		= 2,
 +	.periods_max		= 128,
 +	.buffer_bytes_max	= 128 * 1024,
-+	.fifo_size		= 32,
++	.fifo_size		= RALINK_I2S_FIFO_SIZE,
 +};
 +
-+static const struct snd_dmaengine_pcm_config mt7620_dmaengine_pcm_config = {
++static const struct snd_dmaengine_pcm_config ralink_dmaengine_pcm_config = {
 +	.prepare_slave_config = snd_dmaengine_pcm_prepare_slave_config,
-+	.pcm_hardware = &mt7620_pcm_hardware,
++	.pcm_hardware = &ralink_pcm_hardware,
 +	.prealloc_buffer_size = 256 * PAGE_SIZE,
 +};
 +
-+static const struct snd_soc_component_driver mt7620_i2s_component = {
-+	.name = "mt7620-i2s",
++static const struct snd_soc_component_driver ralink_i2s_component = {
++	.name = DRV_NAME,
 +};
 +
-+static int mt7620_i2s_dev_probe(struct platform_device *pdev)
++static bool ralink_i2s_readable_reg(struct device *dev, unsigned int reg)
 +{
-+	struct mt7620_i2s *i2s;
-+	int ret;
++	return true;
++}
 +
-+	snd_dmaengine_pcm_register(&pdev->dev,
-+		&mt7620_dmaengine_pcm_config,
-+		SND_DMAENGINE_PCM_FLAG_COMPAT);
++static bool ralink_i2s_volatile_reg(struct device *dev, unsigned int reg)
++{
++	switch (reg) {
++	case I2S_REG_INT_STATUS:
++	case I2S_REG_FF_STATUS:
++		return true;
++	}
++	return false;
++}
 +
-+	i2s = kzalloc(sizeof(*i2s), GFP_KERNEL);
++static bool ralink_i2s_writeable_reg(struct device *dev, unsigned int reg)
++{
++	switch (reg) {
++	case I2S_REG_FF_STATUS:
++	case I2S_REG_RREG:
++		return false;
++	}
++	return true;
++}
++
++static const struct regmap_config ralink_i2s_regmap_config = {
++	.reg_bits = 32,
++	.reg_stride = 4,
++	.val_bits = 32,
++	.writeable_reg = ralink_i2s_writeable_reg,
++	.readable_reg = ralink_i2s_readable_reg,
++	.volatile_reg = ralink_i2s_volatile_reg,
++	.max_register = I2S_REG_DIVINT,
++};
++
++#if (RALINK_I2S_INT_EN)
++static irqreturn_t ralink_i2s_irq(int irq, void *devid)
++{
++	struct ralink_i2s *i2s = devid;
++	u32 status;
++
++	regmap_read(i2s->regmap, I2S_REG_INT_STATUS, &status);
++	if (unlikely(!status))
++		return IRQ_NONE;
++
++	/* tx stats */
++	if (status & I2S_REG_INT_TX_MASK) {
++		if (status & I2S_REG_INT_TX_THRES)
++			i2s->txstats.belowthres++;
++		if (status & I2S_REG_INT_TX_UNRUN)
++			i2s->txstats.underrun++;
++		if (status & I2S_REG_INT_TX_OVRUN)
++			i2s->txstats.overrun++;
++		if (status & I2S_REG_INT_TX_FAULT)
++			i2s->txstats.dmafault++;
++	}
++
++	/* rx stats */
++	if (status & I2S_REG_INT_RX_MASK) {
++		if (status & I2S_REG_INT_RX_THRES)
++			i2s->rxstats.belowthres++;
++		if (status & I2S_REG_INT_RX_UNRUN)
++			i2s->rxstats.underrun++;
++		if (status & I2S_REG_INT_RX_OVRUN)
++			i2s->rxstats.overrun++;
++		if (status & I2S_REG_INT_RX_FAULT)
++			i2s->rxstats.dmafault++;
++	}
++
++	/* clean status bits */
++	regmap_write(i2s->regmap, I2S_REG_INT_STATUS, status);
++
++	return IRQ_HANDLED;
++}
++#endif
++
++#if IS_ENABLED(CONFIG_DEBUG_FS)
++static int ralink_i2s_stats_show(struct seq_file *s, void *unused)
++{
++        struct ralink_i2s *i2s = s->private;
++
++	seq_printf(s, "tx stats\n");
++	seq_printf(s, "\tbelow threshold\t%u\n", i2s->txstats.belowthres);
++	seq_printf(s, "\tunder run\t%u\n", i2s->txstats.underrun);
++	seq_printf(s, "\tover run\t%u\n", i2s->txstats.overrun);
++	seq_printf(s, "\tdma fault\t%u\n", i2s->txstats.dmafault);
++
++	seq_printf(s, "rx stats\n");
++	seq_printf(s, "\tbelow threshold\t%u\n", i2s->rxstats.belowthres);
++	seq_printf(s, "\tunder run\t%u\n", i2s->rxstats.underrun);
++	seq_printf(s, "\tover run\t%u\n", i2s->rxstats.overrun);
++	seq_printf(s, "\tdma fault\t%u\n", i2s->rxstats.dmafault);
++
++	ralink_i2s_dump_regs(i2s);
++
++	return 0;
++}
++
++static int ralink_i2s_stats_open(struct inode *inode, struct file *file)
++{
++        return single_open(file, ralink_i2s_stats_show, inode->i_private);
++}
++
++static const struct file_operations ralink_i2s_stats_ops = {
++        .open = ralink_i2s_stats_open,
++        .read = seq_read,
++        .llseek = seq_lseek,
++        .release = single_release,
++};
++
++static inline int ralink_i2s_debugfs_create(struct ralink_i2s *i2s)
++{
++        i2s->dbg_dir = debugfs_create_dir(dev_name(i2s->dev), NULL);
++        if (!i2s->dbg_dir)
++                return -ENOMEM;
++
++        i2s->dbg_stats = debugfs_create_file("stats", S_IRUGO,
++                        i2s->dbg_dir, i2s, &ralink_i2s_stats_ops);
++        if (!i2s->dbg_stats) {
++                debugfs_remove(i2s->dbg_dir);
++                return -ENOMEM;
++        }
++
++        return 0;
++}
++
++static inline void ralink_i2s_debugfs_remove(struct ralink_i2s *i2s)
++{
++	debugfs_remove(i2s->dbg_stats);
++	debugfs_remove(i2s->dbg_dir);
++}
++#else
++static inline int ralink_i2s_debugfs_create(struct ralink_i2s *i2s)
++{
++	return 0;
++}
++
++static inline void ralink_i2s_debugfs_remove(struct fsl_ssi_dbg *ssi_dbg)
++{
++}
++#endif
++
++/*
++ * TODO: these refclk setup functions should use
++ * clock framework instead. hardcode it now.
++ */
++static void rt3350_refclk_setup(void)
++{
++	uint32_t data;
++
++	/* set refclk output 12Mhz clock */
++	data = rt_sysc_r32(0x2c);
++	data |= (0x1 << 8);
++	rt_sysc_w32(data, 0x2c);
++}
++
++static void rt3883_refclk_setup(void)
++{
++	uint32_t data;
++
++	/* set refclk output 12Mhz clock */
++	data = rt_sysc_r32(0x2c);
++	data &= ~(0x3 << 13);
++	data |= (0x1 << 13);
++	rt_sysc_w32(data, 0x2c);
++}
++
++static void rt3552_refclk_setup(void)
++{
++	uint32_t data;
++
++	/* set refclk output 12Mhz clock */
++	data = rt_sysc_r32(0x2c);
++	data &= ~(0xf << 8);
++	data |= (0x3 << 8);
++	rt_sysc_w32(data, 0x2c);
++}
++
++static void mt7620_refclk_setup(void)
++{
++	uint32_t data;
++
++	/* set refclk output 12Mhz clock */
++	data = rt_sysc_r32(0x2c);
++	data &= ~(0x7 << 9);
++	data |= 0x1 << 9;
++	rt_sysc_w32(data, 0x2c);
++}
++
++static void mt7621_refclk_setup(void)
++{
++	uint32_t data;
++
++	/* set refclk output 12Mhz clock */
++	data = rt_sysc_r32(0x2c);
++	data &= ~(0x1f << 18);
++	data |= (0x19 << 18);
++	data &= ~(0x1f << 12);
++	data |= (0x1 << 12);
++	data &= ~(0x7 << 9);
++	data |= (0x5 << 9);
++	rt_sysc_w32(data, 0x2c);
++}
++
++static void mt7628_refclk_setup(void)
++{
++	uint32_t data;
++
++	/* set i2s and refclk digital pad */
++	data = rt_sysc_r32(0x3c);
++	data |= 0x1f;
++	rt_sysc_w32(data, 0x3c);
++
++	/* Adjust REFCLK0's driving strength */
++	data = rt_sysc_r32(0x1354);
++	data &= ~(0x1 << 5);
++	rt_sysc_w32(data, 0x1354);
++	data = rt_sysc_r32(0x1364);
++	data |= ~(0x1 << 5);
++	rt_sysc_w32(data, 0x1364);
++
++	/* set refclk output 12Mhz clock */
++	data = rt_sysc_r32(0x2c);
++	data &= ~(0x7 << 9);
++	data |= 0x1 << 9;
++	rt_sysc_w32(data, 0x2c);
++}
++
++struct rt_i2s_data {
++	u32 flags;
++	void (*refclk_setup)(void);
++};
++
++struct rt_i2s_data rt3050_i2s_data = { .flags = RALINK_FLAGS_TXONLY };
++struct rt_i2s_data rt3350_i2s_data = { .flags = RALINK_FLAGS_TXONLY,
++	.refclk_setup = rt3350_refclk_setup };
++struct rt_i2s_data rt3883_i2s_data = {
++	.flags = (RALINK_FLAGS_LEFT_J | RALINK_FLAGS_RIGHT_J),
++	.refclk_setup = rt3883_refclk_setup };
++struct rt_i2s_data rt3352_i2s_data = { .refclk_setup = rt3552_refclk_setup};
++struct rt_i2s_data mt7620_i2s_data = { .refclk_setup = mt7620_refclk_setup};
++struct rt_i2s_data mt7621_i2s_data = { .refclk_setup = mt7621_refclk_setup};
++struct rt_i2s_data mt7628_i2s_data = {
++	.flags = (RALINK_FLAGS_ENDIAN | RALINK_FLAGS_24BIT |
++			RALINK_FLAGS_LEFT_J),
++	.refclk_setup = mt7628_refclk_setup};
++
++static const struct of_device_id ralink_i2s_match_table[] = {
++	{ .compatible = "ralink,rt3050-i2s",
++		.data = (void *)&rt3050_i2s_data },
++	{ .compatible = "ralink,rt3350-i2s",
++		.data = (void *)&rt3350_i2s_data },
++	{ .compatible = "ralink,rt3883-i2s",
++		.data = (void *)&rt3883_i2s_data },
++	{ .compatible = "ralink,rt3352-i2s",
++		.data = (void *)&rt3352_i2s_data },
++	{ .compatible = "mediatek,mt7620-i2s",
++		.data = (void *)&mt7620_i2s_data },
++	{ .compatible = "mediatek,mt7621-i2s",
++		.data = (void *)&mt7621_i2s_data },
++	{ .compatible = "mediatek,mt7628-i2s",
++		.data = (void *)&mt7628_i2s_data },
++};
++MODULE_DEVICE_TABLE(of, ralink_i2s_match_table);
++
++static int ralink_i2s_probe(struct platform_device *pdev)
++{
++	const struct of_device_id *match;
++	struct device_node *np = pdev->dev.of_node;
++	struct ralink_i2s *i2s;
++	struct resource *res;
++	int irq, ret;
++	u32 dma_req;
++	struct rt_i2s_data *data;
++
++	i2s = devm_kzalloc(&pdev->dev, sizeof(*i2s), GFP_KERNEL);
 +	if (!i2s)
 +		return -ENOMEM;
 +
-+	i2s->mem = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-+	if (!i2s->mem) {
-+		ret = -ENOENT;
-+		goto err_free;
-+	}
-+
-+	i2s->mem = request_mem_region(i2s->mem->start, resource_size(i2s->mem),
-+				pdev->name);
-+	if (!i2s->mem) {
-+		ret = -EBUSY;
-+		goto err_free;
-+	}
-+
-+	i2s->base = ioremap_nocache(i2s->mem->start, resource_size(i2s->mem));
-+	if (!i2s->base) {
-+		ret = -EBUSY;
-+		goto err_release_mem_region;
-+	}
-+
-+	i2s->phys_base = i2s->mem->start;
-+
 +	platform_set_drvdata(pdev, i2s);
-+	ret = snd_soc_register_component(&pdev->dev, &mt7620_i2s_component,
-+					 &mt7620_i2s_dai, 1);
++	i2s->dev = &pdev->dev;
 +
-+	if (!ret) {
-+		dev_err(&pdev->dev, "loaded\n");
++	match = of_match_device(ralink_i2s_match_table, &pdev->dev);
++	if (!match)
++		return -EINVAL;
++	data = (struct rt_i2s_data *)match->data;
++	i2s->flags = data->flags;
++	/* setup out 12Mhz refclk to codec as mclk */
++	if (data->refclk_setup)
++		data->refclk_setup();
++
++	if (of_property_read_u32(np, "txdma-req", &dma_req)) {
++		dev_err(&pdev->dev, "no txdma-req define\n");
++		return -EINVAL;
++	}
++	i2s->txdma_req = (u16)dma_req;
++	if (!(i2s->flags & RALINK_FLAGS_TXONLY)) {
++		if (of_property_read_u32(np, "rxdma-req", &dma_req)) {
++			dev_err(&pdev->dev, "no rxdma-req define\n");
++			return -EINVAL;
++		}
++		i2s->rxdma_req = (u16)dma_req;
++	}
++
++	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
++	i2s->regs = devm_ioremap_resource(&pdev->dev, res);
++	if (IS_ERR(i2s->regs))
++		return PTR_ERR(i2s->regs);
++
++	i2s->regmap = devm_regmap_init_mmio(&pdev->dev, i2s->regs,
++			&ralink_i2s_regmap_config);
++	if (IS_ERR(i2s->regmap)) {
++		dev_err(&pdev->dev, "regmap init failed\n");
++		return PTR_ERR(i2s->regmap);
++	}
++
++        irq = platform_get_irq(pdev, 0);
++        if (irq < 0) {
++                dev_err(&pdev->dev, "failed to get irq\n");
++                return -EINVAL;
++        }
++
++#if (RALINK_I2S_INT_EN)
++	ret = devm_request_irq(&pdev->dev, irq, ralink_i2s_irq,
++			0, dev_name(&pdev->dev), i2s);
++	if (ret) {
++		dev_err(&pdev->dev, "failed to request irq\n");
 +		return ret;
 +	}
++#endif
 +
-+	dev_err(&pdev->dev, "Failed to register DAI\n");
-+	iounmap(i2s->base);
++	i2s->clk = devm_clk_get(&pdev->dev, NULL);
++	if (IS_ERR(i2s->clk)) {
++		dev_err(&pdev->dev, "no clock defined\n");
++		return PTR_ERR(i2s->clk);
++	}
 +
-+err_release_mem_region:
-+	release_mem_region(i2s->mem->start, resource_size(i2s->mem));
-+err_free:
-+	kfree(i2s);
++	ret = clk_prepare_enable(i2s->clk);
++	if (ret)
++		return ret;
++
++	ralink_i2s_init_dma_data(i2s, res);
++
++	device_reset(&pdev->dev);
++
++	ret = ralink_i2s_debugfs_create(i2s);
++	if (ret) {
++		dev_err(&pdev->dev, "create debugfs failed\n");
++		goto err_clk_disable;
++	}
++
++	/* enable 24bits support */
++	if (i2s->flags & RALINK_FLAGS_24BIT) {
++		ralink_i2s_dai.capture.formats |= SNDRV_PCM_FMTBIT_S24_LE;
++		ralink_i2s_dai.playback.formats |= SNDRV_PCM_FMTBIT_S24_LE;
++	}
++
++	/* enable big endian support */
++	if (i2s->flags & RALINK_FLAGS_ENDIAN) {
++		ralink_i2s_dai.capture.formats |= SNDRV_PCM_FMTBIT_S16_BE;
++		ralink_i2s_dai.playback.formats |= SNDRV_PCM_FMTBIT_S16_BE;
++		ralink_pcm_hardware.formats |= SNDRV_PCM_FMTBIT_S16_BE;
++		if (i2s->flags & RALINK_FLAGS_24BIT) {
++			ralink_i2s_dai.capture.formats |=
++				SNDRV_PCM_FMTBIT_S24_BE;
++			ralink_i2s_dai.playback.formats |=
++				SNDRV_PCM_FMTBIT_S24_BE;
++			ralink_pcm_hardware.formats |=
++				SNDRV_PCM_FMTBIT_S24_BE;
++		}
++	}
++
++	/* disable capture support */
++	if (i2s->flags & RALINK_FLAGS_TXONLY)
++		memset(&ralink_i2s_dai.capture, sizeof(ralink_i2s_dai.capture),
++				0);
++
++	ret = devm_snd_soc_register_component(&pdev->dev, &ralink_i2s_component,
++			&ralink_i2s_dai, 1);
++	if (ret)
++		goto err_debugfs;
++
++	ret = devm_snd_dmaengine_pcm_register(&pdev->dev,
++			&ralink_dmaengine_pcm_config,
++			SND_DMAENGINE_PCM_FLAG_COMPAT);
++	if (ret)
++		goto err_debugfs;
++
++	dev_info(i2s->dev, "mclk %luKHz\n", clk_get_rate(i2s->clk) / 1000000);
++
++	return 0;
++
++err_debugfs:
++	ralink_i2s_debugfs_remove(i2s);
++
++err_clk_disable:
++	clk_disable_unprepare(i2s->clk);
 +
 +	return ret;
 +}
 +
-+static int mt7620_i2s_dev_remove(struct platform_device *pdev)
++static int ralink_i2s_remove(struct platform_device *pdev)
 +{
-+	struct mt7620_i2s *i2s = platform_get_drvdata(pdev);
++	struct ralink_i2s *i2s = platform_get_drvdata(pdev);
 +
-+	snd_soc_unregister_component(&pdev->dev);
-+
-+	iounmap(i2s->base);
-+	release_mem_region(i2s->mem->start, resource_size(i2s->mem));
-+
-+	kfree(i2s);
-+
-+	snd_dmaengine_pcm_unregister(&pdev->dev);
++	ralink_i2s_debugfs_remove(i2s);
++	clk_disable_unprepare(i2s->clk);
 +
 +	return 0;
 +}
 +
-+static const struct of_device_id mt7620_i2s_match[] = {
-+	{ .compatible = "ralink,mt7620a-i2s" },
-+	{},
-+};
-+MODULE_DEVICE_TABLE(of, mt7620_i2s_match);
-+
-+static struct platform_driver mt7620_i2s_driver = {
-+	.probe = mt7620_i2s_dev_probe,
-+	.remove = mt7620_i2s_dev_remove,
++static struct platform_driver ralink_i2s_driver = {
++	.probe = ralink_i2s_probe,
++	.remove = ralink_i2s_remove,
 +	.driver = {
-+		.name = "mt7620-i2s",
-+		.owner = THIS_MODULE,
-+		.of_match_table = mt7620_i2s_match,
++		.name = DRV_NAME,
++		.of_match_table = ralink_i2s_match_table,
 +	},
 +};
-+
-+module_platform_driver(mt7620_i2s_driver);
++module_platform_driver(ralink_i2s_driver);
 +
 +MODULE_AUTHOR("Lars-Peter Clausen, <lars@metafoo.de>");
-+MODULE_DESCRIPTION("Ingenic JZ4740 SoC I2S driver");
++MODULE_DESCRIPTION("Ralink/MediaTek I2S driver");
 +MODULE_LICENSE("GPL");
-+MODULE_ALIAS("platform:mt7620-i2s");
---- /dev/null
-+++ b/sound/soc/ralink/mt7620-wm8960.c
-@@ -0,0 +1,233 @@
-+/*
-+ * Copyright 2013 Freescale Semiconductor, Inc.
-+ *
-+ * Based on mt7620-sgtl5000.c
-+ * Copyright 2012 Freescale Semiconductor, Inc.
-+ * Copyright 2012 Linaro Ltd.
-+ *
-+ * The code contained herein is licensed under the GNU General Public
-+ * License. You may obtain a copy of the GNU General Public License
-+ * Version 2 or later at the following locations:
-+ *
-+ * http://www.opensource.org/licenses/gpl-license.html
-+ * http://www.gnu.org/copyleft/gpl.html
-+ */
-+
-+#include <linux/module.h>
-+#include <linux/of_platform.h>
-+#include <linux/i2c.h>
-+#include <linux/slab.h>
-+#include <sound/soc.h>
-+#include <sound/pcm_params.h>
-+#include <sound/soc-dapm.h>
-+#include <linux/pinctrl/consumer.h>
-+
-+#include "../codecs/wm8960.h"
-+
-+#define DAI_NAME_SIZE	32
-+
-+struct mt7620_wm8960_data {
-+	struct snd_soc_dai_link dai;
-+	struct snd_soc_card card;
-+	char codec_dai_name[DAI_NAME_SIZE];
-+	char platform_name[DAI_NAME_SIZE];
-+	unsigned int clk_frequency;
-+};
-+
-+struct mt7620_priv {
-+	struct platform_device *pdev;
-+};
-+static struct mt7620_priv card_priv;
-+
-+static const struct snd_soc_dapm_widget mt7620_wm8960_dapm_widgets[] = {
-+	SND_SOC_DAPM_HP("Headphone Jack", NULL),
-+	SND_SOC_DAPM_SPK("Ext Spk", NULL),
-+	SND_SOC_DAPM_MIC("AMIC", NULL),
-+	SND_SOC_DAPM_MIC("DMIC", NULL),
-+};
-+
-+static int sample_rate = 44100;
-+static snd_pcm_format_t sample_format = SNDRV_PCM_FORMAT_S16_LE;
-+
-+static int mt7620_hifi_hw_params(struct snd_pcm_substream *substream,
-+		struct snd_pcm_hw_params *params)
-+{
-+	sample_rate = params_rate(params);
-+	sample_format = params_format(params);
-+
-+	return 0;
-+}
-+
-+static struct snd_soc_ops mt7620_hifi_ops = {
-+	.hw_params = mt7620_hifi_hw_params,
-+};
-+
-+static int mt7620_wm8960_set_bias_level(struct snd_soc_card *card,
-+					struct snd_soc_dapm_context *dapm,
-+					enum snd_soc_bias_level level)
-+{
-+	struct snd_soc_dai *codec_dai = card->rtd[0].codec_dai;
-+	struct mt7620_priv *priv = &card_priv;
-+	struct mt7620_wm8960_data *data = snd_soc_card_get_drvdata(card);
-+	struct device *dev = &priv->pdev->dev;
-+	int ret;
-+
-+	if (dapm->dev != codec_dai->dev)
-+		return 0;
-+
-+	switch (level) {
-+	case SND_SOC_BIAS_PREPARE:
-+		if (dapm->bias_level == SND_SOC_BIAS_STANDBY) {
-+		}
-+		break;
-+
-+	case SND_SOC_BIAS_STANDBY:
-+		if (dapm->bias_level == SND_SOC_BIAS_PREPARE) {
-+			ret = snd_soc_dai_set_sysclk(codec_dai,
-+					WM8960_SYSCLK_MCLK, data->clk_frequency,
-+					SND_SOC_CLOCK_IN);
-+			if (ret < 0) {
-+				dev_err(dev,
-+					"failed to switch away from FLL: %d\n",
-+					ret);
-+				return ret;
-+			}
-+		}
-+		break;
-+
-+	default:
-+		break;
-+	}
-+
-+	return 0;
-+}
-+
-+static int mt7620_wm8960_late_probe(struct snd_soc_card *card)
-+{
-+	struct snd_soc_dai *codec_dai = card->rtd[0].codec_dai;
-+	struct mt7620_priv *priv = &card_priv;
-+	struct mt7620_wm8960_data *data = snd_soc_card_get_drvdata(card);
-+	struct device *dev = &priv->pdev->dev;
-+	int ret;
-+
-+	ret = snd_soc_dai_set_sysclk(codec_dai, WM8960_SYSCLK_MCLK,
-+			data->clk_frequency, SND_SOC_CLOCK_IN);
-+	if (ret < 0)
-+		dev_err(dev, "failed to set sysclk in %s\n", __func__);
-+
-+	return ret;
-+}
-+
-+static int mt7620_wm8960_probe(struct platform_device *pdev)
-+{
-+	struct device_node *i2s_np, *codec_np;
-+	struct platform_device *i2s_pdev;
-+	struct mt7620_priv *priv = &card_priv;
-+	struct i2c_client *codec_dev;
-+	struct mt7620_wm8960_data *data;
-+	int ret;
-+
-+	priv->pdev = pdev;
-+
-+	i2s_np = of_parse_phandle(pdev->dev.of_node, "i2s-controller", 0);
-+	codec_np = of_parse_phandle(pdev->dev.of_node, "audio-codec", 0);
-+	if (!i2s_np || !codec_np) {
-+		dev_err(&pdev->dev, "phandle missing or invalid\n");
-+		ret = -EINVAL;
-+		goto fail;
-+	}
-+
-+	i2s_pdev = of_find_device_by_node(i2s_np);
-+	if (!i2s_pdev) {
-+		dev_err(&pdev->dev, "failed to find SSI platform device\n");
-+		ret = -EINVAL;
-+		goto fail;
-+	}
-+	codec_dev = of_find_i2c_device_by_node(codec_np);
-+	if (!codec_dev || !codec_dev->dev.driver) {
-+		dev_err(&pdev->dev, "failed to find codec platform device\n");
-+		ret = -EINVAL;
-+		goto fail;
-+	}
-+
-+	data = devm_kzalloc(&pdev->dev, sizeof(*data), GFP_KERNEL);
-+	if (!data) {
-+		ret = -ENOMEM;
-+		goto fail;
-+	}
-+
-+	data->clk_frequency = 12000000;
-+	data->dai.name = "HiFi";
-+	data->dai.stream_name = "HiFi";
-+	data->dai.codec_dai_name = "wm8960-hifi";
-+	data->dai.codec_of_node = codec_np;
-+	data->dai.cpu_dai_name = dev_name(&i2s_pdev->dev);
-+	data->dai.platform_of_node = i2s_np;
-+	data->dai.ops = &mt7620_hifi_ops;
-+	data->dai.dai_fmt = SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
-+			    SND_SOC_DAIFMT_CBM_CFM;
-+
-+	data->card.dev = &pdev->dev;
-+	ret = snd_soc_of_parse_card_name(&data->card, "model");
-+	if (ret)
-+		goto fail;
-+	ret = snd_soc_of_parse_audio_routing(&data->card, "audio-routing");
-+	if (ret)
-+		goto fail;
-+	data->card.num_links = 1;
-+	data->card.dai_link = &data->dai;
-+	data->card.dapm_widgets = mt7620_wm8960_dapm_widgets;
-+	data->card.num_dapm_widgets = ARRAY_SIZE(mt7620_wm8960_dapm_widgets);
-+
-+	data->card.late_probe = mt7620_wm8960_late_probe;
-+	data->card.set_bias_level = mt7620_wm8960_set_bias_level;
-+
-+	platform_set_drvdata(pdev, &data->card);
-+	snd_soc_card_set_drvdata(&data->card, data);
-+
-+	ret = devm_snd_soc_register_card(&pdev->dev, &data->card);
-+	if (ret) {
-+		dev_err(&pdev->dev, "snd_soc_register_card failed (%d)\n", ret);
-+		goto fail;
-+	}
-+
-+	of_node_put(i2s_np);
-+	of_node_put(codec_np);
-+
-+	return 0;
-+fail:
-+	if (i2s_np)
-+		of_node_put(i2s_np);
-+	if (codec_np)
-+		of_node_put(codec_np);
-+
-+	return ret;
-+}
-+
-+static int mt7620_wm8960_remove(struct platform_device *pdev)
-+{
-+	return 0;
-+}
-+
-+static const struct of_device_id mt7620_wm8960_dt_ids[] = {
-+	{ .compatible = "mediatek,mt7620-audio-wm8960", },
-+	{ /* sentinel */ }
-+};
-+MODULE_DEVICE_TABLE(of, mt7620_wm8960_dt_ids);
-+
-+static struct platform_driver mt7620_wm8960_driver = {
-+	.driver = {
-+		.name = "mt7620-wm8960",
-+		.owner = THIS_MODULE,
-+		.pm = &snd_soc_pm_ops,
-+		.of_match_table = mt7620_wm8960_dt_ids,
-+	},
-+	.probe = mt7620_wm8960_probe,
-+	.remove = mt7620_wm8960_remove,
-+};
-+module_platform_driver(mt7620_wm8960_driver);
-+
-+MODULE_AUTHOR("Freescale Semiconductor, Inc.");
-+MODULE_DESCRIPTION("Freescale i.MX WM8962 ASoC machine driver");
-+MODULE_LICENSE("GPL v2");
-+MODULE_ALIAS("platform:mt7620-wm8962");
++MODULE_ALIAS("platform:" DRV_NAME);

--- a/target/linux/ramips/patches-4.4/0720-arch-mips-ralink-add-i2c-clocks.patch
+++ b/target/linux/ramips/patches-4.4/0720-arch-mips-ralink-add-i2c-clocks.patch
@@ -1,0 +1,40 @@
+--- a/arch/mips/ralink/mt7620.c
++++ b/arch/mips/ralink/mt7620.c
+@@ -446,6 +446,7 @@ void __init ralink_clk_init(void)
+ 	ralink_clk_add("cpu", cpu_rate);
+ 	ralink_clk_add("10000100.timer", periph_rate);
+ 	ralink_clk_add("10000120.watchdog", periph_rate);
++	ralink_clk_add("10000900.i2c", periph_rate);
+ 	ralink_clk_add("10000b00.spi", sys_rate);
+ 	ralink_clk_add("10000b40.spi", sys_rate);
+ 	ralink_clk_add("10000c00.uartlite", periph_rate);
+--- a/arch/mips/ralink/rt288x.c
++++ b/arch/mips/ralink/rt288x.c
+@@ -75,6 +75,7 @@ void __init ralink_clk_init(void)
+ 	ralink_clk_add("300100.timer", cpu_rate / 2);
+ 	ralink_clk_add("300120.watchdog", cpu_rate / 2);
+ 	ralink_clk_add("300500.uart", cpu_rate / 2);
++	ralink_clk_add("300900.i2c", cpu_rate / 2);
+ 	ralink_clk_add("300c00.uartlite", cpu_rate / 2);
+ 	ralink_clk_add("400000.ethernet", cpu_rate / 2);
+ 	ralink_clk_add("480000.wmac", wmac_rate);
+--- a/arch/mips/ralink/rt305x.c
++++ b/arch/mips/ralink/rt305x.c
+@@ -200,6 +200,7 @@ void __init ralink_clk_init(void)
+ 
+ 	ralink_clk_add("cpu", cpu_rate);
+ 	ralink_clk_add("sys", sys_rate);
++	ralink_clk_add("10000900.i2c", uart_rate);
+ 	ralink_clk_add("10000b00.spi", sys_rate);
+ 	ralink_clk_add("10000b40.spi", sys_rate);
+ 	ralink_clk_add("10000100.timer", wdt_rate);
+--- a/arch/mips/ralink/rt3883.c
++++ b/arch/mips/ralink/rt3883.c
+@@ -108,6 +108,7 @@ void __init ralink_clk_init(void)
+ 	ralink_clk_add("10000100.timer", sys_rate);
+ 	ralink_clk_add("10000120.watchdog", sys_rate);
+ 	ralink_clk_add("10000500.uart", 40000000);
++	ralink_clk_add("10000900.i2c", 40000000);
+ 	ralink_clk_add("10000b00.spi", sys_rate);
+ 	ralink_clk_add("10000b40.spi", sys_rate);
+ 	ralink_clk_add("10000c00.uartlite", 40000000);

--- a/target/linux/ramips/patches-4.4/0720-arch-mips-ralink-add-i2c-clocks.patch
+++ b/target/linux/ramips/patches-4.4/0720-arch-mips-ralink-add-i2c-clocks.patch
@@ -1,10 +1,35 @@
 --- a/arch/mips/ralink/mt7620.c
 +++ b/arch/mips/ralink/mt7620.c
-@@ -446,6 +446,7 @@ void __init ralink_clk_init(void)
+@@ -389,6 +389,7 @@ void __init ralink_clk_init(void)
+ 	unsigned long sys_rate;
+ 	unsigned long dram_rate;
+ 	unsigned long periph_rate;
++	unsigned long pcmi2s_rate;
+ 
+ 	xtal_rate = mt7620_get_xtal_rate();
+ 
+@@ -403,6 +404,7 @@ void __init ralink_clk_init(void)
+ 			cpu_rate = MHZ(575);
+ 		dram_rate = sys_rate = cpu_rate / 3;
+ 		periph_rate = MHZ(40);
++		pcmi2s_rate = MHZ(480);
+ 
+ 		ralink_clk_add("10000d00.uartlite", periph_rate);
+ 		ralink_clk_add("10000e00.uartlite", periph_rate);
+@@ -414,6 +416,7 @@ void __init ralink_clk_init(void)
+ 		dram_rate = mt7620_get_dram_rate(pll_rate);
+ 		sys_rate = mt7620_get_sys_rate(cpu_rate);
+ 		periph_rate = mt7620_get_periph_rate(xtal_rate);
++		pcmi2s_rate = periph_rate;
+ 
+ 		pr_debug(RFMT("XTAL") RFMT("CPU_PLL") RFMT("PLL"),
+ 			 RINT(xtal_rate), RFRAC(xtal_rate),
+@@ -435,6 +438,8 @@ void __init ralink_clk_init(void)
  	ralink_clk_add("cpu", cpu_rate);
  	ralink_clk_add("10000100.timer", periph_rate);
  	ralink_clk_add("10000120.watchdog", periph_rate);
 +	ralink_clk_add("10000900.i2c", periph_rate);
++	ralink_clk_add("10000a00.i2s", pcmi2s_rate);
  	ralink_clk_add("10000b00.spi", sys_rate);
  	ralink_clk_add("10000b40.spi", sys_rate);
  	ralink_clk_add("10000c00.uartlite", periph_rate);
@@ -20,21 +45,23 @@
  	ralink_clk_add("480000.wmac", wmac_rate);
 --- a/arch/mips/ralink/rt305x.c
 +++ b/arch/mips/ralink/rt305x.c
-@@ -200,6 +200,7 @@ void __init ralink_clk_init(void)
+@@ -200,6 +200,8 @@ void __init ralink_clk_init(void)
  
  	ralink_clk_add("cpu", cpu_rate);
  	ralink_clk_add("sys", sys_rate);
 +	ralink_clk_add("10000900.i2c", uart_rate);
++	ralink_clk_add("10000a00.i2s", uart_rate);
  	ralink_clk_add("10000b00.spi", sys_rate);
  	ralink_clk_add("10000b40.spi", sys_rate);
  	ralink_clk_add("10000100.timer", wdt_rate);
 --- a/arch/mips/ralink/rt3883.c
 +++ b/arch/mips/ralink/rt3883.c
-@@ -108,6 +108,7 @@ void __init ralink_clk_init(void)
+@@ -108,6 +108,8 @@ void __init ralink_clk_init(void)
  	ralink_clk_add("10000100.timer", sys_rate);
  	ralink_clk_add("10000120.watchdog", sys_rate);
  	ralink_clk_add("10000500.uart", 40000000);
 +	ralink_clk_add("10000900.i2c", 40000000);
++	ralink_clk_add("10000a00.i2s", 40000000);
  	ralink_clk_add("10000b00.spi", sys_rate);
  	ralink_clk_add("10000b40.spi", sys_rate);
  	ralink_clk_add("10000c00.uartlite", 40000000);

--- a/target/linux/ramips/patches-4.4/0721-asoc-enable-wm8960-kconfig.patch
+++ b/target/linux/ramips/patches-4.4/0721-asoc-enable-wm8960-kconfig.patch
@@ -1,0 +1,11 @@
+--- a/sound/soc/codecs/Kconfig
++++ b/sound/soc/codecs/Kconfig
+@@ -825,7 +825,7 @@ config SND_SOC_WM8955
+ 	tristate
+ 
+ config SND_SOC_WM8960
+-	tristate
++	tristate "Wolfson Microelectronics WM8960 CODEC"
+ 
+ config SND_SOC_WM8961
+ 	tristate


### PR DESCRIPTION
This patch sets focus on audio function on ramips / mediatek.
It includes updates on i2c / i2s / gdma (hsdma on mt7621) drivers.
I use simple-card as ASOC platform drivers. so we only need to modify
dts file to bind different codecs. verified on below two boards.
DCH-M225  mt7620 + wm8960
DuZun-DM06  mt7628 + wm8960

but need following command to correctly init codec path and volume.
`alsactl init`
`amixer sset "Left Output Mixer PCM" on`
`amixer sset "Right Output Mixer PCM" on`
use speaker-test and mpg123 to verify headphone output function is ok
 
TODO:
- now use mediatek refclk function to provide MCLK for wm8960 codec.
  but the refclk clock speed is hardcode now. only support output 12Mhz clock.
  should use clock framework to rewrite it.

- i also try to use madplay to play mp3. but it seems have mmap problems.
  can't work now.