### PR TITLE
dropbear: hide dropbear version

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -105,6 +105,10 @@ define Build/Configure
 	  mv $(PKG_BUILD_DIR)/options.h.new $(PKG_BUILD_DIR)/options.h || exit 1; \
 	done
 
+	# remove protocol idented software version number
+	$(SED) 's,^#define LOCAL_IDENT .*$$$$,#define LOCAL_IDENT "SSH-2.0-dropbear_",g' \
+		$(PKG_BUILD_DIR)/sysoptions.h
+
 	# Enforce rebuild of svr-chansession.c
 	rm -f $(PKG_BUILD_DIR)/svr-chansession.o
 endef


### PR DESCRIPTION
As security precaution and to limit the attack surface based on
the version reported by tools like nmap mask out the dropbear
version so the version is not visible anymore by snooping on the
wire. Version is still visible by 'dropbear -V'

Based on a patch by Hans Dedecker <dedeckeh@gmail.com>

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>