### PR TITLE
[RFC] ipq806x: switch to cortex-a15 and optimize compiler flags

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -191,7 +191,7 @@ ifeq ($(DUMP),1)
     CPU_CFLAGS_cortex-a7 = -march=armv7-a -mtune=cortex-a7
     CPU_CFLAGS_cortex-a8 = -march=armv7-a -mtune=cortex-a8
     CPU_CFLAGS_cortex-a9 = -march=armv7-a -mtune=cortex-a9
-    CPU_CFLAGS_cortex-a15 = -march=armv7-a -mtune=cortex-a15
+    CPU_CFLAGS_cortex-a15 = -mcpu=cortex-a15
     CPU_CFLAGS_cortex-a53 = -march=armv8-a -mtune=cortex-a53
     CPU_CFLAGS_fa526 = -march=armv4 -mtune=fa526
     CPU_CFLAGS_mpcore = -march=armv6k -mtune=mpcore

--- a/target/linux/ipq806x/Makefile
+++ b/target/linux/ipq806x/Makefile
@@ -6,7 +6,7 @@ ARCH:=arm
 BOARD:=ipq806x
 BOARDNAME:=Qualcomm Atheros IPQ806X
 FEATURES:=squashfs nand ubifs fpu
-CPU_TYPE:=cortex-a9
+CPU_TYPE:=cortex-a15
 CPU_SUBTYPE:=neon-vfpv4
 MAINTAINER:=John Crispin <john@phrozen.org>
 

--- a/target/linux/ipq806x/patches-4.4/801-override-compiler-flags.patch
+++ b/target/linux/ipq806x/patches-4.4/801-override-compiler-flags.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/arm/Makefile b/arch/arm/Makefile
+index 2c2b28e..64c037d 100644
+--- a/arch/arm/Makefile
++++ b/arch/arm/Makefile
+@@ -67,7 +67,7 @@ KBUILD_CFLAGS	+= $(call cc-option,-fno-ipa-sra)
+ # macro, but instead defines a whole series of macros which makes
+ # testing for a specific architecture or later rather impossible.
+ arch-$(CONFIG_CPU_32v7M)	=-D__LINUX_ARM_ARCH__=7 -march=armv7-m -Wa,-march=armv7-m
+-arch-$(CONFIG_CPU_32v7)		=-D__LINUX_ARM_ARCH__=7 $(call cc-option,-march=armv7-a,-march=armv5t -Wa$(comma)-march=armv7-a)
++arch-$(CONFIG_CPU_32v7)		=-D__LINUX_ARM_ARCH__=7 -mcpu=cortex-a15 -mfpu=neon-vfpv4
+ arch-$(CONFIG_CPU_32v6)		=-D__LINUX_ARM_ARCH__=6 $(call cc-option,-march=armv6,-march=armv5t -Wa$(comma)-march=armv6)
+ # Only override the compiler option if ARMv6. The ARMv6K extensions are
+ # always available in ARMv7


### PR DESCRIPTION
Main goal of this change is to use hardware integer division instructions for ipq806x.  These instructions are supported by cortex-a15 but not cortex-a9.  Getting gcc 53x to emit those requires using -mcpu=cortex-a15 (using -march=armv7-a -mtune=cortex-a15 does not work because armv7-a does not include those instructions as a mandatory feature).

I am not really happy patching the kernel makefile to do this, so open to other suggestions how to override the kernel build flags from the lede build system/makefiles.

Underlying motivation for this change is that the emulated integer division is actually a performance hotspot under wired network load, due primarily to the use of the modulo operator in the sttmac ethernet driver (eg here https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/tree/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c?h=v4.4.14#n2175).

This is likely anyway mitigated by driver changes in more recent kernels (see https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/commit/drivers/net/ethernet/stmicro?id=e3ad57c96715df2989ce6c18e58faf2913b305cb) so probably this is less important once updating to 4.6 or later.

@dissent1