### PR TITLE
ramips:Add support for Thunder Timecloud

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -49,6 +49,7 @@ ramips_setup_interfaces()
 	microwrt|\
 	mpr-a2|\
 	ncs601w|\
+	timecloud|\
 	w150m|\
 	widora-neo|\
 	wnce2001|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -118,7 +118,8 @@ get_status_led() {
 	f5d8235-v2)
 		status_led="$board:blue:router"
 		;;
-	f7c027)
+	f7c027|\
+	timecloud)
 		status_led="$board:orange:status"
 		;;
 	hc5*61|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -403,6 +403,9 @@ ramips_board_detect() {
 	*"TEW-692GR")
 		name="tew-692gr"
 		;;
+	*"Timecloud")
+		name="timecloud"
+		;;
 	*"UBNT-ERX")
 		name="ubnt-erx"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -118,6 +118,7 @@ platform_check_image() {
 	sl-r7205|\
 	tew-691gr|\
 	tew-692gr|\
+	timecloud|\
 	tiny-ac|\
 	ur-326n4g|\
 	ur-336un|\

--- a/target/linux/ramips/dts/Timecloud.dts
+++ b/target/linux/ramips/dts/Timecloud.dts
@@ -1,0 +1,110 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+/ {
+	compatible = "mediatek,mt7621-eval-board", "mediatek,mt7621-soc";
+	model = "Thunder Timecloud";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		statw {
+			label = "timecloud:white:status";
+			gpios = <&gpio0 7 0>;
+		};
+
+		stato {
+			label = "timecloud:orange:status";
+			gpios = <&gpio0 8 0>;
+		};
+
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 1>;
+			linux,code = <0x198>;
+		};
+
+		BTN_0 {
+			label = "BTN_0";
+			gpios = <&gpio0 4 1>;
+			linux,code = <0x100>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdhci_pins>;
+};
+
+&xhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80";
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfb0000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uart2", "jtag";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -105,6 +105,13 @@ define Device/sap-g3200u3
 endef
 TARGET_DEVICES += sap-g3200u3
 
+define Device/timecloud
+  DTS := Timecloud
+  DEVICE_TITLE := Thunder Timecloud
+  DEVICE_PACKAGES := kmod-usb3
+endef
+TARGET_DEVICES += timecloud
+
 define Device/witi
   DTS := WITI
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
Thunder Timecloud is a small NAS with MT7621A.
It has 1 USB port and an SD Card slot.There is no wireless cards.

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>