### PR TITLE
Allow default package selection to be chosen by a config option rather than make variable

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -19,6 +19,8 @@ source "target/Config.in"
 
 source "config/Config-images.in"
 
+source "config/Config-device.in"
+
 source "config/Config-build.in"
 
 source "config/Config-devel.in"
@@ -32,3 +34,5 @@ source "target/sdk/Config.in"
 source "target/toolchain/Config.in"
 
 source "tmp/.config-package.in"
+
+source "tmp/.config-defaults.in"

--- a/config/Config-device.in
+++ b/config/Config-device.in
@@ -1,0 +1,76 @@
+# Copyright (C) 2006-2013 OpenWrt.org
+# Copyright (C) 2016 LEDE Project
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+config USE_DEVICE_TYPE_router
+	bool
+
+config USE_DEVICE_TYPE_nas
+	bool
+
+config USE_DEVICE_TYPE_bootloader
+	bool
+
+config USE_DEVICE_TYPE_developerboard
+	bool
+
+config USE_DEVICE_TYPE_other
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_router
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_nas
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_bootloader
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_developerboard
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_other
+	bool
+
+choice
+	prompt "Device Type"
+	default DT_USE_DEVICE_TYPE_router if DEFAULT_USE_DEVICE_TYPE_router
+	default DT_USE_DEVICE_TYPE_nas if DEFAULT_USE_DEVICE_TYPE_nas
+	default DT_USE_DEVICE_TYPE_bootloader if DEFAULT_USE_DEVICE_TYPE_booloader
+	default DT_USE_DEVICE_TYPE_developerboard if DEFAULT_USE_DEVICE_TYPE_developerboard
+	default DT_USE_DEVICE_TYPE_other if DEFAULT_USE_DEVICE_TYPE_other
+	help
+	  "Set default build options based on device type (e.g. router, nas)"
+
+	config DT_USE_DEVICE_TYPE_router
+		bool "Router"
+		select USE_DEVICE_TYPE_router
+
+	config DT_USE_DEVICE_TYPE_nas
+		bool "NAS"
+		select USE_DEVICE_TYPE_nas
+
+	config DT_USE_DEVICE_TYPE_bootloader
+		bool "Bootloader"
+		select USE_DEVICE_TYPE_bootloader
+
+	config DT_USE_DEVICE_TYPE_developerboard
+		bool "Developer Board"
+		select USE_DEVICE_TYPE_developerboard
+
+	config DT_USE_DEVICE_TYPE_other
+		bool "Other"
+		select USE_DEVICE_TYPE_other
+
+endchoice
+
+config DEVICE_TYPE
+	string
+	default "router" if USE_DEVICE_TYPE_router
+	default "nas" if USE_DEVICE_TYPE_nas
+	default "bootloader" if USE_DEVICE_TYPE_bootloader
+	default "developerboard" if USE_DEVICE_TYPE_developerboard
+	default "other" if USE_DEVICE_TYPE_other

--- a/include/scan.mk
+++ b/include/scan.mk
@@ -47,10 +47,14 @@ $(OVERRIDELIST):
 	rm -f $(TMP_DIR)/info/.overrides-$(SCAN_TARGET)-*
 	touch $@
 
+ifeq ($(SCAN_NAME),defaults)
+  GREP_STRING=BuildTarget
+else
 ifeq ($(SCAN_NAME),target)
   GREP_STRING=BuildTarget
 else
   GREP_STRING=(Build/DefaultTargets|BuildPackage|.+Package)
+endif
 endif
 
 $(FILELIST): $(OVERRIDELIST)
@@ -82,7 +86,7 @@ $(TMP_DIR)/info/.files-$(SCAN_TARGET).mk: $(FILELIST)
 
 $(TARGET_STAMP)::
 	+( \
-		$(NO_TRACE_MAKE) $(FILELIST); \
+		$(NO_TRACE_MAKE) -f $(TOPDIR)/include/scan.mk $(FILELIST); \
 		MD5SUM=$$(cat $(FILELIST) $(OVERRIDELIST) | (md5sum || md5) 2>/dev/null | awk '{print $$1}'); \
 		[ -f "$@.$$MD5SUM" ] || { \
 			rm -f $@.*; \

--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -79,7 +79,9 @@ prepare-tmpinfo: FORCE
 	mkdir -p tmp/info
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="packageinfo" SCAN_DIR="package" SCAN_NAME="package" SCAN_DEPS="$(TOPDIR)/include/package*.mk $(TOPDIR)/overlay/*/*.mk" SCAN_DEPTH=5 SCAN_EXTRA=""
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="targetinfo" SCAN_DIR="target/linux" SCAN_NAME="target" SCAN_DEPS="image/Makefile profiles/*.mk $(TOPDIR)/include/kernel*.mk $(TOPDIR)/include/target.mk" SCAN_DEPTH=2 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1"
-	for type in package target; do \
+	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="defaultsinfo" SCAN_DIR="target/linux" SCAN_NAME="defaults" SCAN_DEPS="image/Makefile profiles/*.mk $(TOPDIR)/include/kernel*.mk $(TOPDIR)/include/target.mk" SCAN_DEPTH=2 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1 SCAN_DEFAULTS=1"
+	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f $(TOPDIR)/include/defaults.mk DUMP_DEFAULTS_BASE=1 >>tmp/.defaultsinfo
+	for type in package target defaults; do \
 		f=tmp/.$${type}info; t=tmp/.config-$${type}.in; \
 		[ "$$t" -nt "$$f" ] || ./scripts/$${type}-metadata.pl $(_ignore) config "$$f" > "$$t" || { rm -f "$$t"; echo "Failed to build $$t"; false; break; }; \
 	done

--- a/scripts/defaults-metadata.pl
+++ b/scripts/defaults-metadata.pl
@@ -1,0 +1,102 @@
+#!/usr/bin/env perl
+use FindBin;
+use lib "$FindBin::Bin";
+use strict;
+use metadata;
+use Getopt::Long;
+
+sub merge_package_lists($$) {
+	my $list1 = shift;
+	my $list2 = shift;
+	my @l = ();
+	my %pkgs;
+
+	foreach my $pkg (@$list1, @$list2) {
+		$pkgs{$pkg} = 1;
+	}
+	foreach my $pkg (keys %pkgs) {
+		push @l, $pkg unless ($pkg =~ /^-/ or $pkgs{"-$pkg"});
+	}
+	return sort(@l);
+}
+
+sub gen_defaults_config() {
+	my $file = shift @ARGV;
+	parse_defaults_metadata($file);
+	my %defaults = ();
+
+	# Default packages for a profile (default n; becomes y when profile is enabled)
+	foreach my $target (@defaultstargets) {
+		foreach my $profile (@{$target->{profiles}}) {
+			print "\tconfig DEFAULT_PACKAGES_TARGET_".$target->{conf}."_".$profile->{id}."\n";
+			print "\t\tbool\n";
+			print "\t\tdefault y\n";
+			print "\t\tdepends on ( TARGET_".$target->{conf}."_".$profile->{id}." || TARGET_DEVICE_".$target->{conf}."_".$profile->{id}." )\n";
+			my @pkglist = merge_package_lists($target->{packages}, $profile->{packages});
+			foreach my $pkg (@pkglist) {
+				print "\t\tselect DEFAULT_".$pkg."\n";
+				$defaults{$pkg} = 1;
+			}
+			print "\n";
+		}
+	}
+
+	# Default packages for a device type (on only if given device type is selected)
+	foreach my $devicetypename (keys %devicetypes) {
+		my $devicetype = $devicetypes{$devicetypename};
+		foreach my $pkg (@{$devicetype->{packages}}) {
+			print "\tconfig DEFAULT_".${devicetype}->{conf}."_".$pkg."\n";
+			print "\t\tbool\n";
+			print "\t\tdefault y\n";
+			print "\t\tdepends on ".${devicetype}->{conf}."\n";
+			print "\t\tselect DEFAULT_".$pkg."\n\n";
+			$defaults{$pkg} = 1;
+		}
+	}
+
+	# Default packages for all builds
+	foreach my $pkg (@{$defaultpackages}) {
+		print "\tconfig DEFAULT_".$pkg."\n";
+		print "\t\tbool\n";
+		print "\t\tdefault y\n\n";
+		delete($defaults{pkg});
+	}
+
+	# Create the config KConfig option but don't set it to y
+	# This lets us create a list of all possible defaults and use
+	# select in profiles or device type config to actually set
+	# the package as default on.
+	foreach my $pkg (keys %defaults) {
+		print "\tconfig DEFAULT_".$pkg."\n";
+		print "\t\tbool\n";
+	}
+}
+
+sub gen_defaults_mk() {
+	my $file = shift @ARGV;
+	my $target = shift @ARGV;
+	parse_defaults_metadata($file);
+	foreach my $cur (@defaultstargets) {
+		next unless $cur->{id} eq $target;
+		foreach my $profile (@{$cur->{profiles}}) {
+			print $profile->{id}.'_PACKAGES:='.join(' ', @{$profile->{packages}})."\n";
+		}
+	}
+}
+
+sub parse_command() {
+	GetOptions("ignore=s", \@ignore);
+	my $cmd = shift @ARGV;
+	for ($cmd) {
+		/^config$/ and return gen_defaults_config();
+		/^defaults_mk$/ and return gen_defaults_mk();
+	}
+	die <<EOF
+Available Commands:
+	$0 config [file] 			Target metadata in Kconfig format
+	$0 profile_mk [file] [target]		Profile metadata in makefile format
+
+EOF
+}
+
+parse_command();

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -144,7 +144,6 @@ sub merge_package_lists($$) {
 sub gen_target_config() {
 	my $file = shift @ARGV;
 	my @target = parse_target_metadata($file);
-	my %defaults;
 
 	my @target_sort = sort {
 		target_name($a) cmp target_name($b);
@@ -187,6 +186,8 @@ EOF
 print <<EOF;
 endchoice
 
+EOF
+	print <<EOF;
 choice
 	prompt "Target Profile"
 
@@ -215,11 +216,6 @@ config TARGET_$target->{conf}_$profile->{id}
 	bool "$profile->{name}"
 	depends on TARGET_$target->{conf}
 EOF
-			my @pkglist = merge_package_lists($target->{packages}, $profile->{packages});
-			foreach my $pkg (@pkglist) {
-				print "\tselect DEFAULT_$pkg\n";
-				$defaults{$pkg} = 1;
-			}
 			my $help = $profile->{desc};
 			if ($help =~ /\w+/) {
 				$help =~ s/^\s*/\t  /mg;
@@ -247,11 +243,6 @@ config TARGET_DEVICE_$target->{conf}_$profile->{id}
 	bool "$profile->{name}"
 	depends on TARGET_$target->{conf}
 EOF
-			my @pkglist = merge_package_lists($target->{packages}, $profile->{packages});
-			foreach my $pkg (@pkglist) {
-				print "\tselect DEFAULT_$pkg\n";
-				$defaults{$pkg} = 1;
-			}
 		}
 	}
 
@@ -338,10 +329,6 @@ config LINUX_$v
 
 EOF
 	}
-	foreach my $def (sort keys %defaults) {
-		print "\tconfig DEFAULT_".$def."\n";
-		print "\t\tbool\n\n";
-	}
 }
 
 sub gen_profile_mk() {
@@ -353,7 +340,6 @@ sub gen_profile_mk() {
 		print "PROFILE_NAMES = ".join(" ", map { $_->{id} } @{$cur->{profiles}})."\n";
 		foreach my $profile (@{$cur->{profiles}}) {
 			print $profile->{id}.'_NAME:='.$profile->{name}."\n";
-			print $profile->{id}.'_PACKAGES:='.join(' ', @{$profile->{packages}})."\n";
 		}
 	}
 }

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -25,7 +25,12 @@ include $(INCLUDE_DIR)/debug.mk
 include $(INCLUDE_DIR)/depends.mk
 
 include $(INCLUDE_DIR)/version.mk
+include .config
+
 export REVISION
+
+SCAN_COOKIE?=$(shell echo $$$$)
+export SCAN_COOKIE
 
 define Helptext
 Available Commands:
@@ -75,6 +80,10 @@ OPKG:= \
 include $(INCLUDE_DIR)/target.mk
 -include .profiles.mk
 
+ifneq ($(BUILD_IMAGE),)
+  -include .defaults.mk
+endif
+
 USER_PROFILE ?= $(firstword $(PROFILE_NAMES))
 PROFILE_LIST = $(foreach p,$(PROFILE_NAMES), \
 	echo '$(p):'; $(if $($(p)_NAME),echo '    $($(p)_NAME)'; ) echo '    Packages: $($(p)_PACKAGES)'; \
@@ -82,6 +91,13 @@ PROFILE_LIST = $(foreach p,$(PROFILE_NAMES), \
 
 .profiles.mk: .targetinfo
 	$(SCRIPT_DIR)/target-metadata.pl profile_mk $< '$(BOARD)$(if $(SUBTARGET),/$(SUBTARGET))' > $@
+
+$(TOPDIR)/tmp/.defaultsinfo:
+	mkdir -p tmp/info
+	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="defaultsinfo" SCAN_DIR="target/linux" SCAN_NAME="defaults" SCAN_DEPS="image/Makefile profiles/*.mk $(TOPDIR)/include/kernel*.mk $(TOPDIR)/include/target.mk $(TOPDIR)/include/defaults.mk" SCAN_DEPTH=2 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1 SCAN_DEFAULTS=1"
+
+.defaults.mk: $(TOPDIR)/tmp/.defaultsinfo
+	$(SCRIPT_DIR)/defaults-metadata.pl defaults_mk $(TOPDIR)/tmp/.defaultsinfo '$(BOARD)$(if $(SUBTARGET),/$(SUBTARGET))' > .defaults.mk
 
 staging_dir/host/.prereq-build: include/prereq-build.mk
 	mkdir -p tmp
@@ -99,12 +115,13 @@ staging_dir/host/.prereq-build: include/prereq-build.mk
 	touch $@
 
 _call_info: FORCE
+	echo 'Device Type: "$(DEVICE_TYPE)"'
 	echo 'Current Target: "$(BOARD)$(if $(SUBTARGET), ($(BOARDNAME)))"'
-	echo 'Default Packages: $(DEFAULT_PACKAGES)'
+	echo 'Default Packages: $(BASE_DEFAULT_PACKAGES) $(DEFAULT_PACKAGES.$(DEVICE_TYPE)) $(DEFAULT_PACKAGES)'
 	echo 'Available Profiles:'
 	echo; $(PROFILE_LIST)
 
-BUILD_PACKAGES:=$(USER_PACKAGES) $(sort $(DEFAULT_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel)
+BUILD_PACKAGES:=$(USER_PACKAGES) $(sort $(BASE_DEFAULT_PACKAGES) $(DEFAULT_PACKAGES.$(DEVICE_TYPE)) $(DEFAULT_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel)
 # "-pkgname" in the package list means remove "pkgname" from the package list
 BUILD_PACKAGES:=$(filter-out $(filter -%,$(BUILD_PACKAGES)) $(patsubst -%,%,$(filter -%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
 PACKAGES:=
@@ -180,7 +197,7 @@ clean:
 info:
 	(unset PROFILE FILES PACKAGES MAKEFLAGS; $(MAKE) -s _call_info)
 
-image:
+image_target:
 ifneq ($(PROFILE),)
   ifeq ($(filter $(PROFILE),$(PROFILE_NAMES)),)
 	@echo 'Profile "$(PROFILE)" does not exist!'
@@ -194,6 +211,9 @@ endif
 		$(if $(FILES),USER_FILES="$(FILES)") \
 		$(if $(PACKAGES),USER_PACKAGES="$(PACKAGES)") \
 		$(if $(BIN_DIR),BIN_DIR="$(BIN_DIR)"))
+
+image: .defaults.mk
+	$(MAKE) image_target PROFILE=$(PROFILE) PACKAGES="$(PACKAGES)" FILES="$(FILES)" BIN_DIR="$(BIN_DIR)" EXTRA_IMAGE_NAME="$(EXTRA_IMAGE_NAME)" BUILD_IMAGE=1
 
 .SILENT: help info image
 

--- a/target/linux/arc770/Makefile
+++ b/target/linux/arc770/Makefile
@@ -14,7 +14,7 @@ SUBTARGETS:=generic
 
 KERNEL_PATCHVER:=4.4
 
-DEVICE_TYPE:=developerboard
+TARGET_DEVICE_TYPE:=developerboard
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/archs38/Makefile
+++ b/target/linux/archs38/Makefile
@@ -15,7 +15,7 @@ SUBTARGETS:=generic
 
 KERNEL_PATCHVER:=4.4
 
-DEVICE_TYPE:=developerboard
+TARGET_DEVICE_TYPE:=developerboard
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/arm64/Makefile
+++ b/target/linux/arm64/Makefile
@@ -15,7 +15,7 @@ MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 
 KERNEL_PATCHVER:=4.4
 
-DEVICE_TYPE:=developerboard
+TARGET_DEVICE_TYPE:=developerboard
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/mcs814x/Makefile
+++ b/target/linux/mcs814x/Makefile
@@ -15,7 +15,7 @@ MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 
 KERNEL_PATCHVER:=3.18
 
-DEVICE_TYPE:=other
+TARGET_DEVICE_TYPE:=other
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/oxnas/Makefile
+++ b/target/linux/oxnas/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=oxnas
 BOARDNAME:=PLXTECH/Oxford NAS782x/OX82x
-DEVICE_TYPE:=nas
+TARGET_DEVICE_TYPE:=nas
 FEATURES:=gpio nand pcie usb ramdisk rtc squashfs ubifs
 CPU_TYPE:=mpcore
 

--- a/target/linux/realview/Makefile
+++ b/target/linux/realview/Makefile
@@ -16,7 +16,7 @@ MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 
 KERNEL_PATCHVER:=4.4
 
-DEVICE_TYPE:=developerboard
+TARGET_DEVICE_TYPE:=developerboard
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/xburst/Makefile
+++ b/target/linux/xburst/Makefile
@@ -14,7 +14,7 @@ SUBTARGETS:=qi_lb60
 
 KERNEL_PATCHVER:=3.18
 
-DEVICE_TYPE=other
+TARGET_DEVICE_TYPE=other
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -92,6 +92,7 @@ $(BIN_DIR)/$(SDK_NAME).tar.bz2: clean
 
 	mkdir -p $(SDK_BUILD_DIR)/target/linux
 	$(CP) $(GENERIC_PLATFORM_DIR) $(PLATFORM_DIR) $(SDK_BUILD_DIR)/target/linux/
+	$(CP) $(TOPDIR)/config/Config-device.in $(SDK_BUILD_DIR)/
 	rm -rf \
 		$(SDK_BUILD_DIR)/target/linux/*/files* \
 		$(SDK_BUILD_DIR)/target/linux/*/patches*

--- a/target/sdk/convert-config.pl
+++ b/target/sdk/convert-config.pl
@@ -8,6 +8,10 @@ while (<>) {
 	my $type;
 	chomp;
 	next if /^CONFIG_SIGNED_PACKAGES/;
+	next if /^(# )?CONFIG_DEVICE_TYPE/;
+	next if /^(# )?CONFIG_USE_DEVICE_TYPE/;
+	next if /^(# )?CONFIG_DT_USE/;
+	next if /^(# )?CONFIG_DEFAULT/;
 
 	if (/^CONFIG_([^=]+)=(.*)$/) {
 		$var = $1;

--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -19,5 +19,7 @@ config MODULES
 	default y
 	option modules
 
+source "Config-device.in"
 source "Config-build.in"
 source "tmp/.config-package.in"
+source "tmp/.config-defaults.in"


### PR DESCRIPTION
Has been menuconfig's but not yet built (hence Untested Request for Comments).

Prior to this patch doing something that changed the DEFAULT_
package selections required removing $(TOPDIR)/tmp and
regenerating the metadata.  This patch fixes and and uses it
to make DEVICE_TYPE a configuration option (which allows
for different default package selection for e.g. router
vs NAS).  This should also make it easier to allow for
different build options depending on target device type.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>

This was motivated primarily by an issue I noticed when trying to create a minimal SDK and then use it to build packages for images generated by ImageBuilder with CONFIG_ALL turned off.  The lack of sane default packages meant manual package selection was necessary.

As it turns out the fix also allows to make DEVICE_TYPE more useful by allowing it to be a configuration option which can be influenced by the profile (or even device with the new multi profile work).