### PR TITLE
gre: add "tap" to the prefix of GRE-TAP IPv4/6 tunnel interfaces.

### DIFF
--- a/package/network/config/gre/Makefile
+++ b/package/network/config/gre/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gre
 PKG_VERSION:=1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/config/gre/files/gre.sh
+++ b/package/network/config/gre/files/gre.sh
@@ -71,7 +71,14 @@ gre_setup() {
 
 	[ -z "$df" ] && df="1"
 
-	gre_generic_setup $cfg $mode $ipaddr $peeraddr "gre-$cfg"
+	case "$mode" in
+		gretapip)
+			gre_generic_setup $cfg $mode $ipaddr $peeraddr "gre4t-$cfg"
+			;;
+		*)
+			gre_generic_setup $cfg $mode $ipaddr $peeraddr "gre4-$cfg"
+			;;
+	esac
 }
 
 proto_gre_setup() {
@@ -89,7 +96,7 @@ proto_gretap_setup() {
 	gre_setup $cfg "gretapip"
 
 	json_init
-	json_add_string name "gre-$cfg"
+	json_add_string name "gre4t-$cfg"
 	json_add_boolean link-ext 0
 	json_close_object
 
@@ -129,7 +136,14 @@ grev6_setup() {
 		fi
 	}
 
-	gre_generic_setup $cfg $mode $ip6addr $peer6addr "grev6-$cfg"
+	case "$mode" in
+		gretapip6)
+			gre_generic_setup $cfg $mode $ip6addr $peer6addr "gre6t-$cfg"
+			;;
+		*)
+			gre_generic_setup $cfg $mode $ip6addr $peer6addr "gre6-$cfg"
+			;;
+	esac
 }
 
 proto_grev6_setup() {
@@ -147,7 +161,7 @@ proto_grev6tap_setup() {
 	grev6_setup $cfg "gretapip6"
 
 	json_init
-	json_add_string name "grev6-$cfg"
+	json_add_string name "gre6t-$cfg"
 	json_add_boolean link-ext 0
 	json_close_object
 
@@ -177,7 +191,7 @@ proto_gre_teardown() {
 proto_gretap_teardown() {
 	local cfg="$1"
 
-	gretap_generic_teardown "gre-$cfg"
+	gretap_generic_teardown "gre4t-$cfg"
 }
 
 proto_grev6_teardown() {
@@ -187,7 +201,7 @@ proto_grev6_teardown() {
 proto_grev6tap_teardown() {
 	local cfg="$1"
 
-	gretap_generic_teardown "grev6-$cfg"
+	gretap_generic_teardown "gre6t-$cfg"
 }
 
 gre_generic_init_config() {


### PR DESCRIPTION
This commit modifies the /lib/netifd/proto/gre.sh script so that, when
GRE-TAP tunnels are created, either IPv4 or IPv6, the prefix before the chosen
interface name contains the "tap" substring, to differentiate them from non-TAP
GRE tunnels.

Right now, both GRE and GRE-TAP tunnel (either IPv4 or IPv6) interfaces defined
in /etc/config/network are named "gre-"+$ifname upon creation. For instance,
the following tunnels:

```
    config interface 'tuna'
            option peeraddr '172.30.22.1'
            option proto 'gre'

    config interface 'tunb'
            option peeraddr '192.168.233.4'
            option proto 'gretap'

    config interface 'tunc'
            option peer6addr 'fdc5:7c9e:e93d:45af::1'
            option proto 'grev6'

    config interface 'tund'
            option peer6addr 'fdc0:6071:1348:31ff::2'
            option proto 'grev6tap'
```

are named, respectively, "gre-tuna", "gre-tunb", "grev6-tunc" and "grev6-tund".

The current change makes that each GRE tunnel interfaces of the four different
types available (gre, gretap, grev6 and grev6tap) gets the full protocol name.

This is coherent with other types of virtual interfaces (i.e. PPP, PPPoE, PPPoA)
where the whole protocol name is used. For instance, a PPPoA interface named
"p1" and a PPPoE interface named "p2" will respectively appear as "pppoa-pa"
and "pppoe-p2", not as "ppp-p1" and "ppp-p2").
