### PR TITLE
zram-swap: CONFIG_PROCD_ZRAM_TMPFS compatibility

### DIFF
--- a/package/system/zram-swap/files/zram.init
+++ b/package/system/zram-swap/files/zram.init
@@ -71,8 +71,17 @@ zram_reset()
 
 list_cpu_idx()
 {
-	local line i=0
-
+	# Offset by 1 if /dev/zram0 is in use by /tmp
+	if [ "$(mount | grep /dev/zram0)" ]; then
+		local line i=1
+		# Hot-add new ZRAM device (if necessary)
+		if [ ! -b /dev/zram1 ]; then 
+			cat /sys/class/zram-control/hot_add
+		fi
+	else
+		local line i=0
+	fi
+	
 	while read line; do {
 		case "$line" in
 			[Pp]rocessor*)


### PR DESCRIPTION
Enable CONFIG_PROCD_ZRAM_TMPFS compatibility via two changes to list_cpu_idx():
* detect if /tmp is being used by /dev/zram0; if yes, offset initial value by 1 to skip first zram device.
* hot-add /dev/zram1, if not already present.

Signed-off-by: Conn O'Griofa connogriofa@gmail.com