### PR TITLE
hostapd: Allow RADIUS accounting without 802.1x

### DIFF
--- a/package/network/services/hostapd/files/netifd.sh
+++ b/package/network/services/hostapd/files/netifd.sh
@@ -186,7 +186,7 @@ hostapd_set_bss_options() {
 		wps_pushbutton wps_label ext_registrar wps_pbc_in_m1 \
 		wps_device_type wps_device_name wps_manufacturer wps_pin \
 		macfilter ssid wmm uapsd hidden short_preamble rsn_preauth \
-		iapp_interface eapol_version
+		iapp_interface eapol_version acct_server acct_secret acct_port
 
 	set_default isolate 0
 	set_default maxassoc 0
@@ -197,6 +197,7 @@ hostapd_set_bss_options() {
 	set_default wmm 1
 	set_default uapsd 1
 	set_default eapol_version 0
+	set_default acct_port 1813
 
 	append bss_conf "ctrl_interface=/var/run/hostapd"
 	if [ "$isolate" -gt 0 ]; then
@@ -219,6 +220,13 @@ hostapd_set_bss_options() {
 		[ -n "$wpa_group_rekey"  ] && append bss_conf "wpa_group_rekey=$wpa_group_rekey" "$N"
 		[ -n "$wpa_pair_rekey"   ] && append bss_conf "wpa_ptk_rekey=$wpa_pair_rekey"    "$N"
 		[ -n "$wpa_master_rekey" ] && append bss_conf "wpa_gmk_rekey=$wpa_master_rekey"  "$N"
+	}
+
+	[ -n "$acct_server" ] && {
+		append bss_conf "acct_server_addr=$acct_server" "$N"
+		append bss_conf "acct_server_port=$acct_port" "$N"
+		[ -n "$acct_secret" ] && \
+			append bss_conf "acct_server_shared_secret=$acct_secret" "$N"
 	}
 
 	case "$auth_type" in
@@ -250,7 +258,6 @@ hostapd_set_bss_options() {
 		eap)
 			json_get_vars \
 				auth_server auth_secret auth_port \
-				acct_server acct_secret acct_port \
 				dae_client dae_secret dae_port \
 				ownip \
 				eap_reauth_period dynamic_vlan \
@@ -263,7 +270,6 @@ hostapd_set_bss_options() {
 			[ -n "$auth_secret" ] || json_get_var auth_secret key
 
 			set_default auth_port 1812
-			set_default acct_port 1813
 			set_default dae_port 3799
 
 			set_default vlan_naming 1
@@ -271,13 +277,6 @@ hostapd_set_bss_options() {
 			append bss_conf "auth_server_addr=$auth_server" "$N"
 			append bss_conf "auth_server_port=$auth_port" "$N"
 			append bss_conf "auth_server_shared_secret=$auth_secret" "$N"
-
-			[ -n "$acct_server" ] && {
-				append bss_conf "acct_server_addr=$acct_server" "$N"
-				append bss_conf "acct_server_port=$acct_port" "$N"
-				[ -n "$acct_secret" ] && \
-					append bss_conf "acct_server_shared_secret=$acct_secret" "$N"
-			}
 
 			[ -n "$eap_reauth_period" ] && append bss_conf "eap_reauth_period=$eap_reauth_period" "$N"
 


### PR DESCRIPTION
RADIUS accounting can be used even when RADIUS authentication is not
used. Move the accounting configuration outside of the EAP-exclusive
sections.

Signed-off-by: Petko Bordjukov <bordjukov@gmail.com>