### PR TITLE
[URFC] hostapd: Introduce FST support

### DIFF
--- a/package/network/services/hostapd/files/hostapd-full.config
+++ b/package/network/services/hostapd/files/hostapd-full.config
@@ -166,4 +166,10 @@ CONFIG_NO_DUMP_STATE=y
 CONFIG_WPS=y
 CONFIG_FULL_DYNAMIC_VLAN=y
 
+# Enable Fast Session Transfer (FST)
+CONFIG_FST=y
+
+# Enable CLI commands for FST testing
+CONFIG_FST_TEST=y
+
 CONFIG_UBUS=y

--- a/package/network/services/hostapd/files/netifd.sh
+++ b/package/network/services/hostapd/files/netifd.sh
@@ -57,6 +57,9 @@ hostapd_common_add_device_config() {
 	config_add_boolean country_ie doth
 	config_add_string require_mode
 
+	config_add_string fst_group_id
+	config_add_int fst_priority fst_llt
+
 	hostapd_add_log_config
 }
 
@@ -67,7 +70,9 @@ hostapd_prepare_device_config() {
 	local base="${config%%.conf}"
 	local base_cfg=
 
-	json_get_vars country country_ie beacon_int doth require_mode
+	json_get_vars \
+		country country_ie beacon_int doth require_mode \
+		fst_group_id fst_priority fst_llt
 
 	hostapd_set_log_options base_cfg
 
@@ -102,6 +107,12 @@ hostapd_prepare_device_config() {
 	[ -n "$rlist" ] && append base_cfg "supported_rates=$rlist" "$N"
 	[ -n "$brlist" ] && append base_cfg "basic_rates=$brlist" "$N"
 	[ -n "$beacon_int" ] && append base_cfg "beacon_int=$beacon_int" "$N"
+
+	[ -n "$fst_group_id"  ] && {
+		append base_cfg "fst_group_id=$fst_group_id" "$N"
+		[ -n "$fst_priority"  ] && append base_cfg "fst_priority=$fst_priority" "$N"
+		[ -n "$fst_llt"  ] && append base_cfg "fst_llt=$fst_llt" "$N"
+	}
 
 	cat > "$config" <<EOF
 driver=$driver


### PR DESCRIPTION
802.11ad Fast Session Transfer seems like a very interesting functionality. Has anybody tested it or does anybody know if it can be used in the typical LEDE configuration of separate PHYs with separate hostapd instances for the different bands?

Currently I get the following worrying log entries:

```
root@threemileisland:~# logread | grep FST
Fri Aug  5 18:18:05 2016 daemon.notice netifd: radio1 (3432): FST: lan: wlan1: Zero llt adjusted
Fri Aug  5 18:18:05 2016 daemon.notice netifd: radio1 (3432): FST: lan: wlan1: cannot add MB IE: no backup ifaces
Fri Aug  5 18:18:05 2016 daemon.notice netifd: radio1 (3432): FST: lan: wlan1: cannot create MB IE
Fri Aug  5 18:18:05 2016 daemon.notice netifd: radio1 (3432): FST-EVENT-IFACE attached ifname=wlan1 group=lan
Fri Aug  5 18:18:06 2016 daemon.notice netifd: radio0 (3431): FST: lan: wlan0: Zero llt adjusted
Fri Aug  5 18:18:06 2016 daemon.notice netifd: radio0 (3431): FST: lan: wlan0: cannot add MB IE: no backup ifaces
```

I've started a thread in the hostap mailing list in hope somebody could shed some light on the use cases their implementation has in mind.