### PR TITLE
ramips: dch-m225 don't have ethernet. default enable wifi

### DIFF
--- a/target/linux/ramips/base-files/etc/uci-defaults/03_wireless
+++ b/target/linux/ramips/base-files/etc/uci-defaults/03_wireless
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Copyright (C) 2016 OpenWrt.org
+#
+
+[ ! -e /etc/config/wireless ] && exit 0
+
+. /lib/functions/system.sh
+. /lib/ramips.sh
+
+board=$(ramips_board_name)
+
+case "$board" in
+dch-m225)
+	uci set wireless.@wifi-device[0].disabled=0
+	;;
+esac
+
+uci commit wireless
+
+exit 0


### PR DESCRIPTION
dch-m225 don't have Ethernet port. use uci-default to default enable wifi.

Signed-off-by: Michael Lee <igvtee@gmail.com>