### PR TITLE
Add config symbols for kernel keyring support

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -251,6 +251,25 @@ if KERNEL_DEVTMPFS
 
 endif
 
+config KERNEL_KEYS
+    bool "Enable kernel access key retention support"
+    default n
+
+config KERNEL_PERSISTENT_KEYRINGS
+    bool "Enable kernel persistent keyrings"
+    depends on KERNEL_KEYS
+    default n
+
+config KERNEL_BIG_KEYS
+    bool "Enable large payload keys on kernel keyrings"
+    depends on KERNEL_KEYS
+    default n
+
+config KERNEL_ENCRYPTED_KEYS
+    tristate "Enable keys with encrypted payloads on kernel keyrings"
+    depends on KERNEL_KEYS
+    default n
+
 #
 # CGROUP support symbols
 #


### PR DESCRIPTION
Enable selection of the kernel key retention framework and some of its
additional facilities; see Documentation/security/keys.txt and
security/keys/Kconfig for details

Signed-off-by: Nathaniel Wesley Filardo <nwfilardo@gmail.com>