### PR TITLE
ipq806x: fix MAC_POWER_SEL for Netgear R7800

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7800.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7800.dts
@@ -246,7 +246,7 @@
 					0x00004 0x7600000   /* PAD0_MODE */
 					0x00008 0x1000000   /* PAD5_MODE */
 					0x0000c 0x80        /* PAD6_MODE */
-					0x000e4 0xaa545     /* MAC_POWER_SEL */
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
 					0x000e0 0xc74164de  /* SGMII_CTRL */
 					0x0007c 0x4e        /* PORT0_STATUS */
 					0x00094 0x4e        /* PORT6_STATUS */


### PR DESCRIPTION
Fixes instability/corruption on the ethernet interface connected to port0 on the switch on Netgear R7800 as well.

Signed-off-by: Josh Bendavid <joshbendavid@gmail.com>
Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>