### PR TITLE
fix building with glibc

### DIFF
--- a/package/boot/uboot-envtools/patches/400-u-boot-2015.10-stdint.patch
+++ b/package/boot/uboot-envtools/patches/400-u-boot-2015.10-stdint.patch
@@ -1,0 +1,13 @@
+diff -Naur u-boot-2015.10.orig/tools/env/fw_env.c u-boot-2015.10/tools/env/fw_env.c
+--- u-boot-2015.10.orig/tools/env/fw_env.c	2016-06-24 12:42:31.152391850 +0200
++++ u-boot-2015.10/tools/env/fw_env.c	2016-06-24 12:42:59.080391754 +0200
+@@ -21,7 +21,8 @@
+ #include <sys/types.h>
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+-#include <unistd.h>
++#include <unistd.h>
++#include <stdint.h>
+ 
+ #ifdef MTD_OLD
+ # include <stdint.h>

--- a/package/system/mtd/src/linksys_bootcount.c
+++ b/package/system/mtd/src/linksys_bootcount.c
@@ -28,6 +28,7 @@
 #include <endian.h>
 #include <string.h>
 #include <errno.h>
+#include <stdint.h>
 
 #include <sys/ioctl.h>
 #include <mtd/mtd-user.h>


### PR DESCRIPTION
There are a few occasions where stdint.h is not explictly included.
Apparently musl includes it by default, but glibc does not.

Signed-off-by: Josua Mayer <josua.mayer97@gmail.com>