### PR TITLE
dnsmasq: Add match section support

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.76
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -351,6 +351,22 @@ dhcp_vendorclass_add() {
 	dhcp_option_add "$cfg" "$networkid" "$force"
 }
 
+dhcp_match_add() {
+	local cfg="$1"
+
+	config_get networkid "$cfg" networkid
+	[ -n "$networkid" ] || return 0
+
+	config_get match "$cfg" match
+	[ -n "$match" ] || return 0
+
+	xappend "--dhcp-match=$networkid,$match"
+
+	config_get_bool force "$cfg" force 0
+
+	dhcp_option_add "$cfg" "$networkid" "$force"
+}
+
 dhcp_host_add() {
 	local cfg="$1"
 
@@ -668,6 +684,7 @@ start_service() {
 	config_foreach dhcp_circuitid_add circuitid
 	config_foreach dhcp_remoteid_add remoteid
 	config_foreach dhcp_subscrid_add subscrid
+	config_foreach dhcp_match_add match
 	config_foreach dhcp_domain_add domain
 	config_foreach dhcp_hostrecord_add hostrecord
 	config_foreach dhcp_relay_add relay


### PR DESCRIPTION
Match sections allow to set a tag specified by the option networkid if the client
sends an option and optionally the option value specified by the match option.
The force option will convert the dhcp-option to force-dhcp-option if set to 1 in
the dnsmasq config if options are specified in the dhcp_option option.

config match
    option networkid tag
    option match 12,myhost
    option force 1
    list dhcp_option '3,192.168.1.1'

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>