### PR TITLE
sdk: Allow to configure signed package lists

### DIFF
--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -12,6 +12,10 @@ menu "Global build settings"
 		bool "Select all userspace packages by default"
 		default y
 
+	config SIGNED_PACKAGES
+		bool "Cryptographically sign package lists"
+		default y
+
 endmenu
 
 config MODULES


### PR DESCRIPTION
Add option to enable signing packages lists in SDK.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>