### PR TITLE
Set /dev/kmsg to 600

### DIFF
--- a/package/system/procd/files/hotplug.json
+++ b/package/system/procd/files/hotplug.json
@@ -17,10 +17,6 @@
 						]
 					],
 					[ "if",
-						[ "eq", "DEVNAME", "kmsg" ],
-						[ "makedev", "/dev/%DEVNAME%", "0644" ],
-					],
-					[ "if",
 						[ "regex", "DEVNAME", "^snd" ],
 						[ "makedev", "/dev/%DEVNAME%", "0660", "audio" ],
 					],


### PR DESCRIPTION
Small cleanup. Rebooted my router but I see no impact from this change. dmsg still works.