### PR TITLE
samba: add reload interface triggers

### DIFF
--- a/package/network/services/samba36/files/samba.init
+++ b/package/network/services/samba36/files/samba.init
@@ -5,16 +5,16 @@ START=60
 USE_PROCD=1
 
 smb_header() {
-	local interface
-	config_get interface $1 interface "loopback lan"
+	config_get samba_iface $1 interface "loopback lan"
 
 	# resolve interfaces
 	local interfaces=$(
 		. /lib/functions/network.sh
 
 		local net
-		for net in $interface; do
+		for net in $samba_iface; do
 			local device
+			network_is_up $net || continue
 			network_get_device device "$net" && {
 				local subnet
 				network_get_subnet  subnet "$net" && echo -n "$subnet "
@@ -93,14 +93,13 @@ init_config() {
 	config_foreach smb_add_share sambashare
 }
 
-reload_service() {
-	init_config
-
-	killall -HUP smbd
-}
-
 service_triggers() {
 	procd_add_reload_trigger samba
+
+	local i
+	for i in $samba_iface; do
+		procd_add_reload_interface_trigger $i
+	done
 }
 
 start_service() {
@@ -109,10 +108,12 @@ start_service() {
 	procd_open_instance
 	procd_set_param command /usr/sbin/smbd -F
 	procd_set_param respawn
+	procd_set_param file /var/etc/smb.conf
 	procd_close_instance
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/nmbd -F
 	procd_set_param respawn
+	procd_set_param file /var/etc/smb.conf
 	procd_close_instance
 }


### PR DESCRIPTION
Instead of manually binding to "lan":
* Bind to all interfaces defined in LAN firewall zone
* Skip interfaces which are not up during init_config
* Add network reload triggers for LAN zone interfaces (as not
  all interfaces may be up during first start of service)
* Stop using HUP signal for service reload (as smbd fails to
  honour new interface bindings upon config reload)

Without these changes, Samba fails to work correctly across
a bridged connection due to the 'bind interfaces only' option.

Signed-off-by: Conn O'Griofa <connogriofa@gmail.com>