### PR TITLE
dnsmasq: Don't expose *.bind data incl version

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -112,7 +112,7 @@ Package/dnsmasq-full/conffiles = $(Package/dnsmasq/conffiles)
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections
 
-COPTS = $(if $(CONFIG_IPV6),,-DNO_IPV6)
+COPTS = -DNO_ID $(if $(CONFIG_IPV6),,-DNO_IPV6)
 
 ifeq ($(BUILD_VARIANT),nodhcpv6)
 	COPTS += -DNO_DHCP6

--- a/package/network/services/dnsmasq/patches/120-dnsmasq-compile-time-option-NO_ID.patch
+++ b/package/network/services/dnsmasq/patches/120-dnsmasq-compile-time-option-NO_ID.patch
@@ -1,0 +1,149 @@
+From f6bea86c78ba9efbd01da3dd2fb18764ec806290 Mon Sep 17 00:00:00 2001
+From: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
+Date: Wed, 7 Sep 2016 09:35:07 +0100
+Subject: [PATCH] dnsmasq: compile time option NO_ID
+
+Some consider it good practice to obscure software version numbers to
+clients.  Compiling with -DNO_ID removes the *.bind info structure.
+This includes: version, author, copyright, cachesize, cache insertions,
+evictions, misses & hits, auth & servers.
+
+Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
+---
+ src/cache.c   | 2 ++
+ src/config.h  | 5 +++++
+ src/dnsmasq.h | 4 ++++
+ src/option.c  | 8 ++++++--
+ src/rfc1035.c | 3 ++-
+ 5 files changed, 19 insertions(+), 3 deletions(-)
+
+--- a/src/cache.c
++++ b/src/cache.c
+@@ -1290,6 +1290,7 @@ void cache_add_dhcp_entry(char *host_nam
+ }
+ #endif
+ 
++#ifndef NO_ID
+ int cache_make_stat(struct txt_record *t)
+ { 
+   static char *buff = NULL;
+@@ -1385,6 +1386,7 @@ int cache_make_stat(struct txt_record *t
+   *buff = len;
+   return 1;
+ }
++#endif
+ 
+ /* There can be names in the cache containing control chars, don't 
+    mess up logging or open security holes. */
+--- a/src/config.h
++++ b/src/config.h
+@@ -120,6 +120,8 @@ HAVE_LOOP
+ HAVE_INOTIFY
+    use the Linux inotify facility to efficiently re-read configuration files.
+ 
++NO_ID
++   Don't report *.bind CHAOS info to clients.
+ NO_IPV6
+ NO_TFTP
+ NO_DHCP
+@@ -434,6 +436,9 @@ static char *compile_opts =
+ "no-"
+ #endif
+ "DNSSEC "
++#ifdef NO_ID
++"no-ID "
++#endif
+ #ifndef HAVE_LOOP
+ "no-"
+ #endif
+--- a/src/dnsmasq.h
++++ b/src/dnsmasq.h
+@@ -286,6 +286,7 @@ struct naptr {
+   struct naptr *next;
+ };
+ 
++#ifndef NO_ID
+ #define TXT_STAT_CACHESIZE     1
+ #define TXT_STAT_INSERTS       2
+ #define TXT_STAT_EVICTIONS     3
+@@ -293,6 +294,7 @@ struct naptr {
+ #define TXT_STAT_HITS          5
+ #define TXT_STAT_AUTH          6
+ #define TXT_STAT_SERVERS       7
++#endif
+ 
+ struct txt_record {
+   char *name;
+@@ -1078,7 +1080,9 @@ void cache_add_dhcp_entry(char *host_nam
+ struct in_addr a_record_from_hosts(char *name, time_t now);
+ void cache_unhash_dhcp(void);
+ void dump_cache(time_t now);
++#ifndef NO_ID
+ int cache_make_stat(struct txt_record *t);
++#endif
+ char *cache_get_name(struct crec *crecp);
+ char *cache_get_cname_target(struct crec *crecp);
+ struct crec *cache_enumerate(int init);
+--- a/src/option.c
++++ b/src/option.c
+@@ -657,7 +657,8 @@ static int atoi_check8(char *a, int *res
+   return 1;
+ }
+ #endif
+-	
++
++#ifndef NO_ID
+ static void add_txt(char *name, char *txt, int stat)
+ {
+   struct txt_record *r = opt_malloc(sizeof(struct txt_record));
+@@ -670,13 +671,14 @@ static void add_txt(char *name, char *tx
+       *(r->txt) = len;
+       memcpy((r->txt)+1, txt, len);
+     }
+-  
++
+   r->stat = stat;
+   r->name = opt_string_alloc(name);
+   r->next = daemon->txt;
+   daemon->txt = r;
+   r->class = C_CHAOS;
+ }
++#endif
+ 
+ static void do_usage(void)
+ {
+@@ -4515,6 +4517,7 @@ void read_opts(int argc, char **argv, ch
+   daemon->soa_expiry = SOA_EXPIRY;
+   daemon->max_port = MAX_PORT;
+ 
++#ifndef NO_ID
+   add_txt("version.bind", "dnsmasq-" VERSION, 0 );
+   add_txt("authors.bind", "Simon Kelley", 0);
+   add_txt("copyright.bind", COPYRIGHT, 0);
+@@ -4527,6 +4530,7 @@ void read_opts(int argc, char **argv, ch
+   add_txt("auth.bind", NULL, TXT_STAT_AUTH);
+ #endif
+   add_txt("servers.bind", NULL, TXT_STAT_SERVERS);
++#endif
+ 
+   while (1) 
+     {
+--- a/src/rfc1035.c
++++ b/src/rfc1035.c
+@@ -1264,6 +1264,7 @@ size_t answer_request(struct dns_header
+ 		      unsigned long ttl = daemon->local_ttl;
+ 		      int ok = 1;
+ 		      log_query(F_CONFIG | F_RRNAME, name, NULL, "<TXT>");
++#ifndef NO_ID
+ 		      /* Dynamically generate stat record */
+ 		      if (t->stat != 0)
+ 			{
+@@ -1271,7 +1272,7 @@ size_t answer_request(struct dns_header
+ 			  if (!cache_make_stat(t))
+ 			    ok = 0;
+ 			}
+-		      
++#endif
+ 		      if (ok && add_resource_record(header, limit, &trunc, nameoffset, &ansp, 
+ 						    ttl, NULL,
+ 						    T_TXT, t->class, "t", t->len, t->txt))


### PR DESCRIPTION
Don't expose dnsmasq version & other data to clients via the *.bind
pseudo domain.  This uses a new 'NO_ID' compile time option which has been
discussed and submitted upstream.

This is an alternate to replacing version with 'unknown' which affects
the version reported to syslog and 'dnsmasq --version'

Run time tested with & without NO_ID on Archer C7 v2

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>