### PR TITLE
update tools/sparse to support llvm 3.5.0

### DIFF
--- a/tools/sparse/Makefile
+++ b/tools/sparse/Makefile
@@ -5,14 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sparse
-PKG_VERSION:=0.5.0
+PKG_VERSION:=0.5-git40791b94
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://git.kernel.org/pub/scm/devel/sparse/sparse.git
 PKG_SOURCE_VERSION:=40791b94c56b1a6da2a0ddeb1f9d5c9d64de8f93
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 #PKG_SOURCE_URL:=@KERNEL/software/devel/sparse/dist/
 #PKG_MD5SUM:=68bc834c57836251fbee55a7707bab39
 

--- a/tools/sparse/Makefile
+++ b/tools/sparse/Makefile
@@ -7,9 +7,14 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sparse
 PKG_VERSION:=0.5.0
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@KERNEL/software/devel/sparse/dist/
-PKG_MD5SUM:=68bc834c57836251fbee55a7707bab39
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=git://git.kernel.org/pub/scm/devel/sparse/sparse.git
+PKG_SOURCE_VERSION:=40791b94c56b1a6da2a0ddeb1f9d5c9d64de8f93
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
+#PKG_SOURCE_URL:=@KERNEL/software/devel/sparse/dist/
+#PKG_MD5SUM:=68bc834c57836251fbee55a7707bab39
 
 PKG_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
sparse-0.5.0 won't link against lvm 3.5.0 as  "llvm-config --libs"
does not include system libs like pthreads
This problem got fixed but not released yet, 
so we need to fetch from their git repo.