### PR TITLE
download: add download info file

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -11,6 +11,8 @@ LEDE_GIT = https://git.lede-project.org
 
 DOWNLOAD_RDEP=$(STAMP_PREPARED) $(HOST_STAMP_PREPARED)
 
+DL_INFO_FILE=$(BIN_DIR)/download.txt
+
 # Try to guess the download method from the URL
 define dl_method
 $(strip \
@@ -46,11 +48,12 @@ define DownloadMethod/unknown
 endef
 
 define DownloadMethod/default
-	$(SCRIPT_DIR)/download.pl "$(DL_DIR)" "$(FILE)" "$(MD5SUM)" "$(URL_FILE)" $(foreach url,$(URL),"$(url)")
+	$(SCRIPT_DIR)/download.pl "$(DL_INFO_FILE)" "$(DL_DIR)" "$(FILE)" "$(MD5SUM)" "$(URL_FILE)" $(foreach url,$(URL),"$(url)")
 endef
 
 define wrap_mirror
-$(if $(if $(MIRROR),$(filter-out x,$(MIRROR_MD5SUM))),$(SCRIPT_DIR)/download.pl "$(DL_DIR)" "$(FILE)" "$(MIRROR_MD5SUM)" "" || ( $(1) ),$(1))
+	$(1) echo -n "Url: $(URL)^$(VERSION) File:$(FILE) Md5sum: " >> $(DL_INFO_FILE); md5sum $(DL_DIR)/$(FILE) | cut -d ' ' -f 1 >> $(DL_INFO_FILE);
+	$(if $(if $(MIRROR),$(filter-out x,$(MIRROR_MD5SUM))),$(SCRIPT_DIR)/download.pl "$(DL_INFO_FILE)" "$(DL_DIR)" "$(FILE)" "$(MIRROR_MD5SUM)" "" || ( $(1) ),$(1))
 endef
 
 define DownloadMethod/cvs

--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -11,10 +11,12 @@ use strict;
 use warnings;
 use File::Basename;
 use File::Copy;
+use File::Path qw/make_path/;
 
-@ARGV > 2 or die "Syntax: $0 <target dir> <filename> <hash> <url filename> [<mirror> ...]\n";
+@ARGV > 2 or die "Syntax: $0 <dl_info_file> <target dir> <filename> <hash> <url filename> [<mirror> ...]\n";
 
 my $url_filename;
+my $dl_info_file = shift @ARGV;
 my $target = shift @ARGV;
 my $filename = shift @ARGV;
 my $file_hash = shift @ARGV;
@@ -156,6 +158,11 @@ sub download
 			cleanup();
 			return;
 		}
+
+		make_path(dirname($dl_info_file));
+		open(my $fh, '>>', "$dl_info_file") or die "Could not open file '$dl_info_file' !";
+		print $fh "Url: $mirror File: $url_filename Md5sum: $sum\n";
+		close $fh;
 	};
 
 	unlink "$target/$filename";


### PR DESCRIPTION
Add download info file to get short information where the packages are
downloaded from. If you add a local mirror to your config. It is now
easy possible to see if an offline build is possible.

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>