### PR TITLE
[RFC] Move append-dtb to common image-commands

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -38,6 +38,11 @@ define Build/tplink-safeloader
 		$(if $(findstring sysupgrade,$(word 1,$(1))),-S) && mv $@.new $@ || rm -f $@
 endef
 
+define Build/append-dtb
+    $(if $(DEVICE_DTS_DIR),$(call Image/BuildDTB,$(DEVICE_DTS_DIR)/$(DEVICE_DTS).dts,$(DTS_DIR)/$(DEVICE_DTS).dtb))
+    cat $(DTS_DIR)/$(DEVICE_DTS).dtb >> $@
+endef
+
 define Build/fit
 	$(TOPDIR)/scripts/mkits.sh \
 		-D $(DEVICE_NAME) -o $@.its -k $@ \

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -8,8 +8,6 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
 define Image/Prepare
-	$(CP) $(DTS_DIR)/*.dtb $(KDIR)/
-
 	rm -f $(KDIR)/fs_mark
 	echo -ne '\xde\xad\xc0\xde' > $(KDIR)/fs_mark
 	$(call prepare_generic_squashfs,$(KDIR)/fs_mark)
@@ -19,10 +17,6 @@ define Image/Prepare
 	echo -ne '\xde\xad\xc0\xde' > $(KDIR)/ubi_mark
 
 	$(CP) ./ubinize.cfg $(KDIR)
-endef
-
-define Build/append-dtb
-	cat $(KDIR)/$(DT).dtb >> $@
 endef
 
 define Build/lzma-d16
@@ -78,14 +72,14 @@ define Build/seama-nand
 		-i $@.entity
 endef
 
-DEVICE_VARS += DT PRODUCTID SIGNATURE NETGEAR_BOARD_ID NETGEAR_REGION
+DEVICE_VARS += DEVICE_DTS PRODUCTID SIGNATURE NETGEAR_BOARD_ID NETGEAR_REGION
 
 define Device/Default
   # .dtb files are prefixed by SoC type, e.g. bcm4708- which is not included in device/image names
   # extract the full dtb name based on the device info
-  DT := $(patsubst %.dtb,%,$(notdir $(wildcard $(if $(IB),$(KDIR),$(DTS_DIR))/*-$(1).dtb)))
+  DEVICE_DTS := $(patsubst %.dtb,%,$(notdir $(wildcard $(if $(IB),$(KDIR),$(DTS_DIR))/*-$(1).dtb)))
   KERNEL := kernel-bin | append-dtb | lzma-d16
-  KERNEL_DEPENDS = $$(wildcard $(KDIR)/$$(DT).dts)
+  KERNEL_DEPENDS = $$(wildcard $(DTS_DIR)/$$(DEVICE_DTS).dts)
   FILESYSTEMS := squashfs
   KERNEL_NAME := zImage
   IMAGE_NAME = $$(IMAGE_PREFIX)-$$(1).$$(2)

--- a/target/linux/brcm63xx/image/Makefile
+++ b/target/linux/brcm63xx/image/Makefile
@@ -34,11 +34,6 @@ define Build/Compile
 endef
 
 ### Kernel scripts ###
-define Build/append-dtb
-	$(call Image/BuildDTB,../dts/$(DEVICE_DTS).dts,$@.dtb)
-	cat $@.dtb >> $@
-endef
-
 define Build/hcs-initramfs
 	$(STAGING_DIR_HOST)/bin/hcsmakeimage --magic_bytes=$(HCS_MAGIC_BYTES) \
 		--rev_maj=$(HCS_REV_MAJ) --rev_min=$(HCS_REV_MIN) --input_file=$@ \
@@ -170,8 +165,9 @@ define Device/Default
   KERNEL_DEPENDS = $$(wildcard ../dts/$$(DEVICE_DTS).dts)
   KERNEL_INITRAMFS_SUFFIX := .elf
   DEVICE_DTS :=
+  DEVICE_DTS_DIR := ../dts
 endef
-DEVICE_VARS += DEVICE_DTS
+DEVICE_VARS += DEVICE_DTS DEVICE_DTS_DIR
 
 ATH5K_PACKAGES := kmod-ath5k wpad-mini
 ATH9K_PACKAGES := kmod-ath9k wpad-mini

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -32,10 +32,6 @@ define Image/Build
 	dd if=$(KDIR)/root.$(1) of=$(BIN_DIR)/$(IMG_PREFIX)-$(1)-root.img bs=2k conv=sync
 endef
 
-define Build/append-dtb
-	cat $(DTS_DIR)/$(DEVICE_DTS).dtb >> $@
-endef
-
 define Build/append-file
 	cat $(1) >> $@
 endef

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -75,10 +75,6 @@ define Device/linksys-viper
   IMAGE/sysupgrade.tar := sysupgrade-nand
 endef
 
-define Build/append-dtb
-	cat $(DTS_DIR)/$(DEVICE_DTS).dtb >> $@
-endef
-
 define Image/BuildKernel/Template
 
 	$(CP) $(KDIR)/zImage $(BIN_DIR)/$(IMG_PREFIX)-zImage

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -219,11 +219,6 @@ endef
 
 
 ### Kernel scripts ###
-define Build/append-dtb
-	$(call Image/BuildDTB,../dts/$(DEVICE_DTS).dts,$@.dtb)
-	cat $@.dtb >> $@
-endef
-
 define Build/mkbrncmdline
    mkbrncmdline -i $@ -o $@.new BRN-BOOT
    mv $@.new $@
@@ -243,11 +238,12 @@ define Device/Default
   FILESYSTEMS := squashfs
   DEVICE_PROFILE :=
   DEVICE_DTS = $$(DEVICE_PROFILE)
+  DEVICE_DTS_DIR := ../dts
   IMAGE_SIZE :=
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
 endef
-DEVICE_VARS += DEVICE_PROFILE DEVICE_DTS IMAGE_SIZE
+DEVICE_VARS += DEVICE_PROFILE DEVICE_DTS DEVICE_DTS_DIR IMAGE_SIZE
 
 define Device/lantiqBrnImage
   KERNEL := kernel-bin | append-dtb | mkbrncmdline | lzma-no-dict


### PR DESCRIPTION
This build step is used by various targets, move it to a common section.

For the brcm63xx and lantiq targets where DTSs are in a separate target directory, an extra variable is introduced to allow their building.
I compile tested kirkwood and brcm63xx to make sure it worked as expected with custom dir and without.

I am unsure what to do with bcm53xx when the image builder is used (IB?)