### PR TITLE
Generate switch configuration for BTHOMEHUBV2B

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -122,6 +122,8 @@ BTHOMEHUBV2B|BTHOMEHUBV3A)
 	lan_mac=$(mtd_get_mac_ascii uboot_env ethaddr)
 	wan_mac=$(macaddr_add "$lan_mac" 1)
 	ucidef_set_interface_lan 'eth0'
+	ucidef_add_switch "switch0" \
+		"1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4" "5t@eth0"
 	;;
 
 BTHOMEHUBV5A)


### PR DESCRIPTION
For BT Homehub V2B, the file `/etc/board.json` is not populated with switch information, leading to a [crash in LuCI](https://github.com/openwrt/luci/issues/779) when trying to view Network->Switch.