### PR TITLE
ppp: Extend uci datamodel with persistency support

### DIFF
--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ppp
 PKG_VERSION:=2.4.7
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/ppp/


### PR DESCRIPTION
PPP daemon can be put into persist mode meaning the
daemon will not exit after a connection gets terminated
but will instead try to reopen the connection.
The re-initiation after the link has been terminated
can be controlled via holdoff; this is helpfull in
scenarios where a BRAS is in denial of service mode
due to link setup requests after a BRAS has gone down

Following uci parameters have been added :
persist (boolean) : Puts the ppp daemon in persist mode
maxfail (integer) : Number of consecutive fail attempts which
puts the PPP daemon in exit mode
holdoff (interget) : Specifies how many seconds to wait
before re-initiating link setup after it has been terminated

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>
Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>