### PR TITLE
dropbear: mdns flag is a bool, not integer

### DIFF
--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -41,7 +41,7 @@ validate_section_dropbear()
 		'Port:list(port):22' \
 		'SSHKeepAlive:uinteger:300' \
 		'IdleTimeout:uinteger:0' \
-		'mdns:uinteger:1'
+		'mdns:bool:1'
 }
 
 dropbear_instance()


### PR DESCRIPTION
Effectively the same for most purposes, but more accurate.

Signed-off-by: Karl Palsson <karlp@etactica.com>