### PR TITLE
ar71xx: Fix PowerCloud CAP324 No Cloud title

### DIFF
--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -133,7 +133,7 @@ endef
 TARGET_DEVICES += cap324
 
 define Device/cap324-nocloud
-  DEVICE_TITLE := PowerCloud CAP324 Cloud AP
+  DEVICE_TITLE := PowerCloud CAP324 Cloud AP (No-Cloud)
   DEVICE_PACKAGES := uboot-envtools
   BOARDNAME := CAP324
   DEVICE_PROFILE := CAP324


### PR DESCRIPTION
CAP324 nocloud was missing (No-Cloud) in description

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>