### PR TITLE
scripts/feeds: Prevent .config autocreation

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -534,6 +534,11 @@ sub install_package {
 sub refresh_config {
 	my $default = shift;
 
+	# Don't create .config if it doesn't already exist so that making a
+	# config only occurs when the user intends it do (however we do
+	# want to refresh an existing config).
+	return if not (-e '.config');
+
 	# workaround for timestamp check
 	system("rm -f tmp/.packageinfo");
 


### PR DESCRIPTION
When using scripts/feeds upgrade the .config needs to be
updated but the code to do so was also autocreating a
.config if one didn't exist.  This is counter-productive
when you have not yet used menuconfig (or other config targets)
because things like selecting or deselecting CONFIG_ALL
(to build all package by default) only works if the
package selection has not already been done via an
existing .config selection.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>