### PR TITLE
igmpproxy: logging options - make work & improve

### DIFF
--- a/package/network/services/igmpproxy/Makefile
+++ b/package/network/services/igmpproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=igmpproxy
 PKG_VERSION:=0.1
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/igmpproxy

--- a/package/network/services/igmpproxy/files/igmpproxy.config
+++ b/package/network/services/igmpproxy/files/igmpproxy.config
@@ -1,5 +1,6 @@
 config igmpproxy
 	option quickleave 1
+#	option verbose [0-2]
 
 config phyint wan
 	option network wan

--- a/package/network/services/igmpproxy/files/igmpproxy.init
+++ b/package/network/services/igmpproxy/files/igmpproxy.init
@@ -6,24 +6,13 @@ USE_PROCD=1
 PROG=/usr/sbin/igmpproxy
 CONFIGFILE=/var/etc/igmpproxy.conf
 
-# igmpproxy supports both a debug mode and verbosity, which are very useful
-# when something isn't working.
-#
-# Debug mode will print everything to stdout instead of syslog. Generally
-# verbosity should NOT be set as it will quickly fill your syslog.
-#
-# Put any debug or verbosity options into IGMP_OPTS
-#
-# Examples:
-# OPTIONS="-d -v -v" - debug mode and very verbose, this will land in
-#                        stdout and not in syslog
-# OPTIONS="-v" - be verbose, this will write aditional information to syslog
-
-OPTIONS=""
-
 igmp_header() {
-	local quickleave
+	local quickleave verbose
 	config_get_bool quickleave "$1" quickleave 0
+	config_get verbose "$1" verbose 0
+
+	[ $verbose = "1" ] && logopts="-v"
+	[ $verbose = "2" ] && logopts="-v -v"
 
 	mkdir -p /var/etc
 	rm -f /var/etc/igmpproxy.conf
@@ -113,6 +102,7 @@ service_triggers() {
 start_service() {
 	has_upstream=
 	netdevs=
+	logopts=
 	config_load igmpproxy
 
 	config_foreach igmp_header igmpproxy
@@ -121,7 +111,7 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command $PROG
-	[ -n "$OPTIONS" ] && procd_append_param $OPTIONS
+	[ -n "$logopts" ] && procd_append_param command $logopts
 	procd_append_param command $CONFIGFILE
 	procd_set_param file $CONFIGFILE
 	procd_set_param netdev $netdevs


### PR DESCRIPTION
Move logging/debug command line option to uci 'logopts' and take notice
of it.  Previously handled as 'OPTIONS' in .init script however variable
was ignored

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>