### PR TITLE
fix uimage creation for some kirkwood devices

### DIFF
--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -38,7 +38,6 @@ define Device/dockstar
   IMAGES += factory.bin
   IMAGE/factory.bin := append-ubi
   KERNEL_IN_UBI := 1
-  KERNEL := kernel-bin | append-dtb
 endef
 
 define Device/goflexnet


### PR DESCRIPTION
because with the current system I'm getting fake uImages that are actually a renamed zImage with appended dtb, and that's plain wrong.
This fixes bug https://bugs.lede-project.org/index.php?do=details&task_id=131 
and https://bugs.lede-project.org/index.php?do=details&task_id=139

signed off by Alberto Bursi <alberto.bursi@outlook.it>