### PR TITLE
samba: update smb template socket options defaults

### DIFF
--- a/package/network/services/samba36/files/smb.conf.template
+++ b/package/network/services/samba36/files/smb.conf.template
@@ -21,7 +21,6 @@
 	preferred master = yes
 	security = user
 	smb passwd file = /etc/samba/smbpasswd
-	socket options = TCP_NODELAY IPTOS_LOWDELAY
 	syslog = 2
 	use sendfile = yes
 	writeable = yes


### PR DESCRIPTION
Removed socket options = TCP_NODELAY IPTOS_LOWDELAY

TCP_NODELAY (disables Nagle algorithm) is default since samba2.
IPTOS_LOWDELAY sets DSCP 0x10 coding (CS2)
The alternate IPTOS_THROUGHPUT sets DSCP 0x08 coding (CS1)

CS1 is a scavenger class, whilst CS2 is more OAM/interactive
(SNMP,SSH,syslog)

Using CS2 is definitely an abuse of DSCP classification, CS1 less so
however even if the ISP takes note of DSCP codings having a default that
sets traffic to CS2 is wrong.  Better to use the default Best Effort
class.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>