### PR TITLE
ipq806x: fix MAC_POWER_SEL switch configuration

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
@@ -301,7 +301,7 @@
 					0x00004 0x7600000   /* PAD0_MODE */
 					0x00008 0x1000000   /* PAD5_MODE */
 					0x0000c 0x80        /* PAD6_MODE */
-					0x000e4 0xaa545     /* MAC_POWER_SEL */
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
 					0x000e0 0xc74164de  /* SGMII_CTRL */
 					0x0007c 0x4e        /* PORT0_STATUS */
 					0x00094 0x4e        /* PORT6_STATUS */

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -246,7 +246,7 @@
 					0x00004 0x7600000   /* PAD0_MODE */
 					0x00008 0x1000000   /* PAD5_MODE */
 					0x0000c 0x80        /* PAD6_MODE */
-					0x000e4 0xaa545     /* MAC_POWER_SEL */
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
 					0x000e0 0xc74164de  /* SGMII_CTRL */
 					0x0007c 0x4e        /* PORT0_STATUS */
 					0x00094 0x4e        /* PORT6_STATUS */

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
@@ -284,7 +284,7 @@
 					0x00004 0x7600000   /* PAD0_MODE */
 					0x00008 0x1000000   /* PAD5_MODE */
 					0x0000c 0x80        /* PAD6_MODE */
-					0x000e4 0xaa545     /* MAC_POWER_SEL */
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
 					0x000e0 0xc74164de  /* SGMII_CTRL */
 					0x0007c 0x4e        /* PORT0_STATUS */
 					0x00094 0x4e        /* PORT6_STATUS */

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
@@ -216,7 +216,7 @@
 					0x00004 0x7600000   /* PAD0_MODE */
 					0x00008 0x1000000   /* PAD5_MODE */
 					0x0000c 0x80        /* PAD6_MODE */
-					0x000e4 0xaa545     /* MAC_POWER_SEL */
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
 					0x000e0 0xc74164de  /* SGMII_CTRL */
 					0x0007c 0x4e        /* PORT0_STATUS */
 					0x00094 0x4e        /* PORT6_STATUS */

--- a/target/linux/ipq806x/patches-4.4/707-ARM-dts-qcom-add-mdio-nodes-to-ap148-db149.patch
+++ b/target/linux/ipq806x/patches-4.4/707-ARM-dts-qcom-add-mdio-nodes-to-ap148-db149.patch
@@ -58,7 +58,7 @@ Signed-off-by: Mathieu Olivari <mathieu@codeaurora.org>
 +					0x00004 0x7600000   /* PAD0_MODE */
 +					0x00008 0x1000000   /* PAD5_MODE */
 +					0x0000c 0x80        /* PAD6_MODE */
-+					0x000e4 0xaa545     /* MAC_POWER_SEL */
++					0x000e4 0x6a545     /* MAC_POWER_SEL */
 +					0x000e0 0xc74164de  /* SGMII_CTRL */
 +					0x0007c 0x4e        /* PORT0_STATUS */
 +					0x00094 0x4e        /* PORT6_STATUS */
@@ -120,7 +120,7 @@ Signed-off-by: Mathieu Olivari <mathieu@codeaurora.org>
 +					0x00004 0x7600000   /* PAD0_MODE */
 +					0x00008 0x1000000   /* PAD5_MODE */
 +					0x0000c 0x80        /* PAD6_MODE */
-+					0x000e4 0xaa545     /* MAC_POWER_SEL */
++					0x000e4 0x6a545     /* MAC_POWER_SEL */
 +					0x000e0 0xc74164de  /* SGMII_CTRL */
 +					0x0007c 0x4e        /* PORT0_STATUS */
 +					0x00094 0x4e        /* PORT6_STATUS */


### PR DESCRIPTION
Fixes instability/corruption on the ethernet interface connected to port0 on the switch.

Original source of this problem is a possible typo/inconsistency in Qualcomm sources.

Looking at the TP-Link C2600 GPL tarball, there is an inconsistent definition of bits 18 and 19 of the MAC_POWER_SEL register.

In openwrt/qca/src/qca-ssdk-shell/include/init/ssdk_plat.h there is one definition
```
#define AR8327_REG_PAD_MAC_PWR_SEL                      0x0e4
#define   AR8327_PAD_MAC_PWR_RGMII0_1_8V                BIT(19)
#define   AR8327_PAD_MAC_PWR_RGMII1_1_8V                BIT(18)
```
And what is currently in the device trees is consistent with this definition.

In openwrt/qca/src/qca-ssdk/include/init/ssdk_plat.h there is instead what I suspect is the correct definition with those two bits flipped.
```
#define AR8327_REG_PAD_MAC_PWR_SEL                      0x0e4
#define   AR8327_PAD_MAC_PWR_RGMII0_1_8V                BIT(18)
#define   AR8327_PAD_MAC_PWR_RGMII1_1_8V                BIT(19)
```
Modifying the device tree to be consistent with this definition (enabling bit 18 and disabling bit 19) solves the instability and corruption issues I was having with eth0 on the Archer 2600 at high load.  Probably the same problem affects all IPQ806x devices with switch port0 connected to the cpu with rgmii.