### PR TITLE
ipq806x: add initial support for Netgear R7800

### DIFF
--- a/target/linux/ipq806x/Makefile
+++ b/target/linux/ipq806x/Makefile
@@ -20,7 +20,7 @@ DEFAULT_PACKAGES += \
 	kmod-ata-core kmod-ata-ahci kmod-ata-ahci-platform \
 	kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-ledtrig-usbdev \
 	kmod-usb3 kmod-usb-dwc3-qcom kmod-usb-phy-qcom-dwc3 \
-	kmod-ath10k ath10k-firmware-qca99x0 wpad-mini \
+	kmod-ath10k wpad-mini \
 	uboot-envtools
 
 $(eval $(call BuildTarget))

--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -19,13 +19,14 @@ c2600)
 	ucidef_set_led_default "general" "general" "ledgnr:blue" "1"
 	;;
 d7800 |\
-r7500)
-	ucidef_set_led_usbdev "usb1" "USB 1" "r7500:white:usb1" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB 2" "r7500:white:usb3" "3-1"
-	ucidef_set_led_netdev "wan" "WAN" "r7500:white:wan" "eth0"
-	ucidef_set_led_ide "esata" "eSATA" "r7500:amber:esata"
-	ucidef_set_led_default "wps" "WPS" "r7500:white:wps" "0"
-	ucidef_set_led_default "rfkill" "rfkill" "r7500:white:rfkill" "0"
+r7500 |\
+r7800)
+	ucidef_set_led_usbdev "usb1" "USB 1" "${board}:white:usb1" "1-1"
+	ucidef_set_led_usbdev "usb2" "USB 2" "${board}:white:usb3" "3-1"
+	ucidef_set_led_netdev "wan" "WAN" "${board}:white:wan" "eth0"
+	ucidef_set_led_ide "esata" "eSATA" "${board}:amber:esata"
+	ucidef_set_led_default "wps" "WPS" "${board}:white:wps" "0"
+	ucidef_set_led_default "rfkill" "rfkill" "${board}:white:rfkill" "0"
 	;;
 ea8500)
 	ucidef_set_led_wlan "wifi" "WIFI" "ea8500:green:wifi" "phy0radio"

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -16,7 +16,8 @@ case "$board" in
 ap148 |\
 c2600 |\
 d7800 |\
-r7500)
+r7500 |\
+r7800)
 	ucidef_add_switch "switch0" \
 		"1:lan" "2:lan" "3:lan" "4:lan" "6@eth1" "5:wan" "0@eth0"
 	;;

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -56,6 +56,10 @@ case "$FIRMWARE" in
 		hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		ath10kcal_extract "art" 4096 12064
 		;;
+         r7800)
+		ath10kcal_extract "art" 4096 12064
+# 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary default-mac 8) -1)
+		;;
 	esac
 	;;
 "ath10k/cal-pci-0001:01:00.0.bin")
@@ -67,6 +71,10 @@ case "$FIRMWARE" in
 	ea8500)
 		hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		ath10kcal_extract "art" 20480 12064
+		;;
+        r7800)
+		ath10kcal_extract "art" 20480 12064
+# 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary default-mac 8) -2)
 		;;
 	esac
 	;;

--- a/target/linux/ipq806x/base-files/lib/ipq806x.sh
+++ b/target/linux/ipq806x/base-files/lib/ipq806x.sh
@@ -32,6 +32,9 @@ ipq806x_board_detect() {
 	*"Linksys EA8500"*)
 		name="ea8500"
 		;;
+	*"R7800")
+		name="r7800"
+		;;
 	esac
 
 	[ -z "$name" ] && name="unknown"

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -9,7 +9,8 @@ platform_check_image() {
 	ap148 |\
 	d7800 |\
 	ea8500 |\
-	r7500)
+	r7500 |\
+	r7800)
 		nand_do_platform_check $board $1
 		return $?;
 		;;
@@ -32,7 +33,8 @@ platform_pre_upgrade() {
 	case "$board" in
 	ap148 |\
 	d7800 |\
-	r7500)
+	r7500 |\
+	r7800)
 		nand_do_upgrade "$1"
 		;;
 	ea8500)

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7800.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7800.dts
@@ -1,0 +1,372 @@
+#include "qcom-ipq8065-v1.0.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Netgear Nighthawk X4S R7800";
+	compatible = "netgear,r7800", "qcom,ipq8065";
+
+	memory@0 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		rsvd@41200000 {
+			reg = <0x41200000 0x300000>;
+			no-map;
+		};
+	};
+
+	aliases {
+		serial0 = &uart4;
+		mdio-gpio0 = &mdio0;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs noinitrd";
+		linux,stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		pinmux@800000 {
+			i2c4_pins: i2c4_pinmux {
+				pins = "gpio12", "gpio13";
+				function = "gsbi4";
+				bias-disable;
+			};
+
+			pcie0_pins: pcie0_pinmux {
+				mux {
+					pins = "gpio3";
+					function = "pcie1_rst";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
+			pcie1_pins: pcie1_pinmux {
+				mux {
+					pins = "gpio48";
+					function = "pcie2_rst";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
+			nand_pins: nand_pins {
+				mux {
+					pins = "gpio34", "gpio35", "gpio36",
+					       "gpio37", "gpio38", "gpio39",
+					       "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
+					bias-disable;
+				};
+				pullups {
+					pins = "gpio39";
+					bias-pull-up;
+				};
+				hold {
+					pins = "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					bias-bus-hold;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+
+			rgmii2_pins: rgmii2_pins {
+				mux {
+					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
+					       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+					function = "rgmii2";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+		};
+
+		gsbi@16300000 {
+			qcom,mode = <GSBI_PROT_I2C_UART>;
+			status = "ok";
+			serial@16340000 {
+				status = "ok";
+			};
+			/*
+			 * The i2c device on gsbi4 should not be enabled.
+			 * On ipq806x designs gsbi4 i2c is meant for exclusive
+			 * RPM usage. Turning this on in kernel manifests as
+			 * i2c failure for the RPM.
+			 */
+		};
+
+		sata-phy@1b400000 {
+			status = "ok";
+		};
+
+		sata@29000000 {
+			status = "ok";
+		};
+
+		phy@100f8800 {		/* USB3 port 1 HS phy */
+			status = "ok";
+		};
+
+		phy@100f8830 {		/* USB3 port 1 SS phy */
+			status = "ok";
+		};
+
+		phy@110f8800 {		/* USB3 port 0 HS phy */
+			status = "ok";
+		};
+
+		phy@110f8830 {		/* USB3 port 0 SS phy */
+			status = "ok";
+		};
+
+		usb30@0 {
+			status = "ok";
+		};
+
+		usb30@1 {
+			status = "ok";
+		};
+
+		pcie0: pci@1b500000 {
+			status = "ok";
+			reset-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_LOW>;
+			pinctrl-0 = <&pcie0_pins>;
+			pinctrl-names = "default";
+		};
+
+		pcie1: pci@1b700000 {
+			status = "ok";
+			reset-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_LOW>;
+			pinctrl-0 = <&pcie1_pins>;
+			pinctrl-names = "default";
+		};
+
+		nand@1ac00000 {
+			status = "ok";
+
+			pinctrl-0 = <&nand_pins>;
+			pinctrl-names = "default";
+
+			nand-ecc-strength = <4>;
+			nand-bus-width = <8>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			qcadata@0 {
+				label = "qcadata";
+				reg = <0x0000000 0x0c80000>;
+				read-only;
+			};
+
+			APPSBL@c80000 {
+				label = "APPSBL";
+				reg = <0x0c80000 0x0500000>;
+				read-only;
+			};
+
+			APPSBLENV@1180000 {
+				label = "APPSBLENV";
+				reg = <0x1180000 0x0080000>;
+				read-only;
+			};
+
+			art: art@1200000 {
+				label = "art";
+				reg = <0x1200000 0x0140000>;
+				read-only;
+			};
+
+			artbak: art@1340000 {
+				label = "artbak";
+				reg = <0x1340000 0x0140000>;
+				read-only;
+			};
+
+			kernel@1480000 {
+				label = "kernel";
+				reg = <0x1480000 0x0200000>;
+			};
+
+			ubi@1680000 {
+				label = "ubi";
+				reg = <0x1680000 0x1E00000>;
+			};
+
+			netgear@3480000 {
+				label = "netgear";
+				reg = <0x3480000 0x4480000>;
+				read-only;
+			};
+
+			reserve@7900000 {
+				label = "reserve";
+				reg = <0x7900000 0x0700000>;
+				read-only;
+			};
+
+			firmware@1480000 {
+				label = "firmware";
+				reg = <0x1480000 0x2000000>;
+			};
+
+		};
+
+		mdio0: mdio {
+			compatible = "virtual,mdio-gpio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			gpios = <&qcom_pinmux 1 0 &qcom_pinmux 0 0>;
+			pinctrl-0 = <&mdio0_pins>;
+			pinctrl-names = "default";
+
+			phy0: ethernet-phy@0 {
+				device_type = "ethernet-phy";
+				reg = <0>;
+				qca,ar8327-initvals = <
+					0x00004 0x7600000   /* PAD0_MODE */
+					0x00008 0x1000000   /* PAD5_MODE */
+					0x0000c 0x80        /* PAD6_MODE */
+					0x000e4 0xaa545     /* MAC_POWER_SEL */
+					0x000e0 0xc74164de  /* SGMII_CTRL */
+					0x0007c 0x4e        /* PORT0_STATUS */
+					0x00094 0x4e        /* PORT6_STATUS */
+					>;
+			};
+
+			phy4: ethernet-phy@4 {
+				device_type = "ethernet-phy";
+				reg = <4>;
+			};
+		};
+
+		gmac1: ethernet@37200000 {
+			status = "ok";
+			phy-mode = "rgmii";
+			qcom,id = <1>;
+
+			pinctrl-0 = <&rgmii2_pins>;
+			pinctrl-names = "default";
+
+			mtd-mac-address = <&art 6>;
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+
+		gmac2: ethernet@37400000 {
+			status = "ok";
+			phy-mode = "sgmii";
+			qcom,id = <2>;
+
+			mtd-mac-address = <&art 0>;
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		wifi {
+			label = "wifi";
+			gpios = <&qcom_pinmux 6 1>;
+			linux,code = <KEY_WLAN>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 54 1>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 65 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		usb1 {
+			label = "r7800:amber:usb1";
+			gpios = <&qcom_pinmux 7 0>;
+		};
+
+		usb3 {
+			label = "r7800:amber:usb3";
+			gpios = <&qcom_pinmux 8 0>;
+		};
+
+		status {
+			label = "r7800:amber:status";
+			gpios = <&qcom_pinmux 9 0>;
+		};
+
+		internet {
+			label = "r7800:white:internet";
+			gpios = <&qcom_pinmux 22 0>;
+		};
+
+		wan {
+			label = "r7800:white:wan";
+			gpios = <&qcom_pinmux 23 0>;
+		};
+
+		wps {
+			label = "r7800:white:wps";
+			gpios = <&qcom_pinmux 24 0>;
+		};
+
+		esata {
+			label = "r7800:white:esata";
+			gpios = <&qcom_pinmux 26 0>;
+		};
+
+		power {
+			label = "r7800:white:power";
+			gpios = <&qcom_pinmux 53 0>;
+			default-state = "on";
+		};
+
+		rfkill {
+			label = "r7800:white:rfkill";
+			gpios = <&qcom_pinmux 64 0>;
+		};
+
+		wifi {
+			label = "r7800:white:wifi";
+			gpios = <&qcom_pinmux 67 0>;
+		};
+	};
+};
+
+&adm_dma {
+	status = "ok";
+};

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-v1.0.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-v1.0.dtsi
@@ -1,0 +1,1 @@
+#include "qcom-ipq8065.dtsi"

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
@@ -1,0 +1,1185 @@
+/dts-v1/;
+
+#include "skeleton.dtsi"
+#include <dt-bindings/clock/qcom,gcc-ipq806x.h>
+#include <dt-bindings/mfd/qcom-rpm.h>
+#include <dt-bindings/soc/qcom,gsbi.h>
+#include <dt-bindings/reset/qcom,gcc-ipq806x.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	model = "Qualcomm IPQ8065";
+	compatible = "qcom,ipq8065";
+	interrupt-parent = <&intc>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			compatible = "qcom,krait";
+			enable-method = "qcom,kpss-acc-v1";
+			device_type = "cpu";
+			reg = <0>;
+			next-level-cache = <&L2>;
+			qcom,acc = <&acc0>;
+			qcom,saw = <&saw0>;
+			clocks = <&kraitcc 0>;
+			clock-names = "cpu";
+			clock-latency = <100000>;
+			core-supply = <&smb208_s2a>;
+			voltage-tolerance = <5>;
+			cooling-min-state = <0>;
+			cooling-max-state = <10>;
+			#cooling-cells = <2>;
+
+			operating-points-0-0 = <
+				/* kHz      uV */
+				1725000 1262500
+				1400000 1175000
+				1000000 1100000
+				 800000 1050000
+				 600000 1000000
+ 				 384000 975000
+ 			>;
+			operating-points-0-1 = <
+				/* kHz      uV */
+				1725000 1262500
+				1400000 1175000
+				1000000 1100000
+				 800000 1050000
+				 600000 1000000
+ 				 384000 950000
+			>;
+			operating-points-0-2 = <
+				/* kHz      uV */
+				1725000 1200000
+				1400000 1125000
+				1000000 1050000
+				 800000 1000000
+				 600000 950000
+ 				 384000 925000
+			>;
+			operating-points-0-3 = <
+				/* kHz      uV */
+				1725000 1175000
+				1400000 1100000
+				1000000 1025000
+				 800000 975000
+				 600000 925000
+ 				 384000 900000
+			>;
+			operating-points-0-4 = <
+				/* kHz      uV */
+				1725000 1150000
+				1400000 1075000
+				1000000 1000000
+				 800000 950000
+				 600000 900000
+ 				 384000 875000
+			>;
+			operating-points-0-5 = <
+				/* kHz      uV */
+				1725000 1100000
+				1400000 1025000
+				1000000 950000
+				 800000 900000
+				 600000 850000
+ 				 384000 825000
+			>;
+			operating-points-0-6 = <
+				/* kHz      uV */
+				1725000 1050000
+				1400000 975000
+				1000000 900000
+				 800000 850000
+				 600000 800000
+ 				 384000 775000
+			>;
+		};
+
+		cpu@1 {
+			compatible = "qcom,krait";
+			enable-method = "qcom,kpss-acc-v1";
+			device_type = "cpu";
+			reg = <1>;
+			next-level-cache = <&L2>;
+			qcom,acc = <&acc1>;
+			qcom,saw = <&saw1>;
+			clocks = <&kraitcc 1>;
+			clock-names = "cpu";
+			clock-latency = <100000>;
+			core-supply = <&smb208_s2b>;
+
+			operating-points-0-0 = <
+				/* kHz      uV */
+				1725000 1262500
+				1400000 1175000
+				1000000 1100000
+				 800000 1050000
+				 600000 1000000
+ 				 384000 975000
+ 			>;
+			operating-points-0-1 = <
+				/* kHz      uV */
+				1725000 1262500
+				1400000 1175000
+				1000000 1100000
+				 800000 1050000
+				 600000 1000000
+ 				 384000 950000
+			>;
+			operating-points-0-2 = <
+				/* kHz      uV */
+				1725000 1200000
+				1400000 1125000
+				1000000 1050000
+				 800000 1000000
+				 600000 950000
+ 				 384000 925000
+			>;
+			operating-points-0-3 = <
+				/* kHz      uV */
+				1725000 1175000
+				1400000 1100000
+				1000000 1025000
+				 800000 975000
+				 600000 925000
+ 				 384000 900000
+			>;
+			operating-points-0-4 = <
+				/* kHz      uV */
+				1725000 1150000
+				1400000 1075000
+				1000000 1000000
+				 800000 950000
+				 600000 900000
+ 				 384000 875000
+			>;
+			operating-points-0-5 = <
+				/* kHz      uV */
+				1725000 1100000
+				1400000 1025000
+				1000000 950000
+				 800000 900000
+				 600000 850000
+ 				 384000 825000
+			>;
+			operating-points-0-6 = <
+				/* kHz      uV */
+				1725000 1050000
+				1400000 975000
+				1000000 900000
+				 800000 850000
+				 600000 800000
+ 				 384000 775000
+			>;
+			cooling-min-state = <0>;
+			cooling-max-state = <10>;
+			#cooling-cells = <2>;
+		};
+
+		L2: l2-cache {
+			compatible = "cache";
+			cache-level = <2>;
+			clocks = <&kraitcc 4>;
+			clock-names = "cache";
+			cache-points-kHz = <
+				/* kHz    uV    CPU kHz */
+				1200000 1150000 1200000
+				1000000 1100000  600000
+				 384000 1100000  384000
+			>;
+			vdd_dig-supply = <&smb208_s1a>;
+		};
+	};
+
+	cpu-pmu {
+		compatible = "qcom,krait-pmu";
+		interrupts = <1 10 0x304>;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		nss@40000000 {
+			reg = <0x40000000 0x1000000>;
+			no-map;
+		};
+
+		smem: smem@41000000 {
+			reg = <0x41000000 0x200000>;
+			no-map;
+		};
+	};
+
+	clocks {
+		sleep_clk: sleep_clk {
+			compatible = "fixed-clock";
+			clock-frequency = <32768>;
+			#clock-cells = <0>;
+		};
+	};
+
+	kraitcc: clock-controller {
+		compatible = "qcom,krait-cc-v1";
+		#clock-cells = <1>;
+	};
+
+	qcom,pvs {
+		qcom,pvs-format-a;
+		qcom,speed0-pvs0-bin-v0 =
+			< 1725000000 1262500 >,
+			< 1400000000 1175000 >,
+			< 1000000000 1100000 >,
+			 < 800000000 1050000 >,
+			 < 600000000 1000000 >,
+			 < 384000000 975000 >;
+		qcom,speed0-pvs1-bin-v0 =
+			< 1725000000 1262500 >,
+			< 1400000000 1175000 >,
+			< 1000000000 1100000 >,
+			 < 800000000 1050000 >,
+			 < 600000000 1000000 >,
+			 < 384000000 950000 >;
+		qcom,speed0-pvs2-bin-v0 =
+			< 1725000000 1200000 >,
+			< 1400000000 1125000 >,
+			< 1000000000 1050000 >,
+			 < 800000000 1000000 >,
+			 < 600000000 950000 >,
+			 < 384000000 925000 >;
+		qcom,speed0-pvs3-bin-v0 =
+			< 1725000000 1175000 >,
+			< 1400000000 1100000 >,
+			< 1000000000 1025000 >,
+			 < 800000000 975000 >,
+			 < 600000000 925000 >,
+			 < 384000000 900000 >;
+		qcom,speed0-pvs4-bin-v0 =
+			< 1725000000 1150000 >,
+			< 1400000000 1075000 >,
+			< 1000000000 1000000 >,
+			 < 800000000 950000 >,
+			 < 600000000 900000 >,
+			 < 384000000 875000 >;
+		qcom,speed0-pvs5-bin-v0 =
+			< 1725000000 1100000 >,
+			< 1400000000 1025000 >,
+			< 1000000000 950000 >,
+			 < 800000000 900000 >,
+			 < 600000000 850000 >,
+			 < 384000000 825000 >;
+		qcom,speed0-pvs6-bin-v0 =
+			< 1725000000 1050000 >,
+			< 1400000000 975000 >,
+			< 1000000000 900000 >,
+			 < 800000000 850000 >,
+			 < 600000000 800000 >,
+			 < 384000000 775000 >;
+	};
+
+	soc: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		compatible = "simple-bus";
+
+		imem: memory@700000 {
+			compatible = "qcom,imem-ipq8064", "syscon";
+			reg = <0x00700000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0x00700000 0x1000>;
+		};
+
+		rpm@108000 {
+			compatible = "qcom,rpm-ipq8064";
+			reg = <0x108000 0x1000>;
+			qcom,ipc = <&l2cc 0x8 2>;
+
+			interrupts = <0 19 0>,
+				     <0 21 0>,
+				     <0 22 0>;
+			interrupt-names = "ack",
+					  "err",
+					  "wakeup";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			smb208_s1a: smb208-s1a {
+				compatible = "qcom,rpm-smb208";
+				reg = <QCOM_RPM_SMB208_S1a>;
+
+				regulator-min-microvolt = <1050000>;
+				regulator-max-microvolt = <1150000>;
+
+				qcom,switch-mode-frequency = <1200000>;
+
+			};
+
+			smb208_s1b: smb208-s1b {
+				compatible = "qcom,rpm-smb208";
+				reg = <QCOM_RPM_SMB208_S1b>;
+
+				regulator-min-microvolt = <1050000>;
+				regulator-max-microvolt = <1150000>;
+
+				qcom,switch-mode-frequency = <1200000>;
+			};
+
+			smb208_s2a: smb208-s2a {
+				compatible = "qcom,rpm-smb208";
+				reg = <QCOM_RPM_SMB208_S2a>;
+
+				regulator-min-microvolt = < 800000>;
+				regulator-max-microvolt = <1275000>;
+
+				qcom,switch-mode-frequency = <1400000>;
+			};
+
+			smb208_s2b: smb208-s2b {
+				compatible = "qcom,rpm-smb208";
+				reg = <QCOM_RPM_SMB208_S2b>;
+
+				regulator-min-microvolt = < 800000>;
+				regulator-max-microvolt = <1275000>;
+
+				qcom,switch-mode-frequency = <1400000>;
+			};
+
+			cxo_clk: cxo-clk {
+				#clock-cells = <0>;
+				compatible = "qcom,rpm-clk";
+				reg = <QCOM_RPM_CXO_CLK>;
+				qcom,rpm-clk-name = "cxo";
+				qcom,rpm-clk-freq = <25000000>;
+				qcom,rpm-clk-active-only;
+			};
+
+			pxo_clk: pxo-clk {
+				#clock-cells = <0>;
+				compatible = "qcom,rpm-clk";
+				reg = <QCOM_RPM_PXO_CLK>;
+				qcom,rpm-clk-name = "pxo";
+				qcom,rpm-clk-freq = <25000000>;
+				qcom,rpm-clk-active-only;
+			};
+
+			ebi1_clk: ebi1-clk {
+				#clock-cells = <0>;
+				compatible = "qcom,rpm-clk";
+				reg = <QCOM_RPM_EBI1_CLK>;
+				qcom,rpm-clk-name = "ebi1";
+				qcom,rpm-clk-freq = <533000000>;
+				qcom,rpm-clk-active-only;
+			};
+
+			apps_fabric_clk: apps-fabric-clk {
+				#clock-cells = <0>;
+				compatible = "qcom,rpm-clk";
+				reg = <QCOM_RPM_APPS_FABRIC_CLK>;
+				qcom,rpm-clk-name = "apps-fabric";
+				qcom,rpm-clk-freq = <533000000>;
+				qcom,rpm-clk-active-only;
+			};
+
+			nss_fabric0_clk: nss-fabric0-clk {
+				#clock-cells = <0>;
+				compatible = "qcom,rpm-clk";
+				reg = <QCOM_RPM_NSS_FABRIC_0_CLK>;
+				qcom,rpm-clk-name = "nss-fabric0";
+				qcom,rpm-clk-freq = <533000000>;
+				qcom,rpm-clk-active-only;
+			};
+
+			nss_fabric1_clk: nss-fabric1-clk {
+				#clock-cells = <0>;
+				compatible = "qcom,rpm-clk";
+				reg = <QCOM_RPM_NSS_FABRIC_1_CLK>;
+				qcom,rpm-clk-name = "nss-fabric1";
+				qcom,rpm-clk-freq = <266000000>;
+				qcom,rpm-clk-active-only;
+			};
+		};
+
+		rng@1a500000 {
+			compatible = "qcom,prng";
+			reg = <0x1a500000 0x200>;
+			clocks = <&gcc PRNG_CLK>;
+			clock-names = "core";
+		};
+
+		qcom,msm-imem@2A03F000 {
+			compatible = "qcom,msm-imem";
+			reg = <0x2A03F000 0x1000>; /* Address and size of IMEM */
+			ranges = <0x0 0x2A03F000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			download_mode@0 {
+				compatible = "qcom,msm-imem-download_mode";
+				reg = <0x0 8>;
+			};
+
+			restart_reason@65c {
+				compatible = "qcom,msm-imem-restart_reason";
+				reg = <0x65c 4>;
+			};
+
+			l2_dump_offset@14 {
+				compatible = "qcom,msm-imem-l2_dump_offset";
+				reg = <0x14 8>;
+			};
+		};
+
+		qcom_pinmux: pinmux@800000 {
+			compatible = "qcom,ipq8064-pinctrl";
+			reg = <0x800000 0x4000>;
+
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupts = <0 32 0x4>;
+
+			pcie0_pins: pcie0_pinmux {
+				mux {
+					pins = "gpio3";
+					function = "pcie1_rst";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
+			pcie1_pins: pcie1_pinmux {
+				mux {
+					pins = "gpio48";
+					function = "pcie2_rst";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
+			pcie2_pins: pcie2_pinmux {
+				mux {
+					pins = "gpio63";
+					function = "pcie3_rst";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+		};
+
+		intc: interrupt-controller@2000000 {
+			compatible = "qcom,msm-qgic2";
+			interrupt-controller;
+			#interrupt-cells = <3>;
+			reg = <0x02000000 0x1000>,
+			      <0x02002000 0x1000>;
+		};
+
+		timer@200a000 {
+			compatible = "qcom,kpss-timer", "qcom,msm-timer";
+			interrupts = <1 1 0x301>,
+				     <1 2 0x301>,
+				     <1 3 0x301>,
+				     <1 4 0x301>,
+				     <1 5 0x301>;
+			reg = <0x0200a000 0x100>;
+			clock-frequency = <25000000>,
+					  <32768>;
+			clocks = <&sleep_clk>;
+			clock-names = "sleep";
+			cpu-offset = <0x80000>;
+		};
+
+		acc0: clock-controller@2088000 {
+			compatible = "qcom,kpss-acc-v1";
+			reg = <0x02088000 0x1000>, <0x02008000 0x1000>;
+			clock-output-names = "acpu0_aux";
+		};
+
+		acc1: clock-controller@2098000 {
+			compatible = "qcom,kpss-acc-v1";
+			reg = <0x02098000 0x1000>, <0x02008000 0x1000>;
+			clock-output-names = "acpu1_aux";
+		};
+
+		l2cc: clock-controller@2011000 {
+			compatible = "qcom,kpss-gcc", "syscon";
+			reg = <0x2011000 0x1000>;
+			clock-output-names = "acpu_l2_aux";
+ 		};
+
+		saw0: regulator@2089000 {
+			compatible = "qcom,saw2";
+			reg = <0x02089000 0x1000>, <0x02009000 0x1000>;
+			regulator;
+		};
+
+		saw1: regulator@2099000 {
+			compatible = "qcom,saw2";
+			reg = <0x02099000 0x1000>, <0x02009000 0x1000>;
+			regulator;
+		};
+
+		gsbi2: gsbi@12480000 {
+			compatible = "qcom,gsbi-v1.0.0";
+			cell-index = <2>;
+			reg = <0x12480000 0x100>;
+			clocks = <&gcc GSBI2_H_CLK>;
+			clock-names = "iface";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			status = "disabled";
+
+			syscon-tcsr = <&tcsr>;
+
+			uart2: serial@12490000 {
+				compatible = "qcom,msm-uartdm-v1.3", "qcom,msm-uartdm";
+				reg = <0x12490000 0x1000>,
+				      <0x12480000 0x1000>;
+				interrupts = <0 195 0x0>;
+				clocks = <&gcc GSBI2_UART_CLK>, <&gcc GSBI2_H_CLK>;
+				clock-names = "core", "iface";
+				status = "disabled";
+			};
+
+			i2c@124a0000 {
+				compatible = "qcom,i2c-qup-v1.1.1";
+				reg = <0x124a0000 0x1000>;
+				interrupts = <0 196 0>;
+
+				clocks = <&gcc GSBI2_QUP_CLK>, <&gcc GSBI2_H_CLK>;
+				clock-names = "core", "iface";
+				status = "disabled";
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
+
+		};
+
+		gsbi4: gsbi@16300000 {
+			compatible = "qcom,gsbi-v1.0.0";
+			cell-index = <4>;
+			reg = <0x16300000 0x100>;
+			clocks = <&gcc GSBI4_H_CLK>;
+			clock-names = "iface";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			status = "disabled";
+
+			syscon-tcsr = <&tcsr>;
+
+			uart4: serial@16340000 {
+				compatible = "qcom,msm-uartdm-v1.3", "qcom,msm-uartdm";
+				reg = <0x16340000 0x1000>,
+				      <0x16300000 0x1000>;
+				interrupts = <0 152 0x0>;
+				clocks = <&gcc GSBI4_UART_CLK>, <&gcc GSBI4_H_CLK>;
+				clock-names = "core", "iface";
+				status = "disabled";
+			};
+
+			i2c@16380000 {
+				compatible = "qcom,i2c-qup-v1.1.1";
+				reg = <0x16380000 0x1000>;
+				interrupts = <0 153 0>;
+
+				clocks = <&gcc GSBI4_QUP_CLK>, <&gcc GSBI4_H_CLK>;
+				clock-names = "core", "iface";
+				status = "disabled";
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
+		};
+
+		gsbi5: gsbi@1a200000 {
+			compatible = "qcom,gsbi-v1.0.0";
+			cell-index = <5>;
+			reg = <0x1a200000 0x100>;
+			clocks = <&gcc GSBI5_H_CLK>;
+			clock-names = "iface";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			status = "disabled";
+
+			syscon-tcsr = <&tcsr>;
+
+			uart5: serial@1a240000 {
+				compatible = "qcom,msm-uartdm-v1.3", "qcom,msm-uartdm";
+				reg = <0x1a240000 0x1000>,
+				      <0x1a200000 0x1000>;
+				interrupts = <0 154 0x0>;
+				clocks = <&gcc GSBI5_UART_CLK>, <&gcc GSBI5_H_CLK>;
+				clock-names = "core", "iface";
+				status = "disabled";
+			};
+
+			i2c@1a280000 {
+				compatible = "qcom,i2c-qup-v1.1.1";
+				reg = <0x1a280000 0x1000>;
+				interrupts = <0 155 0>;
+
+				clocks = <&gcc GSBI5_QUP_CLK>, <&gcc GSBI5_H_CLK>;
+				clock-names = "core", "iface";
+				status = "disabled";
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
+
+			spi@1a280000 {
+				compatible = "qcom,spi-qup-v1.1.1";
+				reg = <0x1a280000 0x1000>;
+				interrupts = <0 155 0>;
+
+				clocks = <&gcc GSBI5_QUP_CLK>, <&gcc GSBI5_H_CLK>;
+				clock-names = "core", "iface";
+				status = "disabled";
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
+		};
+
+		sata_phy: sata-phy@1b400000 {
+			compatible = "qcom,ipq806x-sata-phy";
+			reg = <0x1b400000 0x200>;
+
+			clocks = <&gcc SATA_PHY_CFG_CLK>;
+			clock-names = "cfg";
+
+			#phy-cells = <0>;
+			status = "disabled";
+		};
+
+		sata@29000000 {
+			compatible = "qcom,ipq806x-ahci", "generic-ahci";
+			reg = <0x29000000 0x180>;
+
+			interrupts = <0 209 0x0>;
+
+			clocks = <&gcc SFAB_SATA_S_H_CLK>,
+				 <&gcc SATA_H_CLK>,
+				 <&gcc SATA_A_CLK>,
+				 <&gcc SATA_RXOOB_CLK>,
+				 <&gcc SATA_PMALIVE_CLK>;
+			clock-names = "slave_face", "iface", "core",
+					"rxoob", "pmalive";
+
+			assigned-clocks = <&gcc SATA_RXOOB_CLK>, <&gcc SATA_PMALIVE_CLK>;
+			assigned-clock-rates = <100000000>, <100000000>;
+
+			phys = <&sata_phy>;
+			phy-names = "sata-phy";
+			status = "disabled";
+		};
+
+		qcom,ssbi@500000 {
+			compatible = "qcom,ssbi";
+			reg = <0x00500000 0x1000>;
+			qcom,controller-type = "pmic-arbiter";
+		};
+
+		gcc: clock-controller@900000 {
+			compatible = "qcom,gcc-ipq8064";
+			reg = <0x00900000 0x4000>;
+			#clock-cells = <1>;
+			#reset-cells = <1>;
+		};
+
+		tcsr: syscon@1a400000 {
+			compatible = "qcom,tcsr-ipq8064", "syscon";
+			reg = <0x1a400000 0x100>;
+		};
+
+		tsens: tsens-ipq806x {
+			compatible = "qcom,ipq806x-tsens";
+			reg = <0x900000 0x3678>, <0x700000 0x420>;
+			reg-names = "tsens_physical", "tsens_eeprom_physical";
+			interrupts = <0 178 0>;
+			qcom,sensors = <11>;
+			qcom,tsens_factor = <1000>;
+			qcom,slope = <1176 1176 1154 1176 1111 1132 1132 1199 1132 1199 1132>;
+		};
+
+		qcom,msm-thermal {
+			compatible = "qcom,msm-thermal";
+			qcom,sensor-id = <0>;
+			qcom,poll-ms = <250>;
+			qcom,limit-temp = <105>;
+			qcom,temp-hysteresis = <10>;
+			qcom,freq-step = <2>;
+			qcom,core-limit-temp = <115>;
+			qcom,core-temp-hysteresis = <10>;
+			qcom,core-control-mask = <0xe>;
+		};
+
+		sfpb_mutex_block: syscon@1200600 {
+			compatible = "syscon";
+			reg = <0x01200600 0x100>;
+		};
+
+		hs_phy_1: phy@100f8800 {
+			compatible = "qcom,dwc3-hs-usb-phy";
+			reg = <0x100f8800 0x30>;
+			clocks = <&gcc USB30_1_UTMI_CLK>;
+			clock-names = "ref";
+			#phy-cells = <0>;
+
+			status = "disabled";
+		};
+
+		ss_phy_1: phy@100f8830 {
+			compatible = "qcom,dwc3-ss-usb-phy";
+			reg = <0x100f8830 0x30>;
+			clocks = <&gcc USB30_1_MASTER_CLK>;
+			clock-names = "ref";
+			#phy-cells = <0>;
+
+			status = "disabled";
+		};
+
+		hs_phy_0: phy@110f8800 {
+			compatible = "qcom,dwc3-hs-usb-phy";
+			reg = <0x110f8800 0x30>;
+			clocks = <&gcc USB30_0_UTMI_CLK>;
+			clock-names = "ref";
+			#phy-cells = <0>;
+
+			status = "disabled";
+		};
+
+		ss_phy_0: phy@110f8830 {
+			compatible = "qcom,dwc3-ss-usb-phy";
+			reg = <0x110f8830 0x30>;
+			clocks = <&gcc USB30_0_MASTER_CLK>;
+			clock-names = "ref";
+			#phy-cells = <0>;
+
+			status = "disabled";
+		};
+
+		usb3_0: usb30@0 {
+			compatible = "qcom,dwc3";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			clocks = <&gcc USB30_0_MASTER_CLK>;
+			clock-names = "core";
+
+			ranges;
+
+			status = "disabled";
+			resets = <&gcc USB30_0_MASTER_RESET>;
+			reset-names = "usb30_mstr_rst";
+
+			dwc3@11000000 {
+				compatible = "snps,dwc3";
+				reg = <0x11000000 0xcd00>;
+				interrupts = <0 110 0x4>;
+				phys = <&hs_phy_0>, <&ss_phy_0>;
+				phy-names = "usb2-phy", "usb3-phy";
+				tx-fifo-resize;
+				dr_mode = "host";
+			};
+		};
+
+		usb3_1: usb30@1 {
+			compatible = "qcom,dwc3";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			clocks = <&gcc USB30_1_MASTER_CLK>;
+			clock-names = "core";
+
+			ranges;
+
+			status = "disabled";
+
+			dwc3@10000000 {
+				compatible = "snps,dwc3";
+				reg = <0x10000000 0xcd00>;
+				interrupts = <0 205 0x4>;
+				phys = <&hs_phy_1>, <&ss_phy_1>;
+				phy-names = "usb2-phy", "usb3-phy";
+				tx-fifo-resize;
+				dr_mode = "host";
+			};
+		};
+
+		pcie0: pci@1b500000 {
+			compatible = "qcom,pcie-v0";
+			reg = <0x1b500000 0x1000
+			       0x1b502000 0x80
+			       0x1b600000 0x100
+			       0x0ff00000 0x100000>;
+			reg-names = "dbi", "elbi", "parf", "config";
+			device_type = "pci";
+			linux,pci-domain = <0>;
+			bus-range = <0x00 0xff>;
+			num-lanes = <1>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+
+			ranges = <0x81000000 0 0x0fe00000 0x0fe00000 0 0x00100000   /* downstream I/O */
+				  0x82000000 0 0x08000000 0x08000000 0 0x07e00000>; /* non-prefetchable memory */
+
+			interrupts = <GIC_SPI 35 IRQ_TYPE_NONE>;
+			interrupt-names = "msi";
+			#interrupt-cells = <1>;
+			interrupt-map-mask = <0 0 0 0x7>;
+			interrupt-map = <0 0 0 1 &intc 0 36 IRQ_TYPE_LEVEL_HIGH>, /* int_a */
+					<0 0 0 2 &intc 0 37 IRQ_TYPE_LEVEL_HIGH>, /* int_b */
+					<0 0 0 3 &intc 0 38 IRQ_TYPE_LEVEL_HIGH>, /* int_c */
+					<0 0 0 4 &intc 0 39 IRQ_TYPE_LEVEL_HIGH>; /* int_d */
+
+			clocks = <&gcc PCIE_A_CLK>,
+				 <&gcc PCIE_H_CLK>,
+				 <&gcc PCIE_PHY_CLK>,
+				 <&gcc PCIE_AUX_CLK>,
+				 <&gcc PCIE_ALT_REF_CLK>;
+			clock-names = "core", "iface", "phy", "aux", "ref";
+
+			assigned-clocks = <&gcc PCIE_ALT_REF_CLK>;
+			assigned-clock-rates = <100000000>;
+
+			resets = <&gcc PCIE_ACLK_RESET>,
+				 <&gcc PCIE_HCLK_RESET>,
+				 <&gcc PCIE_POR_RESET>,
+				 <&gcc PCIE_PCI_RESET>,
+				 <&gcc PCIE_PHY_RESET>,
+				 <&gcc PCIE_EXT_RESET>;
+			reset-names = "axi", "ahb", "por", "pci", "phy", "ext";
+
+			pinctrl-0 = <&pcie0_pins>;
+			pinctrl-names = "default";
+
+			perst-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_LOW>;
+
+			status = "disabled";
+		};
+
+		pcie1: pci@1b700000 {
+			compatible = "qcom,pcie-v0";
+			reg = <0x1b700000 0x1000
+			       0x1b702000 0x80
+			       0x1b800000 0x100
+			       0x31f00000 0x100000>;
+			reg-names = "dbi", "elbi", "parf", "config";
+			device_type = "pci";
+			linux,pci-domain = <1>;
+			bus-range = <0x00 0xff>;
+			num-lanes = <1>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+
+			ranges = <0x81000000 0 0x31e00000 0x31e00000 0 0x00100000   /* downstream I/O */
+				  0x82000000 0 0x2e000000 0x2e000000 0 0x03e00000>; /* non-prefetchable memory */
+
+			interrupts = <GIC_SPI 57 IRQ_TYPE_NONE>;
+			interrupt-names = "msi";
+			#interrupt-cells = <1>;
+			interrupt-map-mask = <0 0 0 0x7>;
+			interrupt-map = <0 0 0 1 &intc 0 58 IRQ_TYPE_LEVEL_HIGH>, /* int_a */
+					<0 0 0 2 &intc 0 59 IRQ_TYPE_LEVEL_HIGH>, /* int_b */
+					<0 0 0 3 &intc 0 60 IRQ_TYPE_LEVEL_HIGH>, /* int_c */
+					<0 0 0 4 &intc 0 61 IRQ_TYPE_LEVEL_HIGH>; /* int_d */
+
+			clocks = <&gcc PCIE_1_A_CLK>,
+				 <&gcc PCIE_1_H_CLK>,
+				 <&gcc PCIE_1_PHY_CLK>,
+				 <&gcc PCIE_1_AUX_CLK>,
+				 <&gcc PCIE_1_ALT_REF_CLK>;
+			clock-names = "core", "iface", "phy", "aux", "ref";
+
+			assigned-clocks = <&gcc PCIE_1_ALT_REF_CLK>;
+			assigned-clock-rates = <100000000>;
+
+			resets = <&gcc PCIE_1_ACLK_RESET>,
+				 <&gcc PCIE_1_HCLK_RESET>,
+				 <&gcc PCIE_1_POR_RESET>,
+				 <&gcc PCIE_1_PCI_RESET>,
+				 <&gcc PCIE_1_PHY_RESET>,
+				 <&gcc PCIE_1_EXT_RESET>;
+			reset-names = "axi", "ahb", "por", "pci", "phy", "ext";
+
+			pinctrl-0 = <&pcie1_pins>;
+			pinctrl-names = "default";
+
+			perst-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_LOW>;
+
+			status = "disabled";
+		};
+
+		pcie2: pci@1b900000 {
+			compatible = "qcom,pcie-v0";
+			reg = <0x1b900000 0x1000
+			       0x1b902000 0x80
+			       0x1ba00000 0x100
+			       0x35f00000 0x100000>;
+			reg-names = "dbi", "elbi", "parf", "config";
+			device_type = "pci";
+			linux,pci-domain = <2>;
+			bus-range = <0x00 0xff>;
+			num-lanes = <1>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+
+			ranges = <0x81000000 0 0x35e00000 0x35e00000 0 0x00100000   /* downstream I/O */
+				  0x82000000 0 0x32000000 0x32000000 0 0x03e00000>; /* non-prefetchable memory */
+
+			interrupts = <GIC_SPI 71 IRQ_TYPE_NONE>;
+			interrupt-names = "msi";
+			#interrupt-cells = <1>;
+			interrupt-map-mask = <0 0 0 0x7>;
+			interrupt-map = <0 0 0 1 &intc 0 72 IRQ_TYPE_LEVEL_HIGH>, /* int_a */
+					<0 0 0 2 &intc 0 73 IRQ_TYPE_LEVEL_HIGH>, /* int_b */
+					<0 0 0 3 &intc 0 74 IRQ_TYPE_LEVEL_HIGH>, /* int_c */
+					<0 0 0 4 &intc 0 75 IRQ_TYPE_LEVEL_HIGH>; /* int_d */
+
+			clocks = <&gcc PCIE_2_A_CLK>,
+				 <&gcc PCIE_2_H_CLK>,
+				 <&gcc PCIE_2_PHY_CLK>,
+				 <&gcc PCIE_2_AUX_CLK>,
+				 <&gcc PCIE_2_ALT_REF_CLK>;
+			clock-names = "core", "iface", "phy", "aux", "ref";
+
+			assigned-clocks = <&gcc PCIE_2_ALT_REF_CLK>;
+			assigned-clock-rates = <100000000>;
+
+			resets = <&gcc PCIE_2_ACLK_RESET>,
+				 <&gcc PCIE_2_HCLK_RESET>,
+				 <&gcc PCIE_2_POR_RESET>,
+				 <&gcc PCIE_2_PCI_RESET>,
+				 <&gcc PCIE_2_PHY_RESET>,
+				 <&gcc PCIE_2_EXT_RESET>;
+			reset-names = "axi", "ahb", "por", "pci", "phy", "ext";
+
+			pinctrl-0 = <&pcie2_pins>;
+			pinctrl-names = "default";
+
+			perst-gpio = <&qcom_pinmux 63 GPIO_ACTIVE_LOW>;
+
+			status = "disabled";
+		};
+
+		adm_dma: dma@18300000 {
+			compatible = "qcom,adm";
+			reg = <0x18300000 0x100000>;
+			interrupts = <0 170 0>;
+			#dma-cells = <1>;
+
+			clocks = <&gcc ADM0_CLK>, <&gcc ADM0_PBUS_CLK>;
+			clock-names = "core", "iface";
+
+			resets = <&gcc ADM0_RESET>,
+				 <&gcc ADM0_PBUS_RESET>,
+				 <&gcc ADM0_C0_RESET>,
+				 <&gcc ADM0_C1_RESET>,
+				 <&gcc ADM0_C2_RESET>;
+			reset-names = "clk", "pbus", "c0", "c1", "c2";
+			qcom,ee = <0>;
+
+			status = "disabled";
+		};
+
+		nand@1ac00000 {
+			compatible = "qcom,ebi2-nandc";
+			reg = <0x1ac00000 0x800>;
+
+			clocks = <&gcc EBI2_CLK>,
+				 <&gcc EBI2_AON_CLK>;
+			clock-names = "core", "aon";
+
+			dmas = <&adm_dma 3>;
+			dma-names = "rxtx";
+			qcom,cmd-crci = <15>;
+			qcom,data-crci = <3>;
+
+			status = "disabled";
+		};
+
+		nss_common: syscon@03000000 {
+			compatible = "syscon";
+			reg = <0x03000000 0x0000FFFF>;
+		};
+
+		qsgmii_csr: syscon@1bb00000 {
+			compatible = "syscon";
+			reg = <0x1bb00000 0x000001FF>;
+		};
+
+		gmac0: ethernet@37000000 {
+			device_type = "network";
+			compatible = "qcom,ipq806x-gmac";
+			reg = <0x37000000 0x200000>;
+			interrupts = <GIC_SPI 220 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "macirq";
+
+			qcom,nss-common = <&nss_common>;
+			qcom,qsgmii-csr = <&qsgmii_csr>;
+
+			clocks = <&gcc GMAC_CORE1_CLK>;
+			clock-names = "stmmaceth";
+
+			resets = <&gcc GMAC_CORE1_RESET>;
+			reset-names = "stmmaceth";
+
+			status = "disabled";
+		};
+
+		gmac1: ethernet@37200000 {
+			device_type = "network";
+			compatible = "qcom,ipq806x-gmac";
+			reg = <0x37200000 0x200000>;
+			interrupts = <GIC_SPI 223 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "macirq";
+
+			qcom,nss-common = <&nss_common>;
+			qcom,qsgmii-csr = <&qsgmii_csr>;
+
+			clocks = <&gcc GMAC_CORE2_CLK>;
+			clock-names = "stmmaceth";
+
+			resets = <&gcc GMAC_CORE2_RESET>;
+			reset-names = "stmmaceth";
+
+			status = "disabled";
+		};
+
+		gmac2: ethernet@37400000 {
+			device_type = "network";
+			compatible = "qcom,ipq806x-gmac";
+			reg = <0x37400000 0x200000>;
+			interrupts = <GIC_SPI 226 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "macirq";
+
+			qcom,nss-common = <&nss_common>;
+			qcom,qsgmii-csr = <&qsgmii_csr>;
+
+			clocks = <&gcc GMAC_CORE3_CLK>;
+			clock-names = "stmmaceth";
+
+			resets = <&gcc GMAC_CORE3_RESET>;
+			reset-names = "stmmaceth";
+
+			status = "disabled";
+		};
+
+		gmac3: ethernet@37600000 {
+			device_type = "network";
+			compatible = "qcom,ipq806x-gmac";
+			reg = <0x37600000 0x200000>;
+			interrupts = <GIC_SPI 229 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "macirq";
+
+			qcom,nss-common = <&nss_common>;
+			qcom,qsgmii-csr = <&qsgmii_csr>;
+
+			clocks = <&gcc GMAC_CORE4_CLK>;
+			clock-names = "stmmaceth";
+
+			resets = <&gcc GMAC_CORE4_RESET>;
+			reset-names = "stmmaceth";
+
+			status = "disabled";
+		};
+		/* Temporary fixed regulator */
+		vsdcc_fixed: vsdcc-regulator {
+			compatible = "regulator-fixed";
+			regulator-name = "SDCC Power";
+			regulator-min-microvolt = <3300000>;
+			regulator-max-microvolt = <3300000>;
+			regulator-always-on;
+		};
+
+		sdcc1bam:dma@12402000 {
+			compatible = "qcom,bam-v1.3.0";
+			reg = <0x12402000 0x8000>;
+			interrupts = <0 98 0>;
+			clocks = <&gcc SDC1_H_CLK>;
+			clock-names = "bam_clk";
+			#dma-cells = <1>;
+			qcom,ee = <0>;
+                };
+
+		sdcc3bam:dma@12182000 {
+			compatible = "qcom,bam-v1.3.0";
+			reg = <0x12182000 0x8000>;
+			interrupts = <0 96 0>;
+			clocks = <&gcc SDC3_H_CLK>;
+			clock-names = "bam_clk";
+			#dma-cells = <1>;
+			qcom,ee = <0>;
+		};
+
+		amba {
+			compatible = "arm,amba-bus";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+			sdcc1: sdcc@12400000 {
+				status          = "disabled";
+				compatible      = "arm,pl18x", "arm,primecell";
+				arm,primecell-periphid = <0x00051180>;
+				reg             = <0x12400000 0x2000>;
+				interrupts      = <GIC_SPI 104 IRQ_TYPE_LEVEL_HIGH>;
+				interrupt-names = "cmd_irq";
+				clocks          = <&gcc SDC1_CLK>, <&gcc SDC1_H_CLK>;
+				clock-names     = "mclk", "apb_pclk";
+				bus-width       = <8>;
+				max-frequency   = <48000000>;
+				non-removable;
+				cap-sd-highspeed;
+				cap-mmc-highspeed;
+				vmmc-supply = <&vsdcc_fixed>;
+				#dmas = <&sdcc1bam 2>, <&sdcc1bam 1>;
+				#dma-names = "tx", "rx";
+			};
+
+			sdcc3: sdcc@12180000 {
+				compatible      = "arm,pl18x", "arm,primecell";
+				arm,primecell-periphid = <0x00051180>;
+				status          = "disabled";
+				reg             = <0x12180000 0x2000>;
+				interrupts      = <GIC_SPI 102 IRQ_TYPE_LEVEL_HIGH>;
+				interrupt-names = "cmd_irq";
+				clocks          = <&gcc SDC3_CLK>, <&gcc SDC3_H_CLK>;
+				clock-names     = "mclk", "apb_pclk";
+				bus-width       = <8>;
+				cap-sd-highspeed;
+				cap-mmc-highspeed;
+				max-frequency   = <192000000>;
+				#mmc-ddr-1_8v;
+				sd-uhs-sdr50;
+				vmmc-supply = <&vsdcc_fixed>;
+				#dmas = <&sdcc3bam 2>, <&sdcc3bam 1>;
+				#dma-names = "tx", "rx";
+			};
+		};
+
+	};
+
+	sfpb_mutex: sfpb-mutex {
+		compatible = "qcom,sfpb-mutex";
+		syscon = <&sfpb_mutex_block 4 4>;
+
+		#hwlock-cells = <1>;
+	};
+
+	smem {
+		compatible = "qcom,smem";
+		memory-region = <&smem>;
+		hwlocks = <&sfpb_mutex 3>;
+	};
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -107,6 +107,7 @@ define Device/AP148
 	PAGESIZE := 2048
 	BOARD_NAME := ap148
 	DEVICE_TITLE := Qualcom AP148
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
 
 define Device/AP148-legacy
@@ -117,6 +118,7 @@ define Device/AP148-legacy
 	PAGESIZE := 2048
 	BOARD_NAME := ap148
 	DEVICE_TITLE := Qualcom AP148 (legacy)
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
 
 define Device/C2600
@@ -127,6 +129,7 @@ define Device/C2600
 	BOARD_NAME := c2600
 	TPLINK_BOARD_NAME := C2600
 	DEVICE_TITLE := TP-Link Archer C2600
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
 
 define Device/D7800
@@ -139,6 +142,7 @@ define Device/D7800
 	PAGESIZE := 2048
 	BOARD_NAME := d7800
 	DEVICE_TITLE := Netgear Nighthawk X4 D7800
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
 
 define Device/DB149
@@ -147,6 +151,7 @@ define Device/DB149
 	KERNEL_INSTALL := 1
 	BOARD_NAME := db149
 	DEVICE_TITLE := Qualcom DB149
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
 
 define Device/EA8500
@@ -164,6 +169,7 @@ define Device/EA8500
 	IMAGE/sysupgrade.tar := sysupgrade-nand
 	DEVICE_VARS += DEVICE_DTS KERNEL_SIZE PAGESIZE BLOCKSIZE SUBPAGESIZE
 	DEVICE_TITLE := Linksys EA8500
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
 
 define Device/R7500
@@ -176,8 +182,23 @@ define Device/R7500
 	PAGESIZE := 2048
 	BOARD_NAME := r7500
 	DEVICE_TITLE := Netgear Nighthawk X4 R7500
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
 
-TARGET_DEVICES += AP148 AP148-legacy C2600 D7800 DB149 EA8500 R7500
+define Device/R7800
+	$(call Device/DniImage)
+	DEVICE_DTS := qcom-ipq8064-r7800
+	KERNEL_SIZE := 2097152
+	NETGEAR_BOARD_ID := R7800
+	NETGEAR_HW_ID := 29764958+0+128+512+4x4+4x4+cascade
+	BLOCKSIZE := 128KiB
+	PAGESIZE := 2048
+	BOARD_NAME := r7800
+	DEVICE_TITLE := Netgear Nighthawk X4S R7800
+	DEVICE_PACKAGES := ath10k-firmware-qca9984
+endef
+
+
+TARGET_DEVICES += AP148 AP148-legacy C2600 D7800 DB149 EA8500 R7500 R7800
 
 $(eval $(call BuildImage))

--- a/target/linux/ipq806x/patches-4.4/168-ARM-qcom-add-smb208-DT.patch
+++ b/target/linux/ipq806x/patches-4.4/168-ARM-qcom-add-smb208-DT.patch
@@ -71,4 +71,73 @@ Signed-off-by: Adrian Panella <ianchi74@outlook.com>
 +				};
  			};
  		};
+
+--- a/arch/arm/boot/dts/qcom-ipq8065.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq8065.dtsi
+@@ -311,45 +311,37 @@
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
  
+-			smb208_s1a: smb208-s1a {
+-				compatible = "qcom,rpm-smb208";
+-				reg = <QCOM_RPM_SMB208_S1a>;
+-
+-				regulator-min-microvolt = <1050000>;
+-				regulator-max-microvolt = <1150000>;
++			regulators {
++				compatible = "qcom,rpm-smb208-regulators";
+ 
+-				qcom,switch-mode-frequency = <1200000>;
+-
+-			};
++				smb208_s1a: s1a {
++					regulator-min-microvolt = <1050000>;
++					regulator-max-microvolt = <1150000>;
+ 
+-			smb208_s1b: smb208-s1b {
+-				compatible = "qcom,rpm-smb208";
+-				reg = <QCOM_RPM_SMB208_S1b>;
++					qcom,switch-mode-frequency = <1200000>;
+ 
+-				regulator-min-microvolt = <1050000>;
+-				regulator-max-microvolt = <1150000>;
+-
+-				qcom,switch-mode-frequency = <1200000>;
+-			};
++				};
+ 
+-			smb208_s2a: smb208-s2a {
+-				compatible = "qcom,rpm-smb208";
+-				reg = <QCOM_RPM_SMB208_S2a>;
++				smb208_s1b: s1b {
++					regulator-min-microvolt = <1050000>;
++					regulator-max-microvolt = <1150000>;
+ 
+-				regulator-min-microvolt = < 800000>;
+-				regulator-max-microvolt = <1275000>;
++					qcom,switch-mode-frequency = <1200000>;
++				};
+ 
+-				qcom,switch-mode-frequency = <1400000>;
+-			};
++				smb208_s2a: s2a {
++					regulator-min-microvolt = < 800000>;
++					regulator-max-microvolt = <1275000>;
+ 
+-			smb208_s2b: smb208-s2b {
+-				compatible = "qcom,rpm-smb208";
+-				reg = <QCOM_RPM_SMB208_S2b>;
++					qcom,switch-mode-frequency = <1400000>;
++				};
+ 
+-				regulator-min-microvolt = < 800000>;
+-				regulator-max-microvolt = <1275000>;
++				smb208_s2b: s2b {
++					regulator-min-microvolt = < 800000>;
++					regulator-max-microvolt = <1275000>;
+ 
+-				qcom,switch-mode-frequency = <1400000>;
++					qcom,switch-mode-frequency = <1400000>;
++				};
+ 			};
+ 		};

--- a/target/linux/ipq806x/patches-4.4/800-devicetree.patch
+++ b/target/linux/ipq806x/patches-4.4/800-devicetree.patch
@@ -12,7 +12,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -506,7 +506,11 @@
+@@ -506,7 +506,12 @@
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
  	qcom-ipq8064-ap148.dtb \
@@ -21,6 +21,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  	qcom-ipq8064-db149.dtb \
 +	qcom-ipq8064-ea8500.dtb \
 +	qcom-ipq8064-r7500.dtb \
++	qcom-ipq8064-r7800.dtb \
  	qcom-msm8660-surf.dtb \
  	qcom-msm8960-cdp.dtb \
  	qcom-msm8974-sony-xperia-honami.dtb


### PR DESCRIPTION
Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>

The commit adds initial support for Netgear R7800
The device boots and is accessible, networking is okay.

Known issues:
- USB does not function yet
- Not all buttons function
- WIFI support by ath10k driver (QCA9984, compat-wireless) has to be implemnted into LEDE seperately
- not all regulators clocks are supported by LEDE drivers

Seems there should be more changes into other linux drivers related to ipq806x.

For further development I need help from community, that unfortunately I can't get on forums.

Made a new profile file to choose ath10k firmware.