### PR TITLE
tools: add endian conversion functions for OS X

### DIFF
--- a/tools/include/endian.h
+++ b/tools/include/endian.h
@@ -7,9 +7,22 @@
 #elif defined(__APPLE__)
 #include <machine/endian.h>
 #include <machine/byte_order.h>
+#include <libkern/OSByteOrder.h>
 #define bswap_16(x) NXSwapShort(x)
 #define bswap_32(x) NXSwapInt(x)
 #define bswap_64(x) NXSwapLongLong(x)
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
 #elif defined(__FreeBSD__)
 #include <sys/endian.h>
 #define bswap_16(x) bswap16(x)


### PR DESCRIPTION
The endian.h file present in tools/include prevents a successful compilation of dosfstools, since it looks for endian.h presence and it prevents it from including libkern/OSByteOrder.h on OS X.
Should I add a hack to dosfstools or should I add the needed definitions to tools/dosfstools?