### PR TITLE
tools/cmake: update to 3.6.1

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=3.5.2
+PKG_VERSION:=3.6.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://cmake.org/files/v3.5/ \
+PKG_SOURCE_URL:=https://cmake.org/files/v3.6/ \
 		https://fossies.org/linux/misc/
-PKG_MD5SUM:=701386a1b5ec95f8d1075ecf96383e02
+PKG_MD5SUM:=d6dd661380adacdb12f41b926ec99545
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1

--- a/tools/cmake/patches/100-disable_qt_tests.patch
+++ b/tools/cmake/patches/100-disable_qt_tests.patch
@@ -1,8 +1,8 @@
 --- a/Tests/RunCMake/CMakeLists.txt
 +++ b/Tests/RunCMake/CMakeLists.txt
-@@ -217,15 +217,6 @@ add_RunCMake_test(interface_library)
- add_RunCMake_test(no_install_prefix)
+@@ -219,15 +219,6 @@ add_RunCMake_test(no_install_prefix)
  add_RunCMake_test(configure_file)
+ add_RunCMake_test(CTestTimeoutAfterMatch)
  
 -find_package(Qt4 QUIET)
 -find_package(Qt5Core QUIET)
@@ -18,7 +18,7 @@
    add_RunCMake_test(FindPkgConfig)
 --- a/Tests/CMakeLists.txt
 +++ b/Tests/CMakeLists.txt
-@@ -389,10 +389,6 @@ if(BUILD_TESTING)
+@@ -392,10 +392,6 @@ if(BUILD_TESTING)
  
    list(APPEND TEST_BUILD_DIRS ${CMake_TEST_INSTALL_PREFIX})
  

--- a/tools/cmake/patches/110-freebsd-compat.patch
+++ b/tools/cmake/patches/110-freebsd-compat.patch
@@ -21,7 +21,7 @@ Change-Id: I3b91ed7ac0e6878035aee202b3336c536cc6d2ff
 
 --- a/Source/kwsys/SystemInformation.cxx
 +++ b/Source/kwsys/SystemInformation.cxx
-@@ -90,6 +90,15 @@ typedef int siginfo_t;
+@@ -89,6 +89,15 @@ typedef int siginfo_t;
  #  include <ifaddrs.h>
  #  define KWSYS_SYSTEMINFORMATION_IMPLEMENT_FQDN
  # endif


### PR DESCRIPTION
Update cmake from 3.5.2 to 3.6.1

Release notes:
* https://blog.kitware.com/cmake-3-6-1-available-for-download/
* https://blog.kitware.com/cmake-3-6-0-available-for-download/