### PR TITLE
ipq806x: enable ieee80211 phy hotplug and patch macaddress

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -1,0 +1,21 @@
+#!/bin/ash
+
+[ "$ACTION" == "add" ] || exit 0
+
+PHYNBR=${DEVPATH##*/phy}
+
+[ -n $PHYNBR ] || exit 0
+
+. /lib/ipq806x.sh
+. /lib/functions/system.sh
+
+board=$(ipq806x_board_name)
+
+case "$board" in
+	ea8500)
+		echo $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) $(($PHYNBR + 1)) ) > /sys${DEVPATH}/macaddress
+		;;
+	
+	*)
+		;;
+esac


### PR DESCRIPTION
Calibration data for QCA99x0 in this device has bogus macaddress.
The data cannot be modified directly, as it breaks checksum control.
Instead change the macaddress from phy add hotplug event.

Signed-off-by: Adrian Panella <ianchi74@outlook.com>