### PR TITLE
[URFC] Add global setting for default SSL provider

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -74,6 +74,62 @@ menu "Global build settings"
 
 	source "config/Config-kernel.in"
 
+	comment "Default Crypto Options"
+
+	choice
+		prompt "Extent to prefer crypto"
+		default CRYPTO_DEFAULT_PACKAGE
+		help
+		  How strongly to insist on using cryptography
+		  when available (for package builds).
+		config CRYPTO_DEFAULT_PACKAGE
+			bool "According to package and SSL provider defaults"
+		config CRYPTO_DEFAULT_ALL
+			bool "Default to always enabled"
+		config CRYPTO_DEFAULT_NONE
+			bool "Default to not building crypto except internal wireless"
+	endchoice
+
+	choice
+		prompt "Default SSL provider"
+			default SSL_DEFAULT_SELECT_POLARSSL if !CRYPTO_DEFAULT_NONE
+			default SSL_NOSSL if CRYPTO_DEFAULT_NONE
+			help
+			  Set the SSL library to enable by default when there is a
+			  choice if libraries (e.g. to prefer openssl when both
+			  polarssl and openssl are options).  For "No SSL" option
+			  selects no SSL when that is an option, but doesn't
+			  prevent building packages requiring SSL (i.e. it's a
+			  default not a hard setting).
+			config SSL_DEFAULT_POLARSSL
+				bool "PolarSSL"
+				select PACKAGE_libpolarssl
+			config SSL_DEFAULT_OPENSSL
+				bool "OpenSSL"
+				select PACKAGE_libopenssl
+			config SSL_DEFAULT_MBEDTLS
+				bool "mbedtls"
+				select PACKAGE_libmbedtls
+			config SSL_DEFAULT_NOSSL
+				bool "No SSL"
+	endchoice
+
+	config SSL_DEFAULT_FALLBACK_OPENSSL
+		bool "Allow fallback to OpenSSL if default not available"
+		depends on !SSL_DEFAULT_OPENSSL
+		default y if !SSL_DEFAULT_NOSSL
+		help
+		 For non-openssl as the default SSL library, allow
+		  to build packages against openssl if the default
+		  library is not avaiable or not an option.
+		  NB: Saying n here will make packages that can
+		  only be built against openssl default to n.
+
+	config SSL_DEFAULT_NOOPENSSL
+		bool
+		default y
+		depends on ( !SSL_DEFAULT_OPENSSL && !SSL_DEFAULT_FALLBACK_OPENSSL )
+
 	comment "Package build options"
 
 	config DEBUG

--- a/package/libs/nettle/Makefile
+++ b/package/libs/nettle/Makefile
@@ -30,6 +30,7 @@ define Package/libnettle
   TITLE:=GNU crypto library
   URL:=http://www.lysator.liu.se/~nisse/nettle/
   DEPENDS+= +!LIBNETTLE_MINI:libgmp
+  DEFAULT:=n if CRYPTO_DEFAULT_NONE, m if ALL
 endef
 
 define Package/libnettle/config

--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -89,7 +89,7 @@ define Package/dnsmasq-full/config
 		default y
 	config PACKAGE_dnsmasq_full_dnssec
 		bool "Build with DNSSEC support."
-		default y
+		default y if !CRYPTO_DEFAULT_NONE
 	config PACKAGE_dnsmasq_full_auth
 		bool "Build with the facility to act as an authoritative DNS server."
 		default y

--- a/package/network/services/hostapd/Config.in
+++ b/package/network/services/hostapd/Config.in
@@ -9,7 +9,8 @@ config WPA_SUPPLICANT_NO_TIMESTAMP_CHECK
 
 choice
 	prompt "Choose TLS provider"
-	default WPA_SUPPLICANT_INTERNAL
+	default WPA_SUPPLICANT_INTERNAL if SSL_DEFAULT_NOOPENSSL
+	default WPA_SUPPLICANT_OPENSSL if !SSL_DEFAULT_NOOPENSSL
 	depends on PACKAGE_wpa-supplicant || PACKAGE_wpad
 
 config WPA_SUPPLICANT_INTERNAL
@@ -17,7 +18,6 @@ config WPA_SUPPLICANT_INTERNAL
 
 config WPA_SUPPLICANT_OPENSSL
 	bool "openssl"
-	select PACKAGE_libopenssl
 
 endchoice
 

--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -47,28 +47,13 @@ define Package/uhttpd/config
   config PACKAGE_uhttpd_debug
     bool "Build with debug messages"
     default n
-endef
 
-
-define Package/uhttpd-mod-tls
-  $(Package/uhttpd/default)
-  TITLE+= (TLS plugin)
-  DEPENDS:=uhttpd \
-	+PACKAGE_uhttpd-mod-tls_polarssl:libustream-polarssl \
-	+PACKAGE_uhttpd-mod-tls_mbedtls:libustream-mbedtls \
-	+PACKAGE_uhttpd-mod-tls_cyassl:libustream-cyassl \
-	+PACKAGE_uhttpd-mod-tls_openssl:libustream-openssl
-endef
-
-define Package/uhttpd-mod-tls/description
- The TLS plugin adds HTTPS support to uHTTPd.
-endef
-
-define Package/uhttpd-mod-tls/config
   choice
-    depends on PACKAGE_uhttpd-mod-tls
     prompt "TLS Provider"
-    default PACKAGE_uhttpd-mod-tls_polarssl
+    default PACKAGE_uhttpd-mod-tls_polarssl if SSL_DEFAULT_POLARSSL
+    default PACKAGE_uhttpd-mod-tls_mbedtls if SSL_DEFAULT_MBEDTLS
+    default PACKAGE_uhttpd-mod-tls_openssl if !SSL_DEFAULT_NOOPENSSL
+    default PACAKGE_utttpd-mod-tls_nossl if SSL_DEFAULT_NOSSL
 
     config PACKAGE_uhttpd-mod-tls_mbedtls
       bool "mbedTLS"
@@ -81,7 +66,26 @@ define Package/uhttpd-mod-tls/config
 
     config PACKAGE_uhttpd-mod-tls_openssl
       bool "OpenSSL"
+
+    config PACKAGE_uhttpd-mod-tls_nossl
+      bool "No SSL"
   endchoice
+endef
+
+
+define Package/uhttpd-mod-tls
+  $(Package/uhttpd/default)
+  TITLE+= (TLS plugin)
+  DEPENDS:=uhttpd @!PACKAGE_uhttpd-mod-tls_nossl \
+	+PACKAGE_uhttpd-mod-tls_openssl:libustream-openssl \
+	+PACKAGE_uhttpd-mod-tls_polarssl:libustream-polarssl \
+	+PACKAGE_uhttpd-mod-tls_mbedtls:libustream-mbedtls \
+	+PACKAGE_uhttpd-mod-tls_cyassl:libustream-cyassl
+  DEFAULT:=y if !SSL_DEFAULT_NOSSL, m if ALL
+endef
+
+define Package/uhttpd-mod-tls/description
+ The TLS plugin adds HTTPS support to uHTTPd.
 endef
 
 define Package/uhttpd-mod-lua

--- a/package/network/utils/curl/Config.in
+++ b/package/network/utils/curl/Config.in
@@ -4,7 +4,10 @@ comment "SSL support"
 
 choice
 	prompt "Selected SSL library"
-	default LIBCURL_POLARSSL
+	default LIBCURL_POLARSSL if DEFAULT_SSL_POLARSSL
+	default LIBCURL_MBEDTLS if DEFAULT_SSL_MBEDTLS
+	default LIBCURL_OPENSSL if !DEFAULT_SSL_NOOPENSSL
+	default LIBCURL_NOSSL if DEFAULT_SSL_NOSSL
 
 	config LIBCURL_POLARSSL
 		bool "PolarSSL"


### PR DESCRIPTION
This patch set adds a global config option that combined with patches to SSL-using packages allows to select the default SSL provider (e.g. to allow to make openssl the default instead of polarssl) with option to allow or disallow fallback to openssl (that if default provider is not openssl, making packages which require openssl to default to n (not building)).

Also has a "No SSL" option that defaults all SSL and dependent package variants to default n.