### PR TITLE
network/services/uhttpd: Add Basic Auth config

### DIFF
--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -53,6 +53,28 @@ generate_keys() {
 	}
 }
 
+create_httpauth() {
+	local cfg="$1"
+	local basecfg="$2"
+	local prefix username password
+
+	local instance
+	config_get instance "$cfg" instance
+	if [ -n "$instance" ] && [ "$instance" != "$basecfg" ]; then
+		return
+	fi
+
+	config_get prefix "$cfg" prefix
+	config_get username "$cfg" username
+	config_get password "$cfg" password
+
+	if [ -z "$prefix" ] || [ -z "$username" ] || [ -z "$password" ]; then
+		return
+	fi
+	echo "${prefix}:${username}:${password}" >>$httpdconf
+	haveauth=1
+}
+
 start_instance()
 {
 	UHTTPD_CERT=""
@@ -60,12 +82,24 @@ start_instance()
 
 	local cfg="$1"
 	local realm="$(uci_get system.@system[0].hostname)"
-	local listen http https interpreter indexes path handler
+	local listen http https interpreter indexes path handler httpdconf haveauth
 
 	procd_open_instance
 	procd_set_param respawn
 	procd_set_param stderr 1
 	procd_set_param command "$UHTTPD_BIN" -f
+
+	config_get config "$cfg" config
+	if [ -z "$config" ]; then
+		mkdir -p /var/etc/uhttpd
+		httpdconf="/var/etc/uhttpd/httpd.${cfg}.conf"
+		rm -f ${httpdconf}
+		config_foreach create_httpauth httpauth "$cfg"
+		if [ "$haveauth" = "1" ]; then
+			procd_append_param command -c ${httpdconf}
+			[ -r /etc/httpd.conf ] && cat /etc/httpd.conf >>/var/etc/uhttpd/httpd.${cfg}.conf
+		fi
+	fi
 
 	append_arg "$cfg" home "-h"
 	append_arg "$cfg" realm "-r" "${realm:-OpenWrt}"


### PR DESCRIPTION
We add an 'httpauth' section type that contains the options:

instance: Which uhttpd config section the auth is associated with
prefix: What virtual or real URL is being protected
username: The username for the Basic Auth dialogue
password: Hashed (crypt()) or plaintext password for the Basic Auth dialogue

If instance is not specified auth section applies to
all instances of uhttpd; if instance is specified
the auth section only applies to the uhttpd config
section with the same name as specified with the
instance option.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>

Has been tested and contains changes suggested by Jo