### PR TITLE
dnsmasq: Don't report version number

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -137,6 +137,12 @@ MAKE_FLAGS := \
 	COPTS="$(COPTS)" \
 	PREFIX="/usr"
 
+define Build/Configure
+	# Report version number as UNKNOWN
+	echo UNKNOWN > $(PKG_BUILD_DIR)/VERSION.new && \
+	mv $(PKG_BUILD_DIR)/VERSION.new $(PKG_BUILD_DIR)/VERSION || exit 1;
+endef
+
 define Package/dnsmasq/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/dnsmasq $(1)/usr/sbin/


### PR DESCRIPTION
Don't expose the dnsmasq version number (e.g in response to name queries
for the domain version.bind) to limit the attack surface

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>