### PR TITLE
add support for Zyxel NBG-419N2 (WAP3205v2)

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -234,6 +234,10 @@ mzk-ex750np)
 na930)
 	set_usb_led "$board:blue:status"
 	;;
+nbg-419n2)
+	set_usb_led "$board:green:usb"
+	set_wifi_led "rt2800pci-phy0::radio"
+	;;
 newifi-d1)
 	set_usb_led "$board:red:status"
 	;;

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -27,6 +27,7 @@ get_status_led() {
 	mzk-dp150n|\
 	mzk-w300nh2|\
 	nbg-419n|\
+	nbg-419n2|\
 	pwh2004|\
 	wnce2001|\
 	wndr3700v5|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -325,6 +325,9 @@ ramips_board_detect() {
 	*"NBG-419N")
 		name="nbg-419n"
 		;;
+	*"NBG-419N v2")
+		name="nbg-419n2"
+		;;
 	*"Newifi-D1")
 		name="newifi-d1"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -96,6 +96,7 @@ platform_check_image() {
 	mzk-w300nh2|\
 	mzk-wdpr|\
 	nbg-419n|\
+	nbg-419n2|\
 	newifi-d1|\
 	nixcore|\
 	nw718|\

--- a/target/linux/ramips/dts/NBG-419N2.dts
+++ b/target/linux/ramips/dts/NBG-419N2.dts
@@ -1,0 +1,117 @@
+/dts-v1/;
+
+#include "rt3352.dtsi"
+
+/ {
+	compatible = "NBG-419N2", "ralink,rt3352-soc";
+	model = "ZyXEL NBG-419N v2";
+
+	palmbus@10000000 {
+		spi@b00 {
+			status = "okay";
+			m25p80@0 {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				compatible = "mx25l6405d";
+				reg = <0 0>;
+				linux,modalias = "m25p80", "mx25l6405d";
+				spi-max-frequency = <10000000>;
+
+				partition@0 {
+					label = "u-boot";
+					reg = <0x0 0x30000>;
+					read-only;
+				};
+
+				partition@30000 {
+					label = "u-boot-env";
+					reg = <0x30000 0x10000>;
+					read-only;
+				};
+
+				factory: partition@40000 {
+					label = "factory";
+					reg = <0x40000 0x10000>;
+					read-only;
+				};
+
+				partition@50000 {
+					label = "firmware";
+					reg = <0x50000 0x7b0000>;
+				};
+			};
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "nbg-419n2:green:power";
+			gpios = <&gpio0 9 1>;
+		};
+
+		wps {
+			label = "nbg-419n2:green:wps";
+			gpios = <&gpio0 14 1>;
+		};
+
+		usb {
+			label = "nbg-419n2:green:usb";
+			gpios = <&gpio0 13 1>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+		reset {
+			label = "reset";
+			gpios = <&gpio0 10 1>;
+			linux,code = <0x198>;
+		};
+		wps {
+			label = "wps";
+			gpios = <&gpio0 0 1>;
+			linux,code = <0x211>;
+		};
+		rfkill {
+			label = "rfkill";
+			linux,input-type = <5>;
+			gpios = <&gpio0 12 0>;
+			linux,code = <0xf7>;
+		};
+	};
+
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "jtag", "rgmii", "mdio", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&esw {
+	ralink,portmap = <0x2f>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -286,6 +286,14 @@ endef
 TARGET_DEVICES += nbg-419n
 
 
+define Device/nbg-419n2
+  DTS := NBG-419N2
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  DEVICE_TITLE := ZyXEL NBG-419N2
+endef
+TARGET_DEVICES += nbg-419n2
+
+
 define Device/mzk-wdpr
   DTS := MZK-WDPR
   DEVICE_TITLE := Planex MZK-WDPR


### PR DESCRIPTION
applied bb-final-ramips-add-zyxel-nbg-419n2.patch from
123serge123, found at https://yadi.sk/d/1ZV0lKJwbTE65;
see https://forum.openwrt.org/viewtopic.php?pid=246905#p246905,
modified slightly to fit to CC release and to new lede build
system: image/rt305x.mk include file is used now