### PR TITLE
iftop: fix mac address display

### DIFF
--- a/package/network/utils/iftop/Makefile
+++ b/package/network/utils/iftop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iftop
 PKG_VERSION:=1.0pre4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.ex-parrot.com/~pdw/iftop/download

--- a/package/network/utils/iftop/patches/110-fix-mac-display.patch
+++ b/package/network/utils/iftop/patches/110-fix-mac-display.patch
@@ -1,0 +1,67 @@
+iftop: fix mac address display
+
+iftop would display portions of mac address with large ffffff prefixes.
+Make if_hw_addr type consistent.
+
+Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
+---
+ addrs_dlpi.c  | 2 +-
+ addrs_ioctl.c | 2 +-
+ addrs_ioctl.h | 2 +-
+ iftop.c       | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/addrs_dlpi.c b/addrs_dlpi.c
+index 188fef8..6c04ea1 100644
+--- a/addrs_dlpi.c
++++ b/addrs_dlpi.c
+@@ -50,7 +50,7 @@ extern char *strncat2(char *dest, char *src, int n);
+  */
+ 
+ int
+-get_addrs_dlpi(char *interface, char if_hw_addr[], struct in_addr *if_ip_addr)
++get_addrs_dlpi(char *interface, u_int8_t if_hw_addr[], struct in_addr *if_ip_addr)
+ {
+   int got_hw_addr = 0;
+   int got_ip_addr = 0;
+diff --git a/addrs_ioctl.c b/addrs_ioctl.c
+index 870c83b..7d01fb2 100644
+--- a/addrs_ioctl.c
++++ b/addrs_ioctl.c
+@@ -45,7 +45,7 @@
+  */
+ 
+ int
+-get_addrs_ioctl(char *interface, char if_hw_addr[], struct in_addr *if_ip_addr, struct in6_addr *if_ip6_addr)
++get_addrs_ioctl(char *interface, u_int8_t if_hw_addr[], struct in_addr *if_ip_addr, struct in6_addr *if_ip6_addr)
+ {
+   int s;
+   struct ifreq ifr = {};
+diff --git a/addrs_ioctl.h b/addrs_ioctl.h
+index f93a0b4..739de61 100644
+--- a/addrs_ioctl.h
++++ b/addrs_ioctl.h
+@@ -7,6 +7,6 @@
+ #define __ADDRS_IOCTL_H_
+ 
+ int
+-get_addrs_ioctl(char *interface, char if_hw_addr[], struct in_addr *if_ip_addr, struct in6_addr *if_ip6_addr);
++get_addrs_ioctl(char *interface, u_int8_t if_hw_addr[], struct in_addr *if_ip_addr, struct in6_addr *if_ip6_addr);
+ 
+ #endif /* __ADDRS_IOCTL_H_ */
+diff --git a/iftop.c b/iftop.c
+index a090dcf..f1b371a 100644
+--- a/iftop.c
++++ b/iftop.c
+@@ -55,7 +55,7 @@
+ 
+ /* ethernet address of interface. */
+ int have_hw_addr = 0;
+-char if_hw_addr[6];    
++u_int8_t if_hw_addr[6];    
+ 
+ /* IP address of interface */
+ int have_ip_addr = 0;
+-- 
+1.9.1
+


### PR DESCRIPTION
iftop would display portions of mac address with large ffffff prefixes.
Make if_hw_addr type consistent.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>