### PR TITLE
base-files: support oneshot leds properly.

### DIFF
--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -64,7 +64,7 @@ load_led() {
 			}
 			;;
 
-		"timer")
+		"timer"|"oneshot")
 			[ -n "$delayon" ] && \
 				echo $delayon > /sys/class/leds/${sysfs}/delay_on
 			[ -n "$delayoff" ] && \


### PR DESCRIPTION
oneshot trigger configurations for LEDs are created, but the on/off
timing configurations are ignored.  generate_config is correctly creating
oneshot configs, but the later led script doesn't recognise the trigger
details.

Fixes: c0c3f2d4c9178925f66f6df9fb0e4fcb370a8890
Signed-off-by: Karl Palsson <karlp@etactica.com>