### PR TITLE
ustream-ssl: Fix recursive dependency

### DIFF
--- a/package/libs/ustream-ssl/Makefile
+++ b/package/libs/ustream-ssl/Makefile
@@ -32,14 +32,14 @@ endef
 define Package/libustream-openssl
   $(Package/libustream/default)
   TITLE += (openssl)
-  DEPENDS += +PACKAGE_libustream-openssl:libopenssl
+  DEPENDS += +libopenssl
   VARIANT:=openssl
 endef
 
 define Package/libustream-cyassl
   $(Package/libustream/default)
   TITLE += (cyassl)
-  DEPENDS += +PACKAGE_libustream-cyassl:libcyassl
+  DEPENDS += +libcyassl
   VARIANT:=cyassl
 endef
 


### PR DESCRIPTION
Two variants incorrectly include themselves in
conditional depends on ssl libraries, which results
in a recursive dependency.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>