### PR TITLE
dropbear: Add option to hide dropbear version

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -105,6 +105,14 @@ define Build/Configure
 	  mv $(PKG_BUILD_DIR)/options.h.new $(PKG_BUILD_DIR)/options.h || exit 1; \
 	done
 
+	# Force version number as UNKNOWN
+	awk 'BEGIN { rc = 1 } \
+	     /'define[[:space:]]DROPBEAR_VERSION'/ { $$$$3="\"\""; rc = 0 } \
+	     { print } \
+	     END { exit(rc) }' $(PKG_BUILD_DIR)/sysoptions.h \
+	     >$(PKG_BUILD_DIR)/sysoptions.h.new && \
+	mv $(PKG_BUILD_DIR)/sysoptions.h.new $(PKG_BUILD_DIR)/sysoptions.h || exit 1;
+
 	# Enforce rebuild of svr-chansession.c
 	rm -f $(PKG_BUILD_DIR)/svr-chansession.o
 endef


### PR DESCRIPTION
As security precaution and too limit the attack surface based on
the version reported by tools like nmap add a Makefile option
to hide the dropbear version being sent over the wire.

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>