### PR TITLE
Add support for TEW-714TRU

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -269,6 +269,10 @@ rt-n14u)
 	set_wifi_led "$board:blue:air"
 	set_usb_led "$board:blue:usb"
 	;;
+tew-714tru)
+	set_usb_led "$board:red:usb"
+	set_wifi_led "$board:green:wifi"
+	;;
 tiny-ac)
 	set_wifi_led "$board:orange:wifi"
 	set_usb_led "$board:green:usb"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -212,6 +212,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
 		;;
+	tew-714tru|\
 	v11st-fe|\
 	wzr-agl300nh)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -403,6 +403,9 @@ ramips_board_detect() {
 	*"TEW-692GR")
 		name="tew-692gr"
 		;;
+	*"TEW-714TRU")
+		name="tew-714tru"
+		;;
 	*"UBNT-ERX")
 		name="ubnt-erx"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -118,6 +118,7 @@ platform_check_image() {
 	sl-r7205|\
 	tew-691gr|\
 	tew-692gr|\
+	tew-714tru|\
 	tiny-ac|\
 	ur-326n4g|\
 	ur-336un|\

--- a/target/linux/ramips/dts/TEW-714TRU.dts
+++ b/target/linux/ramips/dts/TEW-714TRU.dts
@@ -1,0 +1,122 @@
+/dts-v1/;
+
+#include "rt5350.dtsi"
+
+/ {
+	compatible = "TEW-714TRU", "ralink,rt5350-soc";
+	model = "TRENDnet TEW714TRU";
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "tew-714tru:red:usb";
+			gpios = <&gpio0 9 1>;
+		};
+
+		wifi {
+			label = "tew-714tru:green:wifi";
+			gpios = <&gpio0 13 1>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+                reset {
+                        label = "reset";
+                        gpios = <&gpio0 10 1>;
+                        linux,code = <0x198>;
+                };
+
+                wps {
+                        label = "wps";
+                        gpios = <&gpio0 0 1>;
+                        linux,code = <0x211>;
+                };
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		repeater {
+			gpio-export,name = "repeater_switch";
+			gpios = <&gpio0 7 0>;
+		};
+
+		wisp {
+			gpio-export,name = "wisp_switch";
+			gpios = <&gpio0 12 0>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80", "s25fl064k";
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x7b0000>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "jtag", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&esw {
+	mediatek,portmap = <0x1>;
+	mediatek,portdisable = <0x3e>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -418,6 +418,12 @@ define Device/sl-r7205
 endef
 TARGET_DEVICES += sl-r7205
 
+define Device/tew-714tru
+  DTS := TEW-714TRU
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  DEVICE_TITLE := TRENDnet TEW-714TRU
+endef
+TARGET_DEVICES += tew-714tru
 
 define Device/v22rw-2x2
   DTS := V22RW-2X2


### PR DESCRIPTION
![Image](https://www.trendnet.com/images/products/diagram/di_TEW-714TRU_1.jpg)
![Image](https://i.imgur.com/xaLNg7J.jpg)
![Image](https://i.imgur.com/0XMsY8L.jpg)
![Image](https://i.imgur.com/PADCgxT.jpg)
![Image](https://i.imgur.com/i9n7TGv.jpg)

# Factory MTD
```
Creating 7 MTD partitions on "raspi":
0x00000000-0x00800000 : "ALL"
0x00000000-0x00030000 : "Bootloader"
0x00030000-0x00040000 : "Config"
0x00040000-0x00050000 : "Factory"
0x00050000-0x001a555c : "Kernel"
mtd: partition "Kernel" doesn't end on an erase block -- force read-only
0x001a555c-0x01000000 : "RootFS"
mtd: partition "RootFS" extends beyond the end of device "raspi" -- size truncated to 0x65aaa4
mtd: partition "RootFS" doesn't start on an erase block boundary -- force read-only
0x00050000-0x01000000 : "Kernel_RootFS"
```

# GPIOs
```
[gpio0 ]	wps
[gpio9 ]	red led
[gpio10] 	reset
[gpio11:gpio12]	switch, 11=router, 01=repeater, 10 = wisp
[gpio13]	green led
	
unknown:
gpio7
gpio8
gpio11
gpio14
gpio17
gpio18
gpio19 
gpio20
gpio21
```


# Boot log:
```
U-Boot 1.1.3 (Apr 20 2015 - 13:25:55)

Board: RT5350F-OLinuXino DRAM:  32 MB
relocate_code Pointer at: 81fb4000
spi_wait_nsec: 42
spi device id: c2 20 17 c2 20 (2017c220)
find flash: MX25L6405D
raspi_read: from:30000 len:1000
.raspi_read: from:30000 len:1000
.=============================================================
RT5350F-OLinuXino UBoot Version: 4.0.0.0
--------------------------------------------------------------
ASIC 5350_MP (Port5<->None)
DRAM_CONF_FROM: Boot-Strapping
DRAM_TYPE: SDRAM
DRAM_SIZE: 256 Mbits
DRAM_WIDTH: 16 bits
DRAM_TOTAL_WIDTH: 16 bits
TOTAL_MEMORY_SIZE: 32 MBytes
Flash component: SPI Flash
Date:Apr 20 2015  Time:13:25:55
============================================
icache: sets:256, ways:4, linesz:32 ,total:32768
dcache: sets:128, ways:4, linesz:32 ,total:16384

 ##### The CPU freq = 360 MHZ ####
 estimate memory size =32 Mbytes

Please choose the operation:
   1: Load system code to SDRAM via TFTP.
   2: Load system code then write to Flash via TFTP.
   3: Boot system code via Flash (default).
   4: Entr boot command line interface.
   7: Load Boot Loader code then write to Flash via Serial.
   9: Load Boot Loader code then write to Flash via TFTP.

You choosed 1

 0
raspi_read: from:40028 len:6
.

1: System Load Linux to SDRAM via TFTP.
 Please Input new ones /or Ctrl-C to discard
        Input device IP (192.168.1.1) ==:192.168.1.1
        Input server IP (192.168.1.2) ==:192.168.1.2
        Input Linux Kernel filename (build.bin) ==:lede-ramips-rt305x-tew-714tru-initramfs-uImage.bin

 netboot_common, argc= 3

 NetTxPacket = 0x81FE64C0

 KSEG1ADDR(NetTxPacket) = 0xA1FE64C0

 NetLoop,call eth_halt !

 NetLoop,call eth_init !
Trying Eth0 (10/100-M)

 Waitting for RX_DMA_BUSY status Start... done


 Header Payload scatter function is Disable !!

 ETH_STATE_ACTIVE!!
Using Eth0 (10/100-M) device
TFTP from server 192.168.1.2; our IP address is 192.168.1.1
Filename 'lede-ramips-rt305x-tew-714tru-initramfs-uImage.bin'.

 TIMEOUT_COUNT=10,Load address: 0x80800000
Loading: checksum bad
checksum bad
checksum bad
checksum bad
Got ARP REPLY, set server/gtwy eth addr (00:0a:cd:23:5a:e8)
Got it
#################################################################
         ###################checksum bad
##############################################
         #########checksum bad
########################################################
         ##############################################################checksum bad
###
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #######################
done
Bytes transferred = 3111429 (2f7a05 hex)
NetBootFileXferSize= 002f7a05
raspi_read: from:30000 len:10000
.Erasing SPI Flash...
raspi_erase: offs:30000 len:10000
.
Writing to SPI Flash...
raspi_write: to:30000 len:10000
.
done
Automatic boot of image at addr 0x80800000 ...
## Booting image at 80800000 ...
   Image Name:   Linux Kernel Image
   Created:      2016-08-03  18:03:37 UTC
   Image Type:   MIPS Linux Kernel Image (lzma compressed)
   Data Size:    3111365 Bytes =  3 MB
   Load Address: 80000000
   Entry Point:  80000000
   Verifying Checksum ... OK
   Uncompressing Kernel Image ... OK
No initrd
## Transferring control to Linux (at address 80000000) ...
## Giving linux memsize in MB, 32

Starting kernel ...

[    0.000000] Linux version 4.4.15 (root@debian) (gcc version 5.4.0 (LEDE GCC 5.4.0 r1227) ) #8 Wed Aug 3 18:06:24 UTC 2016
[    0.000000] SoC Type: Ralink RT5350 id:1 rev:3
[    0.000000] bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 0001964c (MIPS 24KEc)
[    0.000000] MIPS: machine is TRENDnet TEW714TRU
[    0.000000] Determined physical RAM map:
[    0.000000]  memory: 02000000 @ 00000000 (usable)
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x0000000001ffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000001ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x0000000001ffffff]
[    0.000000] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 16kB, 4-way, VIPT, no aliases, linesize 32 bytes
[    0.000000] Built 1 zonelists in Zone order, mobility grouping on.  Total pages: 8128
[    0.000000] Kernel command line: console=ttyS0,57600 rootfstype=squashfs,jffs2
[    0.000000] PID hash table entries: 128 (order: -3, 512 bytes)
[    0.000000] Dentry cache hash table entries: 4096 (order: 2, 16384 bytes)
[    0.000000] Inode-cache hash table entries: 2048 (order: 1, 8192 bytes)
[    0.000000] Writing ErrCtl register=0000b2db
[    0.000000] Readback ErrCtl register=0000b2db
[    0.000000] Memory: 26636K/32768K available (2750K kernel code, 130K rwdata, 652K rodata, 2028K init, 191K bss, 6132K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS:256
[    0.000000] CPU Clock: 360MHz
[    0.000000] clocksource: systick: mask: 0xffff max_cycles: 0xffff, max_idle_ns: 583261500 ns
[    0.000000] systick: running - mult: 214748, shift: 32
[    0.000000] clocksource: MIPS: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 10618113593 ns
[    0.000016] sched_clock: 32 bits at 180MHz, resolution 5ns, wraps every 11930464253ns
[    0.015665] Calibrating delay loop... 239.61 BogoMIPS (lpj=1198080)
[    0.090873] pid_max: default: 32768 minimum: 301
[    0.100281] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.113353] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.136546] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.156408] pinctrl core: initialized pinctrl subsystem
[    0.168134] NET: Registered protocol family 16
[    0.183722] rt2880-pinmux pinctrl: invalid group "rgmii" for function "gpio"
[    0.197721] rt2880-pinmux pinctrl: invalid group "mdio" for function "gpio"
[    0.247089] rt2880_gpio 10000600.gpio: registering 22 gpios
[    0.258208] rt2880_gpio 10000600.gpio: registering 22 irq handlers
[    0.273394] clocksource: Switched to clocksource MIPS
[    0.286160] NET: Registered protocol family 2
[    0.296552] TCP established hash table entries: 1024 (order: 0, 4096 bytes)
[    0.310446] TCP bind hash table entries: 1024 (order: 0, 4096 bytes)
[    0.323026] TCP: Hash tables configured (established 1024 bind 1024)
[    0.335888] UDP hash table entries: 256 (order: 0, 4096 bytes)
[    0.347515] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes)
[    0.360548] NET: Registered protocol family 1
[    4.464217] rt-timer 10000100.timer: maximum frequency is 3662Hz
[    4.478110] futex hash table entries: 256 (order: -1, 3072 bytes)
[    4.490418] Crashlog allocated RAM at address 0x1f00000
[    4.537208] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    4.548847] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    4.575103] io scheduler noop registered
[    4.582789] io scheduler deadline registered (default)
[    4.593708] ralink-usb-phy usbphy: invalid resource
[    4.605012] gpio-export gpio_export: 2 gpio(s) exported
[    4.616034] Serial: 8250/16550 driver, 2 ports, IRQ sharing disabled
[    4.631046] console [ttyS0] disabled
[    4.638228] 10000c00.uartlite: ttyS0 at MMIO 0x10000c00 (irq = 20, base_baud = 2500000) is a Palmchip BK-3103
[    4.657951] console [ttyS0] enabled
[    4.657951] console [ttyS0] enabled
[    4.671727] bootconsole [early0] disabled
[    4.671727] bootconsole [early0] disabled
[    4.698818] spi spi0.0: force spi mode3
[    4.707506] m25p80 spi0.0: mx25l6405d (8192 Kbytes)
[    4.717419] 4 ofpart partitions found on MTD device spi0.0
[    4.728406] Creating 4 MTD partitions on "spi0.0":
[    4.738021] 0x000000000000-0x000000030000 : "u-boot"
[    4.751714] 0x000000030000-0x000000040000 : "u-boot-env"
[    4.766510] 0x000000040000-0x000000050000 : "factory"
[    4.780671] 0x000000050000-0x000000800000 : "firmware"
[    4.840897] rt3050-esw 10110000.esw: link changed 0x00
[    4.854547] mtk_soc_eth 10100000.ethernet eth0: mediatek frame engine at 0xb0100000, irq 5
[    4.872294] rt2880_wdt 10000120.watchdog: Initialized
[    4.885537] NET: Registered protocol family 10
[    4.903004] NET: Registered protocol family 17
[    4.912254] bridge: automatic filtering via arp/ip/ip6tables has been deprecated. Update your scripts to load br_netfilter if you need this.
[    4.937564] 8021q: 802.1Q VLAN Support v1.8
[    4.971641] Freeing unused kernel memory: 2028K (80375000 - 80570000)
[    5.010745] init: Console is alive
[    5.018243] init: - watchdog -
[    5.079757] usbcore: registered new interface driver usbfs
[    5.091138] usbcore: registered new interface driver hub
[    5.102120] usbcore: registered new device driver usb
[    5.143994] init: - preinit -
[    5.347770] rt3050-esw 10110000.esw: link changed 0x00
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    6.938289] rt3050-esw 10110000.esw: link changed 0x01
[    8.688823] procd: - early -
[    8.695009] procd: - watchdog -
[    9.297625] procd: - ubus -
[    9.354285] random: ubusd urandom read with 15 bits of entropy available
[    9.372273] procd: - init -
Please press Enter to activate this console.
[    9.682520] ip6_tables: (C) 2000-2006 Netfilter Core Team
[    9.722455] Loading modules backported from Linux version wt-2016-06-20-0-gbc17424
[    9.737710] Backport generated by backports.git backports-20160216-7-g5735958
[    9.760137] ip_tables: (C) 2000-2006 Netfilter Core Team
[    9.791199] nf_conntrack version 0.5.0 (447 buckets, 1788 max)
[    9.876266] xt_time: kernel timezone is -0000
[    9.994487] PPP generic driver version 2.4.2
[   10.008966] NET: Registered protocol family 24
[   10.069810] ieee80211 phy0: rt2x00_set_rt: Info - RT chipset 5350, rev 0500 detected
[   10.085447] ieee80211 phy0: rt2x00_set_rf: Info - RF chipset 5350 detected
[   15.121796] rt3050-esw 10110000.esw: link changed 0x00
[   16.744375] rt3050-esw 10110000.esw: link changed 0x01
[   21.933913] device eth0.1 entered promiscuous mode
[   21.943645] device eth0 entered promiscuous mode
[   22.026457] br-lan: port 1(eth0.1) entered forwarding state
[   22.037805] br-lan: port 1(eth0.1) entered forwarding state
[   22.160540] br-lan: port 2(eth0) entered forwarding state
[   22.171530] br-lan: port 2(eth0) entered forwarding state
[   24.033535] br-lan: port 1(eth0.1) entered forwarding state
[   24.163532] br-lan: port 2(eth0) entered forwarding state



BusyBox v1.24.2 () built-in shell (ash)

     _________
    /        /\      _    ___ ___  ___
   /  LE    /  \    | |  | __|   \| __|
  /    DE  /    \   | |__| _|| |) | _|
 /________/  LE  \  |____|___|___/|___|                      lede-project.org
 \        \   DE /
  \    LE  \    /  -----------------------------------------------------------
   \  DE    \  /    Reboot (HEAD, r1228)
    \________\/    -----------------------------------------------------------

root@lede:/# ifconfig
br-lan    Link encap:Ethernet  HWaddr 00:14:D1:FD:66:1B
          inet addr:192.168.1.1  Bcast:192.168.1.255  Mask:255.255.255.0
          inet6 addr: fd8b:eb69:bebe::1/60 Scope:Global
          inet6 addr: fe80::214:d1ff:fefd:661b/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:165 errors:0 dropped:0 overruns:0 frame:0
          TX packets:55 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:19577 (19.1 KiB)  TX bytes:6931 (6.7 KiB)

eth0      Link encap:Ethernet  HWaddr 00:14:D1:FD:66:1B
          inet6 addr: fe80::214:d1ff:fefd:661b/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:387 errors:0 dropped:8 overruns:0 frame:0
          TX packets:247 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:43969 (42.9 KiB)  TX bytes:34720 (33.9 KiB)
          Interrupt:5

eth0.1    Link encap:Ethernet  HWaddr 00:14:D1:FD:66:1B
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:153 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:0 (0.0 B)  TX bytes:20974 (20.4 KiB)

eth0.2    Link encap:Ethernet  HWaddr 00:14:D1:FD:66:1C
          inet6 addr: fe80::214:d1ff:fefd:661c/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:20 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:0 (0.0 B)  TX bytes:3636 (3.5 KiB)

lo        Link encap:Local Loopback
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:28 errors:0 dropped:0 overruns:0 frame:0
          TX packets:28 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1
          RX bytes:1988 (1.9 KiB)  TX bytes:1988 (1.9 KiB)

root@lede:/#
```