### PR TITLE
add patch to fix ath10k stack traces

### DIFF
--- a/package/kernel/mac80211/patches/937-ath10k_httrx_fix.patch
+++ b/package/kernel/mac80211/patches/937-ath10k_httrx_fix.patch
@@ -1,0 +1,29 @@
+diff --git a/drivers/net/wireless/ath/ath10k/htt_rx.c b/drivers/net/wireless/ath/ath10k/htt_rx.c
+index 80e6453..bab0802 100644
+--- a/drivers/net/wireless/ath/ath10k/htt_rx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_rx.c
+@@ -1525,7 +1525,7 @@ static void ath10k_htt_rx_h_filter(struct ath10k *ar,
+ static int ath10k_htt_rx_handle_amsdu(struct ath10k_htt *htt)
+ {
+ 	struct ath10k *ar = htt->ar;
+-	static struct ieee80211_rx_status rx_status;
++	struct ieee80211_rx_status *rx_status = &htt->rx_status;
+ 	struct sk_buff_head amsdu;
+ 	int ret;
+ 
+@@ -1549,11 +1549,11 @@ static int ath10k_htt_rx_handle_amsdu(struct ath10k_htt *htt)
+ 		return ret;
+ 	}
+ 
+-	ath10k_htt_rx_h_ppdu(ar, &amsdu, &rx_status, 0xffff);
++	ath10k_htt_rx_h_ppdu(ar, &amsdu, rx_status, 0xffff);
+ 	ath10k_htt_rx_h_unchain(ar, &amsdu, ret > 0);
+-	ath10k_htt_rx_h_filter(ar, &amsdu, &rx_status);
+-	ath10k_htt_rx_h_mpdu(ar, &amsdu, &rx_status);
+-	ath10k_htt_rx_h_deliver(ar, &amsdu, &rx_status);
++	ath10k_htt_rx_h_filter(ar, &amsdu, rx_status);
++	ath10k_htt_rx_h_mpdu(ar, &amsdu, rx_status);
++	ath10k_htt_rx_h_deliver(ar, &amsdu, rx_status);
+ 
+ 	return 0;
+ }


### PR DESCRIPTION
Patch comes from the thread here
http://lists.infradead.org/pipermail/ath10k/2016-July/008005.html

Fixes stack traces with multiple QCA99x0 radios which appeared with recent mac80211 updates.