### PR TITLE
ath10k-firmware: fix board-2.bin download URL

### DIFF
--- a/package/firmware/ath10k-firmware/Makefile
+++ b/package/firmware/ath10k-firmware/Makefile
@@ -110,12 +110,13 @@ $(Package/ath10k-firmware-default)
   TITLE:=ath10k firmware for QCA6174 devices
 endef
 
+
 QCA99X0_BOARD_REV:=ddcec9efd245da9365c474f513a855a55f3ac7fe
 QCA99X0_BOARD_FILE:=board-2.bin.$(QCA99X0_BOARD_REV)
 
 define Download/qca99x0-board
-  URL:=https://www.codeaurora.org/cgit/quic/qsdk/oss/firmware/ath10k-firmware/plain/ath10k/QCA99X0/hw2.0
-  URL_FILE:=board-2.bin?id=ddcec9efd245da9365c474f513a855a55f3ac7fe
+  URL:=https://source.codeaurora.org/quic/qsdk/oss/firmware/ath10k-firmware/plain/ath10k/QCA99X0/hw2.0
+  URL_FILE:=board-2.bin?id=$(QCA99X0_BOARD_REV)
   FILE:=$(QCA99X0_BOARD_FILE)
   MD5SUM:=a2b3c653c2363a5641200051d6333d0a
 endef


### PR DESCRIPTION
Original URL got 303 redirect which then also dropped the commit id
leading to different file revision & MD5 mismatch.

Corrected URL & clarified commit ID use in Makefile

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>