### PR TITLE
ar71xx:Fix profile name of Mercury MW4530R

### DIFF
--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -280,7 +280,7 @@ tplink_board_detect() {
 		model="TP-Link TL-WDR6500"
 		;;
 	"453000"*)
-		model="MERCURY MW4530R"
+		model="Mercury MW4530R"
 		;;
 	"934100"*)
 		model="NC-LINK SMART-300"

--- a/target/linux/ar71xx/image/tp-link.mk
+++ b/target/linux/ar71xx/image/tp-link.mk
@@ -145,7 +145,7 @@ endef
 
 define Device/mw4530r-v1
 $(Device/tl-wdr4300-v1)
-  DEVICE_TITLE := TP-LINK TL-WDR4530 v1
+  DEVICE_TITLE := Mercury MW4530R v1
   TPLINK_HWID := 0x45300001
 endef
 TARGET_DEVICES += tl-wdr3500-v1 tl-wdr3600-v1 tl-wdr4300-v1 tl-wdr4300-v1-il tl-wdr4310-v1 mw4530r-v1


### PR DESCRIPTION
 The mw4530r-v1 profile in tp-link.mk is for Mercury MW4530R.There is no such a device called TL-WDR4530. 
Also change MERCURY to Mercury in /lib/ar71xx.sh

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>