### PR TITLE
samba: bind to all interfaces in LAN firewall zone

### DIFF
--- a/package/network/services/samba36/files/samba.init
+++ b/package/network/services/samba36/files/samba.init
@@ -6,7 +6,7 @@ USE_PROCD=1
 
 smb_header() {
 	local interface
-	config_get interface $1 interface "loopback lan"
+	config_get interface $1 interface "loopback $(uci get firewall.@zone[0].network)"
 
 	# resolve interfaces
 	local interfaces=$(


### PR DESCRIPTION
Instead of binding to "lan" interface, bind to all interfaces in the LAN firewall zone.

Fixes samba when router is operating as a pseudobridge (as 'bind interfaces only' option will prevent the server from being accessible on the bridged subnet).

Signed-off-by: Conn O'Griofa <connogriofa@gmail.com>