### PR TITLE
target/toolchain: Fix toolchain packaging without package build

### DIFF
--- a/target/toolchain/Makefile
+++ b/target/toolchain/Makefile
@@ -58,6 +58,7 @@ $(BIN_DIR)/$(TOOLCHAIN_NAME).tar.bz2: clean
 	find $(TOOLCHAIN_BUILD_DIR) -name .git | $(XARGS) rm -rf
 	find $(TOOLCHAIN_BUILD_DIR) -name .svn | $(XARGS) rm -rf
 	find $(TOOLCHAIN_BUILD_DIR) -name CVS | $(XARGS) rm -rf
+	mkdir -p $(BIN_DIR)
 	(cd $(BUILD_DIR); \
 		tar cfj $@ $(TOOLCHAIN_NAME); \
 	)


### PR DESCRIPTION
If the toolchain is packaged for later use as external toolchain, the resulting
tarball is created in $BIN_DIR. But without building all packages first that
directory isn't created, hence 'make target/toolchain/compile' fails when
trying to create the toolchain tarball with error "Cannot open: No such file or
directory".

To fix that the $BIN_DIR is created before using it.

Signed-off-by: Micha Lenk <micha@lenk.info>