### PR TITLE
dnsmasq: fix remove pidfile on shutdown regression

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -643,6 +643,7 @@ start_service() {
 	mkdir -p $(dirname $CONFIGFILE)
 	mkdir -p /var/lib/misc
 	touch /tmp/dhcp.leases
+	chown dnsmasq:dnsmasq /var/run/dnsmasq
 
 	[ -f "$TIMESTAMPFILE" ] && rm -f "$TIMESTAMPFILE"
 


### PR DESCRIPTION
Regression introduced by 3481d0d dnsmasq: run as dedicated UID/GID

dnsmasq is unable to remove its own pidfile as /var/run/dnsmasq is owned
by root and now dnsmasq runs as dnsmasq:dnsmasq.  Change directory
ownership to match.

dnsmasq initially starts as root, creates the pidfile, then drops to
requested non-root user.  Until this fix dnsmasq had insufficient
privilege to remove its own pidfile.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>