### PR TITLE
base-files: sysupgrade: fix pseudobridge upgrades

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -127,7 +127,7 @@ kill_remaining() { # [ <signal> ]
 		else 
 			case "$name" in
 				# Skip essential services
-				*procd*|*ash*|*init*|*watchdog*|*ssh*|*dropbear*|*telnet*|*login*|*hostapd*|*wpa_supplicant*|*nas*) : ;;
+				*procd*|*ash*|*init*|*watchdog*|*ssh*|*dropbear*|*telnet*|*login*|*hostapd*|*wpa_supplicant*|*nas*|*relayd*) : ;;
 
 				# Killable process
 				*)


### PR DESCRIPTION
Treat 'relayd' as an essential service to avoid connection interruptions during sysupgrade on devices configured as a pseudobridge.

Signed-off-by: Conn O'Griofa <connogriofa@gmail.com>