### PR TITLE
base-files: add pkill function to profile

### DIFF
--- a/package/base-files/files/etc/profile
+++ b/package/base-files/files/etc/profile
@@ -22,6 +22,7 @@ alias ll='ls -alF --color=auto'
 
 [ -x /usr/bin/arp ] || arp() { cat /proc/net/arp; }
 [ -x /usr/bin/ldd ] || ldd() { LD_TRACE_LOADED_OBJECTS=1 $*; }
+[ -x /usr/bin/pkill ] || pkill() { pid=$(pidof "$1") && kill $pid; }
 
 [ -n "$FAILSAFE" ] || {
 	for FILE in /etc/profile.d/*.sh; do


### PR DESCRIPTION
This patch adds a simple pkill() function to /etc/profile if a full
procps version is not present.