### PR TITLE
ar71xx: WDR4300: Fixed default VLAN order

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -201,7 +201,7 @@ tellstick-znet-lite)
 tl-wdr4300|\
 tl-wr1041n-v2)
 	ucidef_add_switch "switch0" \
-		"0@eth0" "1:wan" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4"
+		"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
 	;;
 
 tl-wr1043nd)


### PR DESCRIPTION
Reordered the VLANs so the LAN ports are set to VLAN 1 and the WAN
port is set to VLAN 2, as in the other routers in the config file.
Moreover, this model had this VLAN mapping in OpenWRT Chaos Calmer. It seems
that the VLAN were switched when fixing a bug in the port mapping ( OpenWRT
 changeset 47799 )

Signed-off-by: David Pinilla Caparrós <dpinitux@gmail.com>