### PR TITLE
[openvpn] fix missing cipher list for polarssl in v2.3.11

### DIFF
--- a/package/network/services/openvpn/Makefile
+++ b/package/network/services/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.3.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://swupdate.openvpn.net/community/releases
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/package/network/services/openvpn/patches/201-fix-polarssl-no-cipher-list.patch
+++ b/package/network/services/openvpn/patches/201-fix-polarssl-no-cipher-list.patch
@@ -1,0 +1,23 @@
+--- a/src/openvpn/ssl.c
++++ b/src/openvpn/ssl.c
+@@ -561,7 +561,8 @@ init_ssl (const struct options *options,
+   tls_ctx_check_cert_time(new_ctx);
+ 
+   /* Allowable ciphers */
+-  tls_ctx_restrict_ciphers(new_ctx, options->cipher_list);
++  if (options->cipher_list)
++      tls_ctx_restrict_ciphers(new_ctx, options->cipher_list);
+ 
+ #ifdef ENABLE_CRYPTO_POLARSSL
+   /* Personalise the random by mixing in the certificate */
+--- a/src/openvpn/ssl_polarssl.c
++++ b/src/openvpn/ssl_polarssl.c
+@@ -176,7 +176,7 @@ tls_ctx_restrict_ciphers(struct tls_root
+ {
+   char *tmp_ciphers, *tmp_ciphers_orig, *token;
+   int i, cipher_count;
+-  int ciphers_len = strlen (ciphers);
++  int ciphers_len = ciphers ? strlen (ciphers) : 0;
+ 
+   ASSERT (NULL != ctx);
+   ASSERT (0 != ciphers_len);


### PR DESCRIPTION
I Saw later the change in openvpn upstream just now:
http://article.gmane.org/gmane.network.openvpn.devel/11647
https://community.openvpn.net/openvpn/ticket/683

Has been fixed shall be removed when v2.3.12 is released.