### PR TITLE
ramips: Add support for Archer C50

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -78,6 +78,13 @@ broadway)
 	set_usb_led "$board:red:diskmounted"
 	set_wifi_led "$board:red:wps_active"
 	;;
+c50)
+	ucidef_set_led_default "power" "power" "tp-link:blue:power" "0"
+	ucidef_set_led_netdev "lan" "lan" "tp-link:blue:lan" "eth0.2"
+	set_usb_led "tp-link:blue:usb"
+	ucidef_set_led_wlan "wlan2g" "wlan2g" "tp-link:blue:wlan2g" "phy1radio"
+	ucidef_set_led_wlan "wlan5g" "wlan5g" "tp-link:blue:wlan5g" "phy0radio"
+	;;
 cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "$board:white:ethernet" eth0.1
 	set_wifi_led "$board:white:wifi"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -114,6 +114,7 @@ ramips_setup_interfaces()
 	awm002-evb|\
 	awm003-evb|\
 	dir-645|\
+	c50 | \
 	dir-860l-b1|\
 	f5d8235-v1|\
 	f5d8235-v2|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -83,6 +83,9 @@ get_status_led() {
 	wrh-300cr)
 		status_led="$board:green:wps"
 		;;
+	c50)
+		status_led="tp-link:blue:power"
+		;;
 	cf-wr800n|\
 	psg1208)
 		status_led="$board:white:wps"

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -82,6 +82,9 @@ ramips_board_detect() {
 	*"C20i")
 		name="c20i"
 		;;
+	*"C50")
+		name="c50"
+		;;
 	*"Carambola")
 		name="carambola"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -181,7 +181,8 @@ platform_check_image() {
 		}
 		return 0
 		;;
-	c20i)
+	c20i |\
+	c50)
 		[ "$magic" != "03000000" ] && {
 			echo "Invalid image type."
 			return 1

--- a/target/linux/ramips/dts/ArcherC50.dts
+++ b/target/linux/ramips/dts/ArcherC50.dts
@@ -1,0 +1,156 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+/ {
+	compatible = "ralink,mt7620a-soc";
+	model = "TP-Link Archer C50";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "tp-link:blue:lan";
+			gpios = <&gpio0 1 1>;
+		};
+
+		power {
+			label = "tp-link:blue:power";
+			gpios = <&gpio0 7 0>;
+		};
+
+		usb {
+			label = "tp-link:blue:usb";
+			gpios = <&gpio0 9 1>;
+		};
+
+		wlan5g {
+			label = "tp-link:blue:wlan5g";
+			gpios = <&gpio0 11 1>;
+		};
+
+		wlan2g {
+			label = "tp-link:blue:wlan2g";
+			gpios = <&gpio3 0 1>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 1>;
+			linux,code = <0x198>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio0 2 1>;
+			linux,code = <0xf7>;
+		};	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80", "mx25l6405d";
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x20000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "firmware";
+			reg = <0x20000 0x7a0000>;
+		};
+
+		partition@7c0000 {
+			label = "config";
+			reg = <0x7c0000 0x10000>;
+		};
+
+		rom: partition@7d0000 {
+			label = "rom";
+			reg = <0x7d0000 0x10000>;
+		};
+
+		partition@7e0000 {
+			label = "romfile";
+			reg = <0x7e0000 0x10000>;
+		};
+
+		radio: partition@7f0000 {
+			label = "radio";
+			reg = <0x7f0000 0x10000>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uartf", "rgmii1", "rgmii2", "wled", "nd_sd";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+		pinctrl-names = "default";
+		pinctrl-0 = <&ephy_pins>;
+		mtd-mac-address = <&rom 0xf100>;
+		mediatek,portmap = "wllll";
+	};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&gsw {
+	mediatek,port4 = "ephy";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&radio 0>;
+};
+
+&pcie {
+	status = "okay";
+
+	pcie-bridge {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&radio 32768>;
+			mediatek,2ghz = <0>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -50,6 +50,15 @@ define Device/ArcherC20i
 endef
 TARGET_DEVICES += ArcherC20i
 
+define Device/ArcherC50
+  DTS := ArcherC50
+  KERNEL := $(KERNEL_DTB)
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | tplink-header ArcherC50 -c
+  IMAGE/sysupgrade.bin := append-kernel | tplink-header ArcherC50 -j -r $(KDIR)/root.squashfs
+  DEVICE_TITLE := TP-Link ArcherC50
+endef
+TARGET_DEVICES += ArcherC50
+
 ex2700_mtd_size=3866624
 define Device/ex2700
   DTS := EX2700

--- a/tools/firmware-utils/src/mktplinkfw2.c
+++ b/tools/firmware-utils/src/mktplinkfw2.c
@@ -187,7 +187,7 @@ static struct board_info boards[] = {
 	}, {
 		.id		= "ArcherC50",
 		.hw_id		= 0xc7500001,
-		.hw_rev		= 58,
+		.hw_rev		= 69,
 		.layout_id	= "8Mmtk",
 		.hdr_ver	= 3,
 		.endian_swap	= true,

--- a/tools/firmware-utils/src/mktplinkfw2.c
+++ b/tools/firmware-utils/src/mktplinkfw2.c
@@ -185,6 +185,13 @@ static struct board_info boards[] = {
 		.layout_id	= "16Mltq",
 		.hdr_ver	= 2,
 	}, {
+		.id		= "ArcherC50",
+		.hw_id		= 0xc7500001,
+		.hw_rev		= 58,
+		.layout_id	= "8Mmtk",
+		.hdr_ver	= 3,
+		.endian_swap	= true,
+	}, {
 		/* terminating entry */
 	}
 };


### PR DESCRIPTION
Tested and working:

- Flashing from original webui using the sysupgrade image

- Sysupgrading from within OpenWrt.

- wifi 2.4GHz and 5GHz.

- wired lan/wan

- usb storage

Pending:

- WPS led & WAN green not work, WAN orange led blink when cable is connected to port LAN2.



Signed-off-by: Henryk Heisig <hyniu@o2.pl>