### PR TITLE
Fix lede partition size for RT5350F-OLINUXINO-EVB

### DIFF
--- a/target/linux/ramips/dts/RT5350F-OLINUXINO-EVB.dts
+++ b/target/linux/ramips/dts/RT5350F-OLINUXINO-EVB.dts
@@ -60,7 +60,7 @@
 
 		partition@50000 {
 			label = "firmware";
-			reg = <0x50000 0x3b0000>;
+			reg = <0x50000 0x7b0000>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/RT5350F-OLINUXINO.dts
+++ b/target/linux/ramips/dts/RT5350F-OLINUXINO.dts
@@ -38,7 +38,7 @@
 
 		partition@50000 {
 			label = "firmware";
-			reg = <0x50000 0x3b0000>;
+			reg = <0x50000 0x7b0000>;
 		};
 	};
 };


### PR DESCRIPTION
The partition size is wrong, leading to out-of-disk-space even on no/moderate use.

Upstream fix from vendor: https://github.com/OLIMEX/openwrt/commit/2f25eb57edc79d33c4810d185c193be4293c434a
Suggested fix for openwrt: https://dev.openwrt.org/ticket/20321