### PR TITLE
samba: Remove redundant options.

### DIFF
--- a/package/network/services/samba36/files/samba.init
+++ b/package/network/services/samba36/files/samba.init
@@ -25,20 +25,18 @@ smb_header() {
 		done
 	)
 
-	local name workgroup description charset
+	local name workgroup description
 	local hostname="$(uci_get system.@system[0].hostname)"
 
 	config_get name        $1 name        "${hostname:-Lede}"
 	config_get workgroup   $1 workgroup   "${hostname:-Lede}"
 	config_get description $1 description "Samba on ${hostname:-Lede}"
-	config_get charset     $1 charset     "UTF-8"
 
 	mkdir -p /var/etc
 	sed -e "s#|NAME|#$name#g" \
 	    -e "s#|WORKGROUP|#$workgroup#g" \
 	    -e "s#|DESCRIPTION|#$description#g" \
 	    -e "s#|INTERFACES|#$interfaces#g" \
-	    -e "s#|CHARSET|#$charset#g" \
 	    /etc/samba/smb.conf.template > /var/etc/smb.conf
 
 	local homes

--- a/package/network/services/samba36/files/smb.conf.template
+++ b/package/network/services/samba36/files/smb.conf.template
@@ -1,19 +1,16 @@
 [global]
 	netbios name = |NAME| 
-	display charset = |CHARSET|
 	interfaces = |INTERFACES|
 	server string = |DESCRIPTION|
-	unix charset = |CHARSET|
 	workgroup = |WORKGROUP|
-	local master = no
-	browseable = yes
+	bind interfaces only = yes
 	deadtime = 30
 	domain master = yes
 	encrypt passwords = yes
 	enable core files = no
-	guest ok = yes
 	invalid users = root
 	load printers = no
+	local master = no
 	map to guest = Bad User
 	max protocol = SMB2
 	min receivefile size = 16384
@@ -25,4 +22,3 @@
 	syslog = 2
 	use sendfile = yes
 	writeable = yes
-	bind interfaces only = yes


### PR DESCRIPTION
Removed charset since samba defaults to UTF-8. Traditionally this was not the case I believe. guest ok and invalid users are option for a share and not global ones. The former gets applied when configured through LuCI. Also sorted by alphabet.