### PR TITLE
netifd : Quote vendorid and hostname variables in dhcp script

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -56,8 +56,8 @@ proto_dhcp_setup() {
 		-s /lib/netifd/dhcp.script \
 		-f -t 0 -i "$iface" \
 		${ipaddr:+-r $ipaddr} \
-		${hostname:+-H $hostname} \
-		${vendorid:+-V $vendorid} \
+		${hostname:+-H "$hostname"} \
+		${vendorid:+-V "$vendorid"} \
 		$clientid $broadcast $release $dhcpopts
 }
 


### PR DESCRIPTION
Quote hostname and vendorid variables in dhcp script so they can
hold strings having white space(s)

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>