### PR TITLE
network/services/uhttpd: Add Basic Auth config

### DIFF
--- a/package/network/services/uhttpd/files/uhttpd.config
+++ b/package/network/services/uhttpd/files/uhttpd.config
@@ -103,6 +103,11 @@ config uhttpd main
 	# except for development and debug purposes!
 #	option no_ubusauth	0
 
+	# For this instance of uhttpd use the listed httpauth
+	# sections to require Basic auth to the specified
+	# resources.
+#	list httpauth prefix_user
+
 
 # Certificate defaults for px5g key generator
 config cert px5g
@@ -120,3 +125,8 @@ config cert px5g
 
 	# Common name
 	option commonname	'%D'
+
+# config httpauth prefix_user
+#	option prefix /protected/url/path
+#	option username user
+#	option password 'plaintext_or_md5_or_$p$user_for_system_user'

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -53,6 +53,21 @@ generate_keys() {
 	}
 }
 
+create_httpauth() {
+	local cfg="$1"
+	local prefix username password
+
+	config_get prefix "$cfg" prefix
+	config_get username "$cfg" username
+	config_get password "$cfg" password
+
+	if [ -z "$prefix" ] || [ -z "$username" ] || [ -z "$password" ]; then
+		return
+	fi
+	echo "${prefix}:${username}:${password}" >>$httpdconf
+	haveauth=1
+}
+
 start_instance()
 {
 	UHTTPD_CERT=""
@@ -60,12 +75,24 @@ start_instance()
 
 	local cfg="$1"
 	local realm="$(uci_get system.@system[0].hostname)"
-	local listen http https interpreter indexes path handler
+	local listen http https interpreter indexes path handler httpdconf haveauth
 
 	procd_open_instance
 	procd_set_param respawn
 	procd_set_param stderr 1
 	procd_set_param command "$UHTTPD_BIN" -f
+
+	config_get config "$cfg" config
+	if [ -z "$config" ]; then
+		mkdir -p /var/etc/uhttpd
+		httpdconf="/var/etc/uhttpd/httpd.${cfg}.conf"
+		rm -f ${httpdconf}
+		config_list_foreach "$cfg" httpauth create_httpauth
+		if [ "$haveauth" = "1" ]; then
+			procd_append_param command -c ${httpdconf}
+			[ -r /etc/httpd.conf ] && cat /etc/httpd.conf >>/var/etc/uhttpd/httpd.${cfg}.conf
+		fi
+	fi
 
 	append_arg "$cfg" home "-h"
 	append_arg "$cfg" realm "-r" "${realm:-OpenWrt}"


### PR DESCRIPTION
We add an 'httpauth' section type that contains the options:

prefix: What virtual or real URL is being protected
username: The username for the Basic Auth dialogue
password: Hashed (crypt()) or plaintext password for the Basic Auth dialogue

httpauth section names are given included as list
items to the instances to which they are to be applied.

Further any existing httpd.conf file (really whatever
is configured in the instane with a default of
/etc/httpd.conf) is appended to the per-instance httpd.conf

Signed-off-by: Daniel Dickinson lede@cshore.thecshore.com

This has been updated per comments on previous version of this PR and I have a corresponding LuCI patch.
This has been updated per comments on previous PR that was closed as I was away for a while.  I have a corresponding LuCI patch.
