### PR TITLE
scksum: simple checksum for ath10k QCA99x0

### DIFF
--- a/package/utils/scksum/Makefile
+++ b/package/utils/scksum/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2016 LEDE
+# Copyright (C) 2016 Adrian Panella
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=simple-cksum
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/simple-cksum
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Utility to calculate simple checksum
+  MAINTAINER:=Adrian Panella <ianchi74@outlook.com>
+endef
+
+define Package/simple-cksum/description
+Utility to calculate simple checksum
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	$(CP) ./src/* $(PKG_BUILD_DIR)/
+endef
+
+define Build/Configure
+endef
+
+define Package/simple-cksum/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/scksum $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,simple-cksum))

--- a/package/utils/scksum/src/Makefile
+++ b/package/utils/scksum/src/Makefile
@@ -1,0 +1,9 @@
+
+all: scksum
+
+scksum: scksum.c 
+	$(CC) $(CFLAGS) -o $@ scksum.c $(LDFLAGS) 
+
+clean: 
+	rm scksum
+	rm *.o

--- a/package/utils/scksum/src/scksum.c
+++ b/package/utils/scksum/src/scksum.c
@@ -1,0 +1,126 @@
+/*
+ * 
+ * Copyright (C) 2016 Adrian Panella <ianchi74@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+ 
+/*
+ * 
+ * scksum
+ * 
+ * Utility for calculating a simple checksum (mainly for for ath10k calibration data).
+ * 
+ */
+ 
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <ctype.h>
+ 
+unsigned short checksum(FILE *fp)	
+{
+	unsigned short data;
+	unsigned short crc = 0;
+	int i;
+
+	while (fread(&data, sizeof(unsigned short), 1, fp) == 1) { 
+		
+		crc ^= data;
+	}
+
+	if(ferror(fp)) {
+		fprintf(stderr, "Error reading input.\n");
+		exit(1);
+	}
+	
+	crc = ~crc;
+
+	return crc;
+}
+
+void usage(char *prog)
+{
+	fprintf(stderr, "Usage: %s [-b | -h] [file]\n\n", prog);
+	fprintf(stderr, "\t-b: output in binary format.\n\t-h: output in hex format (default).\n");
+	fprintf(stderr, "\t[file] to process, blank or - to use stdin.\n");
+}
+
+
+int main(int argc, char **argv) {
+	FILE *input;
+	int bflag = 0;
+	int hflag = 0;
+	int c;
+	unsigned short crc = 0;
+	opterr = 0;
+
+	while((c = getopt(argc, argv, "hb")) != -1)
+	switch(c)
+	  {
+	  case 'b':
+		bflag = 1;
+		break;
+		
+	  case 'h':
+		hflag = 1;
+		break;
+		
+	  case '?':
+		if (isprint(optopt))
+		  fprintf(stderr, "Unknown option '-%c'.\n", optopt);
+		else
+		  fprintf(stderr, "Unknown option character '\\x%x'.\n", optopt);
+		usage(argv[0]);
+		return 1;
+		
+	  default:
+		usage(argv[0]);
+		return 1;
+	  }
+
+	if( bflag && hflag ) {
+		fprintf(stderr, "Only one output format can be selected [-h | -b]\n");
+		usage(argv[0]);
+		return 1;
+	}
+		
+	if( (argc - optind) > 1 ) {
+		fprintf(stderr, "Provide only one input file.\n");
+		usage(argv[0]);
+		return 1;
+	}
+	
+	if( optind == argc || argv[optind] == "-" )
+		input = stdin;
+	else {
+		input = fopen(argv[optind],"rb");
+		if( NULL == input) {
+			fprintf(stderr, "Unable to open '%s'\n", argv[optind]);
+			return 1;
+		}
+	}
+
+	crc=checksum(input);
+	
+	if(bflag)
+		fwrite(&crc, sizeof(unsigned short), 1, stdout);
+		
+	else
+		printf("%x\n",crc);
+		
+	return 0;
+}
+

--- a/target/linux/ipq806x/Makefile
+++ b/target/linux/ipq806x/Makefile
@@ -21,6 +21,6 @@ DEFAULT_PACKAGES += \
 	kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-ledtrig-usbdev \
 	kmod-usb3 kmod-usb-dwc3-qcom kmod-usb-phy-qcom-dwc3 \
 	kmod-ath10k ath10k-firmware-qca99x0 wpad-mini \
-	uboot-envtools
+	uboot-envtools simple-checksum
 
 $(eval $(call BuildTarget))

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -18,23 +18,36 @@ ath10kcal_extract() {
 	local part=$1
 	local offset=$2
 	local count=$3
+	local of=$4
 	local mtd
+	[ -z "$4" ] && of=/lib/firmware/$FIRMWARE
 
 	mtd=$(find_mtd_chardev $part)
 	[ -n "$mtd" ] || \
 		ath10kcal_die "no mtd device found for partition $part"
 
-	dd if=$mtd of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count 2>/dev/null || \
+	dd if=$mtd of="$of" bs=1 skip=$offset count=$count 2>/dev/null || \
 		ath10kcal_die "failed to extract calibration data from $mtd"
 }
 
 ath10kcal_patch_mac() {
 	local mac=$1
+	local of=$2
+	[ -z "$2" ] && of=/lib/firmware/$FIRMWARE
 
 	[ -z "$mac" ] && return
 
-	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=6 count=6
+	macaddr_2bin $mac | dd of="$of" conv=notrunc bs=1 seek=6 count=6
 }
+
+ath10kcal_patch_cksum() {
+	local of=$1
+	[ -z "$1" ] && of=/lib/firmware/$FIRMWARE
+
+	dd if=/dev/zero of="$of" conv=notrunc bs=1 seek=2 count=2
+	scksum -b "$of" | dd of="$of" conv=notrunc bs=1 seek=2 count=2
+}
+
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0
 
@@ -47,26 +60,32 @@ board=$(ipq806x_board_name)
 
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:01:00.0.bin")
+	tmp=/tmp/cal-pci-0000:01:00.0.bin
+
 	case $board in
 	c2600)
 		ath10kcal_extract "radio" 4096 12064
 # 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary default-mac 8) -1)
 		;;
 	ea8500)
-		hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-		ath10kcal_extract "art" 4096 12064
+		ath10kcal_extract "art" 4096 12064 $tmp
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) 1) $tmp
+		ath10kcal_patch_cksum $tmp
 		;;
 	esac
 	;;
 "ath10k/cal-pci-0001:01:00.0.bin")
+	tmp=/tmp/cal-pci-0001:01:00.0.bin
+
 	case $board in
 	c2600)
-		ath10kcal_extract "radio" 20480 12064
+		ath10kcal_extract "radio" 20480 12064 
 # 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary default-mac 8) -2)
 		;;
 	ea8500)
-		hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-		ath10kcal_extract "art" 20480 12064
+		ath10kcal_extract "art" 20480 12064 $tmp
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) 2) $tmp
+		ath10kcal_patch_cksum $tmp
 		;;
 	esac
 	;;
@@ -74,3 +93,8 @@ case "$FIRMWARE" in
 	exit 1
 	;;
 esac
+
+[ -f "$tmp" ] && {
+		cp -f $tmp /lib/firmware/$FIRMWARE
+		rm -f $tmp
+	}


### PR DESCRIPTION
In ath10k QCA99x0 verifies calibration data checksum and throws an error if it does not match.
So when patching mac address, it is also needed to patch cksum info.
This utility implements the simple checksum method used in calibration data files.

The PR also enables its use for ipq806x/EA8500.


