### PR TITLE
Allow to build a minimal SDK/IB

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -19,6 +19,8 @@ source "target/Config.in"
 
 source "config/Config-images.in"
 
+source "config/Config-device.in"
+
 source "config/Config-build.in"
 
 source "config/Config-devel.in"
@@ -32,3 +34,5 @@ source "target/sdk/Config.in"
 source "target/toolchain/Config.in"
 
 source "tmp/.config-package.in"
+
+source "tmp/.config-defaults.in"

--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -17,6 +17,7 @@ menu "Global build settings"
 
 	config ALL
 		bool "Select all userspace packages by default"
+		depends on !SDK_MINIMAL
 		default n
 
 	config SIGNED_PACKAGES

--- a/config/Config-device.in
+++ b/config/Config-device.in
@@ -1,0 +1,79 @@
+# Copyright (C) 2006-2013 OpenWrt.org
+# Copyright (C) 2016 LEDE Project
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+config USE_DEVICE_TYPE_router
+	bool
+
+config USE_DEVICE_TYPE_nas
+	bool
+
+config USE_DEVICE_TYPE_bootloader
+	bool
+
+config USE_DEVICE_TYPE_developerboard
+	bool
+
+config USE_DEVICE_TYPE_other
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_router
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_nas
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_bootloader
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_developerboard
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_other
+	bool
+
+config DEFAULT_USE_DEVICE_TYPE_minimal_sdk
+	bool
+
+choice
+	prompt "Device Type"
+	default DT_USE_DEVICE_TYPE_router if DEFAULT_USE_DEVICE_TYPE_router
+	default DT_USE_DEVICE_TYPE_nas if DEFAULT_USE_DEVICE_TYPE_nas
+	default DT_USE_DEVICE_TYPE_bootloader if DEFAULT_USE_DEVICE_TYPE_booloader
+	default DT_USE_DEVICE_TYPE_developerboard if DEFAULT_USE_DEVICE_TYPE_developerboard
+	default DT_USE_DEVICE_TYPE_other if DEFAULT_USE_DEVICE_TYPE_other
+	help
+	  "Set default build options based on device type (e.g. router, nas)"
+
+	config DT_USE_DEVICE_TYPE_router
+		bool "Router"
+		select USE_DEVICE_TYPE_router
+
+	config DT_USE_DEVICE_TYPE_nas
+		bool "NAS"
+		select USE_DEVICE_TYPE_nas
+
+	config DT_USE_DEVICE_TYPE_bootloader
+		bool "Bootloader"
+		select USE_DEVICE_TYPE_bootloader
+
+	config DT_USE_DEVICE_TYPE_developerboard
+		bool "Developer Board"
+		select USE_DEVICE_TYPE_developerboard
+
+	config DT_USE_DEVICE_TYPE_other
+		bool "Other"
+		select USE_DEVICE_TYPE_other
+
+endchoice
+
+config DEVICE_TYPE
+	string
+	default "router" if USE_DEVICE_TYPE_router
+	default "nas" if USE_DEVICE_TYPE_nas
+	default "bootloader" if USE_DEVICE_TYPE_bootloader
+	default "developerboard" if USE_DEVICE_TYPE_developerboard
+	default "other" if USE_DEVICE_TYPE_other

--- a/config/Config-device.in
+++ b/config/Config-device.in
@@ -20,6 +20,9 @@ config USE_DEVICE_TYPE_developerboard
 config USE_DEVICE_TYPE_other
 	bool
 
+config USE_DEVICE_TYPE_minimal_sdk
+	bool
+
 config DEFAULT_USE_DEVICE_TYPE_router
 	bool
 
@@ -45,6 +48,7 @@ choice
 	default DT_USE_DEVICE_TYPE_bootloader if DEFAULT_USE_DEVICE_TYPE_booloader
 	default DT_USE_DEVICE_TYPE_developerboard if DEFAULT_USE_DEVICE_TYPE_developerboard
 	default DT_USE_DEVICE_TYPE_other if DEFAULT_USE_DEVICE_TYPE_other
+	default DT_USE_DEVICE_TYPE_minimal_sdk if SDK_MINIMAL
 	help
 	  "Set default build options based on device type (e.g. router, nas)"
 
@@ -68,6 +72,11 @@ choice
 		bool "Other"
 		select USE_DEVICE_TYPE_other
 
+	config DT_USE_DEVICE_TYPE_minimal_sdk
+		bool "Minimal SDK"
+		select USE_DEVICE_TYPE_minimal_sdk
+
+
 endchoice
 
 config DEVICE_TYPE
@@ -77,3 +86,4 @@ config DEVICE_TYPE
 	default "bootloader" if USE_DEVICE_TYPE_bootloader
 	default "developerboard" if USE_DEVICE_TYPE_developerboard
 	default "other" if USE_DEVICE_TYPE_other
+	default "minimal_sdk" if USE_DEVICE_TYPE_minimal_sdk

--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -8,7 +8,7 @@ menu "Target Images"
 
 	menuconfig TARGET_ROOTFS_INITRAMFS
 		bool "ramdisk"
-		default y if USES_INITRAMFS
+		default y if ( USES_INITRAMFS && !SDK_MINIMAL )
 		help
 		  Embed the root filesystem into the kernel (initramfs).
 
@@ -54,13 +54,13 @@ menu "Target Images"
 
 	config TARGET_ROOTFS_CPIOGZ
 		bool "cpio.gz"
-		default y if USES_CPIOGZ
+		default y if ( USES_CPIOGZ && !SDK_MINIMAL )
 		help
 		  Build a compressed cpio archive of the root filesystem.
 
 	config TARGET_ROOTFS_TARGZ
 		bool "tar.gz"
-		default y if USES_TARGZ
+		default y if ( USES_TARGZ && !SDK_MINIMAL )
 		help
 		  Build a compressed tar archive of the root filesystem.
 
@@ -68,7 +68,7 @@ menu "Target Images"
 
 	menuconfig TARGET_ROOTFS_EXT4FS
 		bool "ext4"
-		default y if USES_EXT4
+		default y if ( USES_EXT4 && !SDK_MINIMAL )
 		help
 		  Build an ext4 root filesystem.
 
@@ -126,20 +126,20 @@ menu "Target Images"
 
 	config TARGET_ROOTFS_JFFS2
 		bool "jffs2"
-		default y if USES_JFFS2
+		default y if ( USES_JFFS2 && !SDK_MINIMAL )
 		help
 		  Build a JFFS2 root filesystem.
 
 	config TARGET_ROOTFS_JFFS2_NAND
 		bool "jffs2 for NAND"
-		default y if USES_JFFS2_NAND
+		default y if ( USES_JFFS2_NAND && !SDK_MINIMAL )
 		depends on USES_JFFS2_NAND
 		help
 		  Build a JFFS2 root filesystem for NAND flash.
 
 	menuconfig TARGET_ROOTFS_SQUASHFS
 		bool "squashfs"
-		default y if USES_SQUASHFS
+		default y if ( USES_SQUASHFS && !SDK_MINIMAL )
 		help
 		  Build a squashfs-lzma root filesystem.
 
@@ -151,7 +151,7 @@ menu "Target Images"
 
 	menuconfig TARGET_ROOTFS_UBIFS
 		bool "ubifs"
-		default y if USES_UBIFS
+		default y if ( USES_UBIFS && !SDK_MINIMAL )
 		depends on USES_UBIFS
 		help
 		  Build a UBIFS root filesystem.
@@ -189,7 +189,7 @@ menu "Target Images"
 		depends on TARGET_x86
 		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_ISO || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS
 		select PACKAGE_grub2
-		default y
+		default y if !SDK_MINIMAL
 
 	config GRUB_CONSOLE
 		bool "Use Console Terminal (in addition to Serial)"
@@ -245,7 +245,7 @@ menu "Target Images"
 	config TARGET_IMAGES_GZIP
 		bool "GZip images"
 		depends on TARGET_IMAGES_PAD || TARGET_ROOTFS_EXT4FS
-		default y
+		default y if !SDK_MINIMAL
 
 	comment "Image Options"
 

--- a/include/defaults.mk
+++ b/include/defaults.mk
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2007-2008 OpenWrt.org
+# Copyright (C) 2016 LEDE Project
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+ifneq ($(__defaults_inc),1)
+__defaults_inc=1
+
+# default device type
+DEVICE_TYPE:=$(if $(call qstrip,$(CONFIG_DEVICE_TYPE)),$(call qstrip,$(CONFIG_DEVICE_TYPE)),router)
+DEVICE_TYPES:=nas router bootloader developerboard other
+
+# Default packages - the really basic set
+BASE_DEFAULT_PACKAGES:=base-files libc libgcc busybox opkg
+
+DEFAULT_PACKAGES.device_common:=dropbear mtd uci netifd fstools uclient-fetch logd
+# For nas targets
+DEFAULT_PACKAGES.nas:=block-mount fdisk lsblk mdadm $(DEFAULT_PACKAGES.device_common)
+# For router targets
+DEFAULT_PACKAGES.router:=dnsmasq iptables ip6tables ppp ppp-mod-pppoe firewall odhcpd odhcp6c $(DEFAULT_PACKAGES.device_common)
+DEFAULT_PACKAGES.bootloader:=
+DEFAULT_PACKAGES.other:=$(DEFAULT_PACKAGES.device_common)
+DEFAULT_PACKAGES.developerboard:=$(DEFAULT_PACKAGES.device_common)
+
+filter_packages = $(filter-out -% $(patsubst -%,%,$(filter -%,$(1))),$(1))
+extra_packages = $(if $(filter wpad-mini wpad nas,$(1)),iwinfo)
+
+ifneq ($(DUMP_DEFAULTS_BASE),)
+
+define DeviceTypeDefaults
+	echo 'Device-Type: $(1)'; \
+	echo 'Device-Type-Conf: USE_DEVICE_TYPE_$(1)'; \
+	echo 'Device-Type-Packages: $(DEFAULT_PACKAGES.$(1)) $(call extra_packages,$(DEFAULT_PACKAGES.$(1)))' ; \
+	echo '@@' ;
+endef
+
+define BuildDefaults/DumpCurrent
+  all:
+	@echo 'Base-Default-Packages: $(BASE_DEFAULT_PACKAGES)'; \
+	 echo '@@' ; \
+	 $(foreach dt,$(DEVICE_TYPES),$(call DeviceTypeDefaults,$(dt)))
+endef
+
+$(eval $(call BuildDefaults/DumpCurrent))
+
+else
+
+include $(TOPDIR)/include/profiles.mk
+
+# DEFAULT_PACKAGES may appended in target definitions
+define BuildDefaults/DumpCurrent
+  .PHONY: dumpinfo
+  dumpinfo:
+	@echo 'Target: $(TARGETID)'; \
+	 echo 'Default-Packages: $(DEFAULT_PACKAGES) $(call extra_packages,$(DEFAULT_PACKAGES))'; \
+	 $(PKGDUMPINFO)
+	$(if $(CUR_SUBTARGET),$(SUBMAKE) -r --no-print-directory -C image -s DUMP=1 SUBTARGET=$(CUR_SUBTARGET))
+	$(if $(SUBTARGET),,@$(foreach SUBTARGET,$(SUBTARGETS),$(SUBMAKE) -s DUMP=1 SUBTARGET=$(SUBTARGET); ))
+endef
+
+include $(TOPDIR)/include/target.mk
+
+endif #DUMP_DEFAULTS_BASE
+
+endif #__defaults_inc

--- a/include/defaults.mk
+++ b/include/defaults.mk
@@ -11,7 +11,7 @@ __defaults_inc=1
 
 # default device type
 DEVICE_TYPE:=$(if $(call qstrip,$(CONFIG_DEVICE_TYPE)),$(call qstrip,$(CONFIG_DEVICE_TYPE)),router)
-DEVICE_TYPES:=nas router bootloader developerboard other
+DEVICE_TYPES:=nas router bootloader developerboard other minimal_sdk
 
 # Default packages - the really basic set
 BASE_DEFAULT_PACKAGES:=base-files libc libgcc busybox opkg
@@ -22,6 +22,7 @@ DEFAULT_PACKAGES.nas:=block-mount fdisk lsblk mdadm $(DEFAULT_PACKAGES.device_co
 # For router targets
 DEFAULT_PACKAGES.router:=dnsmasq iptables ip6tables ppp ppp-mod-pppoe firewall odhcpd odhcp6c $(DEFAULT_PACKAGES.device_common)
 DEFAULT_PACKAGES.bootloader:=
+DEFAULT_PACKAGES.minimal_sdk:=
 DEFAULT_PACKAGES.other:=$(DEFAULT_PACKAGES.device_common)
 DEFAULT_PACKAGES.developerboard:=$(DEFAULT_PACKAGES.device_common)
 

--- a/include/profiles.mk
+++ b/include/profiles.mk
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2007-2008 OpenWrt.org
+# Copyright (C) 2016 LEDE Project
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+ifneq ($(__profiles_inc),1)
+__profiles_inc=1
+
+ifneq ($(DUMP),)
+  all: dumpinfo
+endif
+
+include $(TOPDIR)/include/target.mk
+include $(TOPDIR)/include/defaults.mk
+
+define ProfileDefault
+  NAME:=
+  PRIORITY:=
+  PACKAGES:=
+endef
+
+ifndef Profile
+define Profile
+  $(eval $(call ProfileDefault))
+  $(eval $(call Profile/$(1)))
+  dumpinfo : $(call shexport,Profile/$(1)/Description)
+  PKGDUMPINFO += \
+	echo "Target-Profile: $(1)"; \
+	echo "Target-Profile-Packages: $(PACKAGES) $(call extra_packages,$(DEFAULT_PACKAGES) $(PACKAGES))"; \
+	echo "@@"; \
+	echo;
+  DUMPINFO += \
+	echo "Target-Profile: $(1)"; \
+	$(if $(PRIORITY), echo "Target-Profile-Priority: $(PRIORITY)"; ) \
+	echo "Target-Profile-Name: $(NAME)"; \
+	echo "Target-Profile-Device-Type: $(if $(TARGET_DEVICE_TYPE),$(TARGET_DEVICE_TYPE),router)"; \
+	echo "Target-Profile-Description:"; \
+	echo "$$$$$$$$$(call shvar,Profile/$(1)/Description)"; \
+	echo "@@"; \
+	echo;
+endef
+endif
+
+ifneq ($(PLATFORM_DIR),$(PLATFORM_SUBDIR))
+  define IncludeProfiles
+    -include $(sort $(wildcard $(PLATFORM_DIR)/profiles/*.mk))
+    -include $(sort $(wildcard $(PLATFORM_SUBDIR)/profiles/*.mk))
+  endef
+else
+  define IncludeProfiles
+    -include $(sort $(wildcard $(PLATFORM_DIR)/profiles/*.mk))
+  endef
+endif
+
+PROFILE:=$(call qstrip,$(CONFIG_TARGET_PROFILE))
+
+ifeq ($(TARGET_BUILD),1)
+  ifneq ($(DUMP),)
+    $(eval $(call IncludeProfiles))
+  endif
+endif
+
+endif #__profiles_inc

--- a/include/scan.mk
+++ b/include/scan.mk
@@ -47,10 +47,14 @@ $(OVERRIDELIST):
 	rm -f $(TMP_DIR)/info/.overrides-$(SCAN_TARGET)-*
 	touch $@
 
+ifeq ($(SCAN_NAME),defaults)
+  GREP_STRING=BuildTarget
+else
 ifeq ($(SCAN_NAME),target)
   GREP_STRING=BuildTarget
 else
   GREP_STRING=(Build/DefaultTargets|BuildPackage|.+Package)
+endif
 endif
 
 $(FILELIST): $(OVERRIDELIST)
@@ -82,7 +86,7 @@ $(TMP_DIR)/info/.files-$(SCAN_TARGET).mk: $(FILELIST)
 
 $(TARGET_STAMP)::
 	+( \
-		$(NO_TRACE_MAKE) $(FILELIST); \
+		$(NO_TRACE_MAKE) -f $(TOPDIR)/include/scan.mk $(FILELIST); \
 		MD5SUM=$$(cat $(FILELIST) $(OVERRIDELIST) | (md5sum || md5) 2>/dev/null | awk '{print $$1}'); \
 		[ -f "$@.$$MD5SUM" ] || { \
 			rm -f $@.*; \

--- a/include/target.mk
+++ b/include/target.mk
@@ -9,17 +9,6 @@
 ifneq ($(__target_inc),1)
 __target_inc=1
 
-# default device type
-DEVICE_TYPE?=router
-
-# Default packages - the really basic set
-DEFAULT_PACKAGES:=base-files libc libgcc busybox dropbear mtd uci opkg netifd fstools uclient-fetch logd
-# For nas targets
-DEFAULT_PACKAGES.nas:=block-mount fdisk lsblk mdadm
-# For router targets
-DEFAULT_PACKAGES.router:=dnsmasq iptables ip6tables ppp ppp-mod-pppoe firewall odhcpd odhcp6c
-DEFAULT_PACKAGES.bootloader:=
-
 ifneq ($(DUMP),)
   all: dumpinfo
 endif
@@ -51,53 +40,8 @@ else
   endif
 endif
 
-# Add device specific packages (here below to allow device type set from subtarget)
-DEFAULT_PACKAGES += $(DEFAULT_PACKAGES.$(DEVICE_TYPE))
-
-filter_packages = $(filter-out -% $(patsubst -%,%,$(filter -%,$(1))),$(1))
-extra_packages = $(if $(filter wpad-mini wpad nas,$(1)),iwinfo)
-
-define ProfileDefault
-  NAME:=
-  PRIORITY:=
-  PACKAGES:=
-endef
-
-ifndef Profile
-define Profile
-  $(eval $(call ProfileDefault))
-  $(eval $(call Profile/$(1)))
-  dumpinfo : $(call shexport,Profile/$(1)/Description)
-  DUMPINFO += \
-	echo "Target-Profile: $(1)"; \
-	$(if $(PRIORITY), echo "Target-Profile-Priority: $(PRIORITY)"; ) \
-	echo "Target-Profile-Name: $(NAME)"; \
-	echo "Target-Profile-Packages: $(PACKAGES) $(call extra_packages,$(DEFAULT_PACKAGES) $(PACKAGES))"; \
-	echo "Target-Profile-Description:"; \
-	echo "$$$$$$$$$(call shvar,Profile/$(1)/Description)"; \
-	echo "@@"; \
-	echo;
-endef
-endif
-
-ifneq ($(PLATFORM_DIR),$(PLATFORM_SUBDIR))
-  define IncludeProfiles
-    -include $(sort $(wildcard $(PLATFORM_DIR)/profiles/*.mk))
-    -include $(sort $(wildcard $(PLATFORM_SUBDIR)/profiles/*.mk))
-  endef
-else
-  define IncludeProfiles
-    -include $(sort $(wildcard $(PLATFORM_DIR)/profiles/*.mk))
-  endef
-endif
-
-PROFILE:=$(call qstrip,$(CONFIG_TARGET_PROFILE))
-
-ifeq ($(TARGET_BUILD),1)
-  ifneq ($(DUMP),)
-    $(eval $(call IncludeProfiles))
-  endif
-endif
+include $(TOPDIR)/include/defaults.mk
+include $(TOPDIR)/include/profiles.mk
 
 ifneq ($(TARGET_BUILD)$(if $(DUMP),,1),)
   include $(INCLUDE_DIR)/kernel-version.mk
@@ -153,7 +97,7 @@ LINUX_RECONF_CMD = $(call __linux_confcmd,$(LINUX_RECONFIG_LIST),)
 LINUX_RECONF_DIFF = $(call __linux_confcmd,$(filter-out $(LINUX_RECONFIG_TARGET),$(LINUX_RECONFIG_LIST)),'>')
 
 ifeq ($(DUMP),1)
-  BuildTarget=$(BuildTargets/DumpCurrent)
+  BuildTarget=$(if $(SCAN_DEFAULTS),$(BuildDefaults/DumpCurrent),$(BuildTargets/DumpCurrent))
 
   ifneq ($(BOARD),)
     TMP_CONFIG:=$(TMP_DIR)/.kconfig-$(call target_conf,$(TARGETID))
@@ -280,6 +224,7 @@ define BuildTargets/DumpCurrent
 	 echo 'Target-Arch: $(ARCH)'; \
 	 echo 'Target-Arch-Packages: $(if $(ARCH_PACKAGES),$(ARCH_PACKAGES),$(ARCH)$(if $(CPU_TYPE),_$(CPU_TYPE))$(if $(CPU_SUBTYPE),_$(CPU_SUBTYPE)))'; \
 	 echo 'Target-Features: $(FEATURES)'; \
+	 echo 'Target-Device-Type: $(if $(TARGET_DEVICE_TYPE),$(TARGET_DEVICE_TYPE),router)'; \
 	 echo 'Target-Depends: $(DEPENDS)'; \
 	 echo 'Target-Optimization: $(if $(CFLAGS),$(CFLAGS),$(DEFAULT_CFLAGS))'; \
 	 echo 'CPU-Type: $(CPU_TYPE)$(if $(CPU_SUBTYPE),+$(CPU_SUBTYPE))'; \
@@ -290,7 +235,6 @@ define BuildTargets/DumpCurrent
 	 echo 'Target-Description:'; \
 	 echo "$$$$DESCRIPTION"; \
 	 echo '@@'; \
-	 echo 'Default-Packages: $(DEFAULT_PACKAGES) $(call extra_packages,$(DEFAULT_PACKAGES))'; \
 	 $(DUMPINFO)
 	$(if $(CUR_SUBTARGET),$(SUBMAKE) -r --no-print-directory -C image -s DUMP=1 SUBTARGET=$(CUR_SUBTARGET))
 	$(if $(SUBTARGET),,@$(foreach SUBTARGET,$(SUBTARGETS),$(SUBMAKE) -s DUMP=1 SUBTARGET=$(SUBTARGET); ))

--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -79,7 +79,9 @@ prepare-tmpinfo: FORCE
 	mkdir -p tmp/info
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="packageinfo" SCAN_DIR="package" SCAN_NAME="package" SCAN_DEPS="$(TOPDIR)/include/package*.mk $(TOPDIR)/overlay/*/*.mk" SCAN_DEPTH=5 SCAN_EXTRA=""
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="targetinfo" SCAN_DIR="target/linux" SCAN_NAME="target" SCAN_DEPS="image/Makefile profiles/*.mk $(TOPDIR)/include/kernel*.mk $(TOPDIR)/include/target.mk" SCAN_DEPTH=2 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1"
-	for type in package target; do \
+	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="defaultsinfo" SCAN_DIR="target/linux" SCAN_NAME="defaults" SCAN_DEPS="image/Makefile profiles/*.mk $(TOPDIR)/include/kernel*.mk $(TOPDIR)/include/target.mk $(TOPDIR)/include/defaults.mk" SCAN_DEPTH=2 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1 SCAN_DEFAULTS=1"
+	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f $(TOPDIR)/include/defaults.mk DUMP_DEFAULTS_BASE=1 >>tmp/.defaultsinfo
+	for type in package target defaults; do \
 		f=tmp/.$${type}info; t=tmp/.config-$${type}.in; \
 		[ "$$t" -nt "$$f" ] || ./scripts/$${type}-metadata.pl $(_ignore) config "$$f" > "$$t" || { rm -f "$$t"; echo "Failed to build $$t"; false; break; }; \
 	done

--- a/scripts/defaults-metadata.pl
+++ b/scripts/defaults-metadata.pl
@@ -1,0 +1,102 @@
+#!/usr/bin/env perl
+use FindBin;
+use lib "$FindBin::Bin";
+use strict;
+use metadata;
+use Getopt::Long;
+
+sub merge_package_lists($$) {
+	my $list1 = shift;
+	my $list2 = shift;
+	my @l = ();
+	my %pkgs;
+
+	foreach my $pkg (@$list1, @$list2) {
+		$pkgs{$pkg} = 1;
+	}
+	foreach my $pkg (keys %pkgs) {
+		push @l, $pkg unless ($pkg =~ /^-/ or $pkgs{"-$pkg"});
+	}
+	return sort(@l);
+}
+
+sub gen_defaults_config() {
+	my $file = shift @ARGV;
+	parse_defaults_metadata($file);
+	my %defaults = ();
+
+	# Default packages for a profile (default n; becomes y when profile is enabled)
+	foreach my $target (@defaultstargets) {
+		foreach my $profile (@{$target->{profiles}}) {
+			print "\tconfig DEFAULT_PACKAGES_TARGET_".$target->{conf}."_".$profile->{id}."\n";
+			print "\t\tbool\n";
+			print "\t\tdefault y\n";
+			print "\t\tdepends on ( TARGET_".$target->{conf}."_".$profile->{id}." || TARGET_DEVICE_".$target->{conf}."_".$profile->{id}." )\n";
+			my @pkglist = merge_package_lists($target->{packages}, $profile->{packages});
+			foreach my $pkg (@pkglist) {
+				print "\t\tselect DEFAULT_".$pkg."\n";
+				$defaults{$pkg} = 1;
+			}
+			print "\n";
+		}
+	}
+
+	# Default packages for a device type (on only if given device type is selected)
+	foreach my $devicetypename (keys %devicetypes) {
+		my $devicetype = $devicetypes{$devicetypename};
+		foreach my $pkg (@{$devicetype->{packages}}) {
+			print "\tconfig DEFAULT_".${devicetype}->{conf}."_".$pkg."\n";
+			print "\t\tbool\n";
+			print "\t\tdefault y\n";
+			print "\t\tdepends on ".${devicetype}->{conf}."\n";
+			print "\t\tselect DEFAULT_".$pkg."\n\n";
+			$defaults{$pkg} = 1;
+		}
+	}
+
+	# Default packages for all builds
+	foreach my $pkg (@{$defaultpackages}) {
+		print "\tconfig DEFAULT_".$pkg."\n";
+		print "\t\tbool\n";
+		print "\t\tdefault y\n\n";
+		delete($defaults{pkg});
+	}
+
+	# Create the config KConfig option but don't set it to y
+	# This lets us create a list of all possible defaults and use
+	# select in profiles or device type config to actually set
+	# the package as default on.
+	foreach my $pkg (keys %defaults) {
+		print "\tconfig DEFAULT_".$pkg."\n";
+		print "\t\tbool\n";
+	}
+}
+
+sub gen_defaults_mk() {
+	my $file = shift @ARGV;
+	my $target = shift @ARGV;
+	parse_defaults_metadata($file);
+	foreach my $cur (@defaultstargets) {
+		next unless $cur->{id} eq $target;
+		foreach my $profile (@{$cur->{profiles}}) {
+			print $profile->{id}.'_PACKAGES:='.join(' ', @{$profile->{packages}})."\n";
+		}
+	}
+}
+
+sub parse_command() {
+	GetOptions("ignore=s", \@ignore);
+	my $cmd = shift @ARGV;
+	for ($cmd) {
+		/^config$/ and return gen_defaults_config();
+		/^defaults_mk$/ and return gen_defaults_mk();
+	}
+	die <<EOF
+Available Commands:
+	$0 config [file] 			Target metadata in Kconfig format
+	$0 profile_mk [file] [target]		Profile metadata in makefile format
+
+EOF
+}
+
+parse_command();

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -144,7 +144,6 @@ sub merge_package_lists($$) {
 sub gen_target_config() {
 	my $file = shift @ARGV;
 	my @target = parse_target_metadata($file);
-	my %defaults;
 
 	my @target_sort = sort {
 		target_name($a) cmp target_name($b);
@@ -187,6 +186,8 @@ EOF
 print <<EOF;
 endchoice
 
+EOF
+	print <<EOF;
 choice
 	prompt "Target Profile"
 
@@ -215,11 +216,6 @@ config TARGET_$target->{conf}_$profile->{id}
 	bool "$profile->{name}"
 	depends on TARGET_$target->{conf}
 EOF
-			my @pkglist = merge_package_lists($target->{packages}, $profile->{packages});
-			foreach my $pkg (@pkglist) {
-				print "\tselect DEFAULT_$pkg\n";
-				$defaults{$pkg} = 1;
-			}
 			my $help = $profile->{desc};
 			if ($help =~ /\w+/) {
 				$help =~ s/^\s*/\t  /mg;
@@ -247,11 +243,6 @@ config TARGET_DEVICE_$target->{conf}_$profile->{id}
 	bool "$profile->{name}"
 	depends on TARGET_$target->{conf}
 EOF
-			my @pkglist = merge_package_lists($target->{packages}, $profile->{packages});
-			foreach my $pkg (@pkglist) {
-				print "\tselect DEFAULT_$pkg\n";
-				$defaults{$pkg} = 1;
-			}
 		}
 	}
 
@@ -338,10 +329,6 @@ config LINUX_$v
 
 EOF
 	}
-	foreach my $def (sort keys %defaults) {
-		print "\tconfig DEFAULT_".$def."\n";
-		print "\t\tbool\n\n";
-	}
 }
 
 sub gen_profile_mk() {
@@ -353,7 +340,6 @@ sub gen_profile_mk() {
 		print "PROFILE_NAMES = ".join(" ", map { $_->{id} } @{$cur->{profiles}})."\n";
 		foreach my $profile (@{$cur->{profiles}}) {
 			print $profile->{id}.'_NAME:='.$profile->{name}."\n";
-			print $profile->{id}.'_PACKAGES:='.join(' ', @{$profile->{packages}})."\n";
 		}
 	}
 }

--- a/target/convert-config.pl
+++ b/target/convert-config.pl
@@ -12,6 +12,7 @@ while (<>) {
 	next if /^(# )?CONFIG_USE_DEVICE_TYPE/;
 	next if /^(# )?CONFIG_DT_USE/;
 	next if /^(# )?CONFIG_DEFAULT/;
+	next if /^CONFIG_SDK_MINIMAL/;
 
 	if (/^CONFIG_([^=]+)=(.*)$/) {
 		$var = $1;

--- a/target/imagebuilder/Config.in
+++ b/target/imagebuilder/Config.in
@@ -1,6 +1,7 @@
 config IB
 	bool "Build the LEDE Image Builder"
 	depends on !EXTERNAL_TOOLCHAIN
+	default y if SDK_MINIMAL
 	help
 	  This is essentially a stripped-down version of the buildroot
 	  with precompiled packages, kernel image and image building tools.
@@ -8,7 +9,7 @@ config IB
 
 config IB_STANDALONE
 	bool "Include package repositories"
-	default y
+	default y if !SDK_MINIMAL
 	depends on IB
 	help
 	  Disabling this option will cause the ImageBuilder to embed only

--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -24,8 +24,8 @@ all: compile
 $(BIN_DIR)/$(IB_NAME).tar.bz2: clean
 	rm -rf $(PKG_BUILD_DIR)
 	mkdir -p $(IB_KDIR) $(IB_LDIR) $(PKG_BUILD_DIR)/staging_dir/host/lib \
-		$(PKG_BUILD_DIR)/target $(PKG_BUILD_DIR)/scripts $(IB_DTSDIR)
-	-cp $(TOPDIR)/.config $(PKG_BUILD_DIR)/.config
+		$(PKG_BUILD_DIR)/target $(IB_DTSDIR)
+	../convert-config.pl $(TOPDIR)/.config > $(PKG_BUILD_DIR)/Config-build.in
 	$(CP) \
 		$(INCLUDE_DIR) $(SCRIPT_DIR) \
 		$(TOPDIR)/rules.mk \
@@ -33,7 +33,14 @@ $(BIN_DIR)/$(IB_NAME).tar.bz2: clean
 		./files/repositories.conf \
 		$(TMP_DIR)/.targetinfo \
 		$(TMP_DIR)/.packageinfo \
+		./files/Config.in \
+		$(TOPDIR)/config/Config-images.in \
 		$(PKG_BUILD_DIR)/
+	$(CP) $(TOPDIR)/config/Config-device.in $(PKG_BUILD_DIR)/
+	if [ -r $(TOPDIR)/linux/$(BOARD)/image/Config.in ]; then \
+		$(CP) $(TOPDIR)/linux/$(BOARD)/image/Config.in $(PKG_BUILD_DIR)/Config-$(BOARD).in ; \
+		echo "\nsource \"Config-$(BOARD).in\"" >$(PKG_BUILD_DIR)/Config.in ; \
+	fi
 
 ifeq ($(CONFIG_IB_STANDALONE),)
 	echo '## Remote package repositories' >> $(PKG_BUILD_DIR)/repositories.conf

--- a/target/imagebuilder/files/Config.in
+++ b/target/imagebuilder/files/Config.in
@@ -1,0 +1,3 @@
+source "Config-device.in"
+source "Config-build.in"
+source "Config-images.in"

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -9,8 +9,11 @@
 TOPDIR:=${CURDIR}
 LC_ALL:=C
 LANG:=C
-export TOPDIR LC_ALL LANG
+export TOPDIR LC_ALL LANG IB
 export OPENWRT_VERBOSE=s
+
+IB:=1
+
 all: help
 
 include $(TOPDIR)/include/host.mk
@@ -25,7 +28,10 @@ include $(INCLUDE_DIR)/debug.mk
 include $(INCLUDE_DIR)/depends.mk
 
 include $(INCLUDE_DIR)/version.mk
-include .config
+
+ifneq ($(BUILD_IMAGE),)
+  -include .config
+endif
 
 export REVISION
 
@@ -216,6 +222,31 @@ endif
 
 image: .defaults.mk
 	$(MAKE) image_target PROFILE=$(PROFILE) PACKAGES="$(PACKAGES)" FILES="$(FILES)" BIN_DIR="$(BIN_DIR)" EXTRA_IMAGE_NAME="$(EXTRA_IMAGE_NAME)" BUILD_IMAGE=1
+
+.config: ./scripts/config/conf
+	@+if [ \! -e .config ] || ! grep CONFIG_HAVE_DOT_CONFIG .config >/dev/null; then \
+		[ -e $(HOME)/.cshorewrt/defconfig ] && cp $(HOME)/.cshorewrt/defconfig .config; \
+		$(_SINGLE)$(NO_TRACE_MAKE) menuconfig $(PREP_MK); \
+	fi
+
+defconfig: scripts/config/conf FORCE
+	touch .config
+	@if [ -e $(HOME)/.cshorewrt/defconfig ]; then cp $(HOME)/.cshorewrt/defconfig .config; fi
+	$< --defconfig=.config Config.in
+
+confdefault-y=allyes
+confdefault-m=allmod
+confdefault-n=allno
+confdefault:=$(confdefault-$(CONFDEFAULT))
+
+oldconfig: scripts/config/conf FORCE
+	$< --$(if $(confdefault),$(confdefault),old)config Config.in
+
+menuconfig: scripts/config/mconf FORCE
+	if [ \! -e .config -a -e $(HOME)/.cshorewrt/defconfig ]; then \
+		cp $(HOME)/.cshorewrt/defconfig .config; \
+	fi
+	$< Config.in
 
 .SILENT: help info image
 

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -25,7 +25,12 @@ include $(INCLUDE_DIR)/debug.mk
 include $(INCLUDE_DIR)/depends.mk
 
 include $(INCLUDE_DIR)/version.mk
+include .config
+
 export REVISION
+
+SCAN_COOKIE?=$(shell echo $$$$)
+export SCAN_COOKIE
 
 define Helptext
 Available Commands:
@@ -75,6 +80,12 @@ OPKG:= \
 include $(INCLUDE_DIR)/target.mk
 -include .profiles.mk
 
+include $(INCLUDE_DIR)/defaults.mk
+
+ifneq ($(BUILD_IMAGE),)
+  -include .defaults.mk
+endif
+
 USER_PROFILE ?= $(firstword $(PROFILE_NAMES))
 PROFILE_LIST = $(foreach p,$(PROFILE_NAMES), \
 	echo '$(p):'; $(if $($(p)_NAME),echo '    $($(p)_NAME)'; ) echo '    Packages: $($(p)_PACKAGES)'; \
@@ -82,6 +93,13 @@ PROFILE_LIST = $(foreach p,$(PROFILE_NAMES), \
 
 .profiles.mk: .targetinfo
 	$(SCRIPT_DIR)/target-metadata.pl profile_mk $< '$(BOARD)$(if $(SUBTARGET),/$(SUBTARGET))' > $@
+
+$(TOPDIR)/tmp/.defaultsinfo:
+	mkdir -p tmp/info
+	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="defaultsinfo" SCAN_DIR="target/linux" SCAN_NAME="defaults" SCAN_DEPS="image/Makefile profiles/*.mk $(TOPDIR)/include/kernel*.mk $(TOPDIR)/include/target.mk $(TOPDIR)/include/defaults.mk" SCAN_DEPTH=2 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1 SCAN_DEFAULTS=1"
+
+.defaults.mk: $(TOPDIR)/tmp/.defaultsinfo
+	$(SCRIPT_DIR)/defaults-metadata.pl defaults_mk $(TOPDIR)/tmp/.defaultsinfo '$(BOARD)$(if $(SUBTARGET),/$(SUBTARGET))' > .defaults.mk
 
 staging_dir/host/.prereq-build: include/prereq-build.mk
 	mkdir -p tmp
@@ -99,12 +117,13 @@ staging_dir/host/.prereq-build: include/prereq-build.mk
 	touch $@
 
 _call_info: FORCE
+	echo 'Device Type: "$(DEVICE_TYPE)"'
 	echo 'Current Target: "$(BOARD)$(if $(SUBTARGET), ($(BOARDNAME)))"'
-	echo 'Default Packages: $(DEFAULT_PACKAGES)'
+	echo 'Default Packages: $(BASE_DEFAULT_PACKAGES) $(DEFAULT_PACKAGES.$(DEVICE_TYPE)) $(DEFAULT_PACKAGES)'
 	echo 'Available Profiles:'
 	echo; $(PROFILE_LIST)
 
-BUILD_PACKAGES:=$(USER_PACKAGES) $(sort $(DEFAULT_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel)
+BUILD_PACKAGES:=$(USER_PACKAGES) $(sort $(BASE_DEFAULT_PACKAGES) $(DEFAULT_PACKAGES.$(DEVICE_TYPE)) $(DEFAULT_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel)
 # "-pkgname" in the package list means remove "pkgname" from the package list
 BUILD_PACKAGES:=$(filter-out $(filter -%,$(BUILD_PACKAGES)) $(patsubst -%,%,$(filter -%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
 PACKAGES:=
@@ -180,7 +199,7 @@ clean:
 info:
 	(unset PROFILE FILES PACKAGES MAKEFLAGS; $(MAKE) -s _call_info)
 
-image:
+image_target:
 ifneq ($(PROFILE),)
   ifeq ($(filter $(PROFILE),$(PROFILE_NAMES)),)
 	@echo 'Profile "$(PROFILE)" does not exist!'
@@ -194,6 +213,9 @@ endif
 		$(if $(FILES),USER_FILES="$(FILES)") \
 		$(if $(PACKAGES),USER_PACKAGES="$(PACKAGES)") \
 		$(if $(BIN_DIR),BIN_DIR="$(BIN_DIR)"))
+
+image: .defaults.mk
+	$(MAKE) image_target PROFILE=$(PROFILE) PACKAGES="$(PACKAGES)" FILES="$(FILES)" BIN_DIR="$(BIN_DIR)" EXTRA_IMAGE_NAME="$(EXTRA_IMAGE_NAME)" BUILD_IMAGE=1
 
 .SILENT: help info image
 

--- a/target/linux/arc770/Makefile
+++ b/target/linux/arc770/Makefile
@@ -14,7 +14,7 @@ SUBTARGETS:=generic
 
 KERNEL_PATCHVER:=4.4
 
-DEVICE_TYPE:=developerboard
+TARGET_DEVICE_TYPE:=developerboard
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/archs38/Makefile
+++ b/target/linux/archs38/Makefile
@@ -15,7 +15,7 @@ SUBTARGETS:=generic
 
 KERNEL_PATCHVER:=4.4
 
-DEVICE_TYPE:=developerboard
+TARGET_DEVICE_TYPE:=developerboard
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/arm64/Makefile
+++ b/target/linux/arm64/Makefile
@@ -15,7 +15,7 @@ MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 
 KERNEL_PATCHVER:=4.4
 
-DEVICE_TYPE:=developerboard
+TARGET_DEVICE_TYPE:=developerboard
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/mcs814x/Makefile
+++ b/target/linux/mcs814x/Makefile
@@ -15,7 +15,7 @@ MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 
 KERNEL_PATCHVER:=3.18
 
-DEVICE_TYPE:=other
+TARGET_DEVICE_TYPE:=other
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/oxnas/Makefile
+++ b/target/linux/oxnas/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=oxnas
 BOARDNAME:=PLXTECH/Oxford NAS782x/OX82x
-DEVICE_TYPE:=nas
+TARGET_DEVICE_TYPE:=nas
 FEATURES:=gpio nand pcie usb ramdisk rtc squashfs ubifs
 CPU_TYPE:=mpcore
 

--- a/target/linux/realview/Makefile
+++ b/target/linux/realview/Makefile
@@ -16,7 +16,7 @@ MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 
 KERNEL_PATCHVER:=4.4
 
-DEVICE_TYPE:=developerboard
+TARGET_DEVICE_TYPE:=developerboard
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/xburst/Makefile
+++ b/target/linux/xburst/Makefile
@@ -14,7 +14,7 @@ SUBTARGETS:=qi_lb60
 
 KERNEL_PATCHVER:=3.18
 
-DEVICE_TYPE=other
+TARGET_DEVICE_TYPE=other
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/sdk/Config.in
+++ b/target/sdk/Config.in
@@ -6,4 +6,12 @@ config SDK
 	  with a precompiled toolchain. It can be used to develop and
 	  test packages for LEDE before including them in the buildroot
 
+config SDK_MINIMAL
+	bool "Build a minimal LEDE SDK"
+	depends on SDK
+	default n
+	help
+	  Builds the minimum set of packages necessary to create an
+          SDK and ImageBuilder combo capable of building images for
+	  the desired boards.
 

--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -96,7 +96,7 @@ $(BIN_DIR)/$(SDK_NAME).tar.bz2: clean
 	rm -rf \
 		$(SDK_BUILD_DIR)/target/linux/*/files* \
 		$(SDK_BUILD_DIR)/target/linux/*/patches*
-	./convert-config.pl $(TOPDIR)/.config > $(SDK_BUILD_DIR)/Config-build.in
+	../convert-config.pl $(TOPDIR)/.config > $(SDK_BUILD_DIR)/Config-build.in
 	$(CP) -L \
 		$(TOPDIR)/LICENSE \
 		$(TOPDIR)/rules.mk \

--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -92,6 +92,7 @@ $(BIN_DIR)/$(SDK_NAME).tar.bz2: clean
 
 	mkdir -p $(SDK_BUILD_DIR)/target/linux
 	$(CP) $(GENERIC_PLATFORM_DIR) $(PLATFORM_DIR) $(SDK_BUILD_DIR)/target/linux/
+	$(CP) $(TOPDIR)/config/Config-device.in $(SDK_BUILD_DIR)/
 	rm -rf \
 		$(SDK_BUILD_DIR)/target/linux/*/files* \
 		$(SDK_BUILD_DIR)/target/linux/*/patches*

--- a/target/sdk/convert-config.pl
+++ b/target/sdk/convert-config.pl
@@ -8,6 +8,10 @@ while (<>) {
 	my $type;
 	chomp;
 	next if /^CONFIG_SIGNED_PACKAGES/;
+	next if /^(# )?CONFIG_DEVICE_TYPE/;
+	next if /^(# )?CONFIG_USE_DEVICE_TYPE/;
+	next if /^(# )?CONFIG_DT_USE/;
+	next if /^(# )?CONFIG_DEFAULT/;
 
 	if (/^CONFIG_([^=]+)=(.*)$/) {
 		$var = $1;

--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -19,5 +19,7 @@ config MODULES
 	default y
 	option modules
 
+source "Config-device.in"
 source "Config-build.in"
 source "tmp/.config-package.in"
+source "tmp/.config-defaults.in"


### PR DESCRIPTION
This is a rebase of an accidentally closed PR which is based on #113.  It allows one to build an SDK consists only of the packages necessary to build the SDK/IB combo suitable for building all other required packages and creating the target images.