### PR TITLE
fix kernel localversion for external kernel pulled with git

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -111,6 +111,7 @@ define Kernel/SetNoInitramfs
 endef
 
 define Kernel/Configure/Default
+	rm -f $(LINUX_DIR)/localversion
 	$(LINUX_CONF_CMD) > $(LINUX_DIR)/.config.target
 # copy CONFIG_KERNEL_* settings over to .config.target
 	awk '/^(#[[:space:]]+)?CONFIG_KERNEL/{sub("CONFIG_KERNEL_","CONFIG_");print}' $(TOPDIR)/.config >> $(LINUX_DIR)/.config.target

--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -33,6 +33,10 @@ ifdef CONFIG_USE_SPARSE
   KERNEL_MAKEOPTS += C=1 CHECK=$(STAGING_DIR_HOST)/bin/sparse
 endif
 
+ifneq ($(strip $(CONFIG_KERNEL_GIT_CLONE_URI)),"")
+ KERNEL_MAKEOPTS += LOCALVERSION=
+endif
+
 export HOST_EXTRACFLAGS=-I$(STAGING_DIR_HOST)/include
 
 # defined in quilt.mk


### PR DESCRIPTION
Kernel Makefiles introduce all sorts of localversion autogeneration.
However the lede build system always installes modules to /lib/modules/\<VERSION\>/ (e.g. 4.4.15).

This means a kernel built from a git repo is not able to load any modules, because the module loader will look in the wrong place (/lib/modules/$(uname -r)/)