### PR TITLE
openssl: enable asm opts in openssl for ipq806x

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -156,6 +156,8 @@ else
     OPENSSL_TARGET:=linux-mips-openwrt
 #  else ifeq ($(CONFIG_arm)$(CONFIG_armeb),y)
 #    OPENSSL_TARGET:=linux-armv4-openwrt
+  else ifneq ($(findstring cortex,$(CONFIG_CPU_TYPE)),)
+    OPENSSL_TARGET:=linux-armv4-openwrt
   else
     OPENSSL_TARGET:=linux-generic-openwrt
     OPENSSL_OPTIONS+=no-perlasm


### PR DESCRIPTION
As assembler optimisations are known to bring some issues on specific cpus, let's enable it for those boards that are ok with it.
These optimisations bring severe performance boost for ipq806x boards as neon fpu seem to thread crypto operations by itself this way.

Could those who have c2600 and ea8500 compare the performance boost as well, please.