### PR TITLE
kernel: Move POSIX ACL and attr support options into submenu

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -631,87 +631,90 @@ if KERNEL_IP_PNP
 
 endif
 
-config USE_FS_ACL_ATTR
-	bool "Use filesystem ACL and attr support by default"
-	default n
-	help
-	  Make using ACLs (e.g. POSIX ACL, NFSv4 ACL) the default
-	  for kernel and packages, except tmpfs, flash filesystems,
-	  and old NFS.  Also enable userspace extended attribute support
-	  by default.  (OpenWrt already has an expection it will be
-	  present in the kernel).
+menu "Filesystem ACL and attr support options"
+	config USE_FS_ACL_ATTR
+		bool "Use filesystem ACL and attr support by default"
+		default n
+		help
+		  Make using ACLs (e.g. POSIX ACL, NFSv4 ACL) the default
+		  for kernel and packages, except tmpfs, flash filesystems,
+		  and old NFS.  Also enable userspace extended attribute support
+		  by default.  (OpenWrt already has an expection it will be
+		  present in the kernel).
 
-config KERNEL_FS_POSIX_ACL
-	bool "Enable POSIX ACL support"
-	default y if USE_FS_ACL_ATTR
+	config KERNEL_FS_POSIX_ACL
+		bool "Enable POSIX ACL support"
+		default y if USE_FS_ACL_ATTR
 
-config KERNEL_BTRFS_FS_POSIX_ACL
-	bool "Enable POSIX ACL for BtrFS Filesystems"
-	select KERNEL_FS_POSIX_ACL
-	default y if USE_FS_ACL_ATTR
+	config KERNEL_BTRFS_FS_POSIX_ACL
+		bool "Enable POSIX ACL for BtrFS Filesystems"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_ATTR
 
-config KERNEL_EXT4_FS_POSIX_ACL
-	bool "Enable POSIX ACL for Ext4 Filesystems"
-	select KERNEL_FS_POSIX_ACL
-	default y if USE_FS_ACL_ATTR
+	config KERNEL_EXT4_FS_POSIX_ACL
+		bool "Enable POSIX ACL for Ext4 Filesystems"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_ATTR
 
-config KERNEL_F2FS_FS_POSIX_ACL
-	bool "Enable POSIX ACL for F2FS Filesystems"
-	select KERNEL_FS_POSIX_ACL
-	default n
+	config KERNEL_F2FS_FS_POSIX_ACL
+		bool "Enable POSIX ACL for F2FS Filesystems"
+		select KERNEL_FS_POSIX_ACL
+		default n
 
-config KERNEL_JFFS2_FS_POSIX_ACL
-	bool "Enable POSIX ACL for JFFS2 Filesystems"
-	select KERNEL_FS_POSIX_ACL
-	default n
+	config KERNEL_JFFS2_FS_POSIX_ACL
+		bool "Enable POSIX ACL for JFFS2 Filesystems"
+		select KERNEL_FS_POSIX_ACL
+		default n
 
-config KERNEL_TMPFS_POSIX_ACL
-	bool "Enable POSIX ACL for TMPFS Filesystems"
-	select KERNEL_FS_POSIX_ACL
-	default n
+	config KERNEL_TMPFS_POSIX_ACL
+		bool "Enable POSIX ACL for TMPFS Filesystems"
+		select KERNEL_FS_POSIX_ACL
+		default n
 
-config KERNEL_CIFS_ACL
-	bool "Enable CIFS ACLs"
-	select KERNEL_FS_POSIX_ACL
-	default y if USE_FS_ACL_ATTR
+	config KERNEL_CIFS_ACL
+		bool "Enable CIFS ACLs"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_ATTR
 
-config KERNEL_HFS_FS_POSIX_ACL
-	bool "Enable POSIX ACL for HFS Filesystems"
-	select KERNEL_FS_POSIX_ACL
-	default y if USE_FS_ACL_ATTR
+	config KERNEL_HFS_FS_POSIX_ACL
+		bool "Enable POSIX ACL for HFS Filesystems"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_ATTR
 
-config KERNEL_HFSPLUG_FS_POSIX_ACL
-	bool "Enable POSIX ACL for HFS+ Filesystems"
-	select KERNEL_FS_POSIX_ACL
-	default y if USE_FS_ACL_ATTR
+	config KERNEL_HFSPLUG_FS_POSIX_ACL
+		bool "Enable POSIX ACL for HFS+ Filesystems"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_ATTR
 
-config KERNEL_NFS_ACL_SUPPORT
-	bool "Enable ACLs for NFS"
-	default y if USE_FS_ACL_ATTR
+	config KERNEL_NFS_ACL_SUPPORT
+		bool "Enable ACLs for NFS"
+		default y if USE_FS_ACL_ATTR
 
-config KERNEL_NFS_V3_ACL_SUPPORT
-	bool "Enable ACLs for NFSv3"
-	default n
+	config KERNEL_NFS_V3_ACL_SUPPORT
+		bool "Enable ACLs for NFSv3"
+		default n
 
-config KERNEL_NFSD_V2_ACL_SUPPORT
-	bool "Enable ACLs for NFSDv2"
-	default n
+	config KERNEL_NFSD_V2_ACL_SUPPORT
+		bool "Enable ACLs for NFSDv2"
+		default n
 
-config KERNEL_NFSD_V3_ACL_SUPPORT
-	bool "Enable ACLs for NFSDv3"
-	default n
+	config KERNEL_NFSD_V3_ACL_SUPPORT
+		bool "Enable ACLs for NFSDv3"
+		default n
 
-config KERNEL_REISER_FS_POSIX_ACL
-	bool "Enable POSIX ACLs for ReiserFS"
-	select KERNEL_FS_POSIX_ACL
-	default y if USE_FS_ACL_ATTR
+	config KERNEL_REISER_FS_POSIX_ACL
+		bool "Enable POSIX ACLs for ReiserFS"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_ATTR
 
-config KERNEL_XFS_POSIX_ACL
-	bool "Enable POSIX ACLs for XFS"
-	select KERNEL_FS_POSIX_ACL
-	default y if USE_FS_ACL_ATTR
+	config KERNEL_XFS_POSIX_ACL
+		bool "Enable POSIX ACLs for XFS"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_ATTR
 
-config KERNEL_JFS_POSIX_ACL
-	bool "Enable POSIX ACLs for JFS"
-	select KERNEL_FS_POSIX_ACL
-	default y if USE_FS_ACL_ATTR
+	config KERNEL_JFS_POSIX_ACL
+		bool "Enable POSIX ACLs for JFS"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_ATTR
+
+endmenu


### PR DESCRIPTION
Make global options menuconfig cleaner by moving POSIX ACL
and attr support options into a submenu.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>