### PR TITLE
ath10k-firmware: updated board-2.bin

### DIFF
--- a/package/firmware/ath10k-firmware/Makefile
+++ b/package/firmware/ath10k-firmware/Makefile
@@ -114,10 +114,10 @@ QCA99X0_BOARD_REV:=ddcec9efd245da9365c474f513a855a55f3ac7fe
 QCA99X0_BOARD_FILE:=board-2.bin.$(QCA99X0_BOARD_REV)
 
 define Download/qca99x0-board
-  URL:=https://www.codeaurora.org/cgit/quic/qsdk/oss/firmware/ath10k-firmware/plain/ath10k/QCA99X0/hw2.0
-  URL_FILE:=board-2.bin?id=ddcec9efd245da9365c474f513a855a55f3ac7fe
+  URL:=https://source.codeaurora.org/quic/qsdk/oss/firmware/ath10k-firmware/plain/ath10k/QCA99X0/hw2.0
+  URL_FILE:=board-2.bin
   FILE:=$(QCA99X0_BOARD_FILE)
-  MD5SUM:=a2b3c653c2363a5641200051d6333d0a
+  MD5SUM:=410f0672e86b01fd65b15a246b5c0d32
 endef
 $(eval $(call Download,qca99x0-board))
 


### PR DESCRIPTION
board-2.bin location and version updated causing package download
failure. Firmware package now correctly downloads.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>