### PR TITLE
config busybox/config: Add a meta-option to enable LXC support

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -23,6 +23,14 @@ menu "Global build settings"
 		bool "Cryptographically signed package lists"
 		default y
 
+	config LXC_HOST_SUPPORT
+		bool "Build with LXC host support"
+		default n
+		help
+		  Enable options required to act as an LXC host.
+		  NB: this is not required for building rootfs to
+		  be used as an LXC guest.
+
 	comment "General build options"
 
 	config DISPLAY_SUPPORT

--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -251,6 +251,7 @@ endif
 
 config KERNEL_CGROUPS
 	bool "Enable kernel cgroups"
+	default y if LXC_HOST_SUPPORT
 	default n
 
 if KERNEL_CGROUPS
@@ -478,6 +479,7 @@ endif
 
 config KERNEL_NAMESPACES
 	bool "Enable kernel namespaces"
+	default y if LXC_HOST_SUPPORT
 	default n
 
 if KERNEL_NAMESPACES
@@ -526,6 +528,7 @@ endif
 
 config KERNEL_LXC_MISC
 	bool "Enable miscellaneous LXC related options"
+	default y if LXC_HOST_SUPPORT
 	default n
 
 if KERNEL_LXC_MISC


### PR DESCRIPTION
Supporting lxc requires a number of configuration options;
add a meta option that selects all options required for lxc
support

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>