### PR TITLE
Use -x hostname:$hostname instead of -H $hostname

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -56,7 +56,7 @@ proto_dhcp_setup() {
 		-s /lib/netifd/dhcp.script \
 		-f -t 0 -i "$iface" \
 		${ipaddr:+-r $ipaddr} \
-		${hostname:+-H "$hostname"} \
+		${hostname:+-x "hostname:$hostname"} \
 		${vendorid:+-V "$vendorid"} \
 		$clientid $broadcast $release $dhcpopts
 }


### PR DESCRIPTION
Passing the hostname is currently broken in since the shipped busybox includes this commit:
https://git.busybox.net/busybox/commit/networking/udhcp/dhcpc.c?id=2017d48c0d70bef8768efb42909e605ea8eb5a21

Before:

    Sun Jan 31 18:11:32 2016 daemon.notice netifd: Interface 'wan' is now down
    Sun Jan 31 18:11:32 2016 daemon.notice netifd: Interface 'wan' is setting up now
    Sun Jan 31 18:11:32 2016 daemon.notice netifd: wan (18158): udhcpc: option -h NAME is deprecated, use -x hostname:NAME
    Sun Jan 31 18:11:32 2016 daemon.notice netifd: wan (18158): udhcpc: malformed hex string 'WR150'

After:

    Sun Jan 31 18:11:33 2016 daemon.notice netifd: wan (18169): udhcpc (v1.23.2) started
    Sun Jan 31 18:11:33 2016 daemon.notice netifd: wan (18169): Sending discover...
    Sun Jan 31 18:11:33 2016 daemon.notice netifd: wan (18169): Sending select for xxx.yyy.zzz.xyz...
    Sun Jan 31 18:11:33 2016 daemon.notice netifd: wan (18169): Lease of xxx.yyy.zzz.xyz obtained, lease time 600

Signed-off-by: Merlijn Wajer <merlijn@wizzup.org>