### PR TITLE
fortify-headers: update to 0.8

### DIFF
--- a/toolchain/fortify-headers/Makefile
+++ b/toolchain/fortify-headers/Makefile
@@ -8,12 +8,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=fortify-headers
-PKG_VERSION:=0.7
+PKG_VERSION:=0.8
 PKG_RELEASE=1
 
 PKG_SOURCE_URL:=http://dl.2f30.org/releases
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=3f7c36daa0be000987e8ad8c0a202b42
+PKG_MD5SUM:=678ebdac0c3278b934c6524cd1e3dc4c
 
 include $(INCLUDE_DIR)/toolchain-build.mk
 


### PR DESCRIPTION
compile & run tested Archer C7 v2 ar71xx MIPS 74Kc

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>