### PR TITLE
Ramips: Add support for Eylike SS aka HC5661 clone(MT7620A SOC)

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -171,6 +171,12 @@ hc5661)
 	ucidef_set_led_netdev "internet" "internet" "$board:blue:internet" "eth0.2"
 	set_wifi_led "$board:blue:wlan2g"
 	;;
+hc5661-v2)
+	ucidef_set_led_default "system" "system" "$board:blue:system" "1"
+	ucidef_set_led_netdev "internet" "internet" "$board:blue:internet" "eth0.2"
+	set_wifi_led "$board:blue:wlan2g"
+	set_usb_led "$board:blue:wlan5g"
+	;;
 hc5761)
 	ucidef_set_led_default "system" "system" "$board:blue:system" "1"
 	ucidef_set_led_netdev "internet" "internet" "$board:blue:internet" "eth0.2"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -187,6 +187,7 @@ ramips_setup_interfaces()
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
 	hc5*61|\
+	hc5661-v2)
 	y1s)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5:lan" "0:wan" "6@eth0"
@@ -307,6 +308,10 @@ ramips_setup_macs()
 		lan_mac=`mtd_get_mac_ascii bdinfo "Vfac_mac "`
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
+	hc5661-v2)
+		lan_mac=$(mtd_get_mac_ascii factory lanmac)
+		wan_mac=$(mtd_get_mac_ascii factory wanmac)
 		;;
 	linkits7688 | \
 	linkits7688d)

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -199,6 +199,9 @@ ramips_board_detect() {
 	*"HC5661")
 		name="hc5661"
 		;;
+	*"HC5661-v2")
+		name="hc5661-v2"
+		;;
 	*"HC5761")
 		name="hc5761"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -62,6 +62,7 @@ platform_check_image() {
 	gl-mt300n|\
 	gl-mt750|\
 	hc5*61|\
+	hc5661-v2|\
 	hg255d|\
 	hlk-rm04|\
 	hpm|\

--- a/target/linux/ramips/dts/HC5661-v2.dts
+++ b/target/linux/ramips/dts/HC5661-v2.dts
@@ -1,0 +1,32 @@
+/dts-v1/;
+
+#include "HC5XXX.dtsi"
+
+/ {
+	compatible = "HC5661-v2", "ralink,mt7620a-soc";
+	model = "Eylike HC5661-v2";
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		system {
+			label = "hc5661-v2:blue:system";
+			gpios = <&gpio0 9 1>;
+		};
+
+		internet {
+			label = "hc5661-v2:blue:internet";
+			gpios = <&gpio0 11 1>;
+		};
+
+		wlan2g {
+			label = "hc5661-v2:blue:wlan2g";
+			gpios = <&gpio3 0 1>;
+		};
+
+		wlan5g {
+			label = "hc5661-v2:blue:wlan5g";
+			gpios = <&gpio0 7 1>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -259,6 +259,14 @@ define Device/hc5661
 endef
 TARGET_DEVICES += hc5661
 
+define Device/hc5661-v2
+  DTS := HC5661-v2
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Eylike HC5661-v2
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci kmod-sdhci-mt7620 kmod-ledtrig-usbdev
+endef
+TARGET_DEVICES += hc5661-v2
+
 define Device/hc5761
   DTS := HC5761
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
With 16mb flash & 128MB ram and a 802.11b/g/n SoC 2.4 GHz radio
Board name is: Eylike HC5661-v2
Diffs:
1. MAC's are taken from factory partition as we dont have valid Vfac_mac
in our bdinfo partition.
2. Board has support for USB 2.0 and SD Card module(missing)

Signed-off-by: Demetris <ierokipides.dem@gmail.com>