### PR TITLE
[v2] hostapd: IAPP: Set SO_REUSEADDR on listening socket

### DIFF
--- a/package/network/services/hostapd/patches/150-iapp-set-so_reuseaddr-on-listening-socket.patch
+++ b/package/network/services/hostapd/patches/150-iapp-set-so_reuseaddr-on-listening-socket.patch
@@ -1,0 +1,48 @@
+From bc9aa4fe11b0d416f1d7f4f9406227e0409b38b4 Mon Sep 17 00:00:00 2001
+From: Petko Bordjukov <bordjukov@gmail.com>
+Date: Tue, 10 Nov 2015 20:17:13 +0200
+Subject: [PATCH v2] IAPP: Set SO_REUSEADDR on listening socket
+
+Make it possible for several instances of hostapd to listen on the same
+network interface.
+
+Signed-off-by: Petko Bordjukov <bordjukov@gmail.com>
+---
+
+Changes since v1:
+
+ * Fixed a mistake in the error message.
+ * Made the inability to set SO_REUSEADDR not fatal
+
+ src/ap/iapp.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/ap/iapp.c b/src/ap/iapp.c
+index 07672ce..3fd0951 100644
+--- a/src/ap/iapp.c
++++ b/src/ap/iapp.c
+@@ -381,6 +381,7 @@ struct iapp_data * iapp_init(struct hostapd_data *hapd, const char *iface)
+ 	struct sockaddr_in *paddr, uaddr;
+ 	struct iapp_data *iapp;
+ 	struct ip_mreqn mreq;
++	int reuseaddr = 1;
+ 
+ 	iapp = os_zalloc(sizeof(*iapp));
+ 	if (iapp == NULL)
+@@ -443,6 +444,13 @@ struct iapp_data * iapp_init(struct hostapd_data *hapd, const char *iface)
+ 	os_memset(&uaddr, 0, sizeof(uaddr));
+ 	uaddr.sin_family = AF_INET;
+ 	uaddr.sin_port = htons(IAPP_UDP_PORT);
++
++	if (setsockopt(iapp->udp_sock, SOL_SOCKET, SO_REUSEADDR, &reuseaddr,
++		       sizeof(reuseaddr)) < 0) {
++		wpa_printf(MSG_INFO, "iapp_init - setsockopt[UDP,SO_REUSEADDR]: %s",
++			   strerror(errno));
++	}
++
+ 	if (bind(iapp->udp_sock, (struct sockaddr *) &uaddr,
+ 		 sizeof(uaddr)) < 0) {
+ 		wpa_printf(MSG_INFO, "iapp_init - bind[UDP]: %s",
+-- 
+2.9.2
+


### PR DESCRIPTION
This patch makes it possible to use the Inter-Access Point Protocol
implementation of hostapd in one of the most common scenarios -- when
having more than one interface or BSS.

Upstream tracking: https://patchwork.ozlabs.org/patch/656818/

As a side note, the upstream patch comes as a follow-up to https://patchwork.ozlabs.org/patch/542556/, which wasn't merged because there were concerns about `SO_REUSE`*`PORT`*'s compatibility.