### PR TITLE
ipq806x: Archer C2600: Renaming LED accordance with the standard

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -12,11 +12,11 @@ board=$(ipq806x_board_name)
 
 case "$board" in
 c2600)
-	ucidef_set_led_usbdev "usb1" "USB 1" "usb_2:blue" "2-1"
-	ucidef_set_led_usbdev "usb2" "USB 2" "usb_4:blue" "4-1"
-	ucidef_set_led_netdev "wan" "WAN" "wan:blue" "eth0"
-	ucidef_set_led_netdev "lan" "LAN" "lan:blue" "br-lan"
-	ucidef_set_led_default "general" "general" "ledgnr:blue" "1"
+	ucidef_set_led_usbdev "usb1" "USB 1" "${board}:blue:usb_2" "2-1"
+	ucidef_set_led_usbdev "usb2" "USB 2" "${board}:blue:usb_4" "4-1"
+	ucidef_set_led_netdev "wan" "WAN" "${board}:blue:wan" "eth0"
+	ucidef_set_led_netdev "lan" "LAN" "${board}:blue:lan" "br-lan"
+	ucidef_set_led_default "general" "general" "${board}:blue:ledgnr" "1"
 	;;
 d7800 |\
 r7500 |\

--- a/target/linux/ipq806x/base-files/etc/diag.sh
+++ b/target/linux/ipq806x/base-files/etc/diag.sh
@@ -6,7 +6,7 @@
 get_status_led() {
 	case $(ipq806x_board_name) in
 	c2600)
-		status_led="status:blue"
+		status_led="c2600:blue:status"
 		;;
 	ea8500)
 		status_led="ea8500:white:power"

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
@@ -376,35 +376,35 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "lan:blue";
+			label = "c2600:blue:lan";
 			gpios = <&qcom_pinmux 6 0>;
 		};
-                usb4 {
-			label = "usb_4:blue";
+		usb4 {
+			label = "c2600:blue:usb_4";
 			gpios = <&qcom_pinmux 7 0>;
 		};
-                usb2 {
-			label = "usb_2:blue";
+		usb2 {
+			label = "c2600:blue:usb_2";
 			gpios = <&qcom_pinmux 8 0>;
 		};
-                wps {
-			label = "wps:blue";
+		wps {
+			label = "c2600:blue:wps";
 			gpios = <&qcom_pinmux 9 0>;
 		};
-                wan_blue {
-			label = "wan:blue";
+		wan_blue {
+			label = "c2600:blue:wan";
 			gpios = <&qcom_pinmux 33 1>;
 		};
-                status {
-			label = "status:blue";
+		status {
+			label = "c2600:blue:status";
 			gpios = <&qcom_pinmux 53 0>;
 			default-state = "on";
 		};
-                ledgnr {
-			label = "ledgnr:blue";
+		ledgnr {
+			label = "c2600:blue:ledgnr";
 			gpios = <&qcom_pinmux 66 0>;
 		};
-        };
+	};
 };
 
 &adm_dma {


### PR DESCRIPTION
Signed-off-by: Cezary Jackiewicz <cezary.jackiewicz@gmail.com>