### PR TITLE
uml: basic target fixes

### DIFF
--- a/target/linux/uml/Makefile
+++ b/target/linux/uml/Makefile
@@ -35,7 +35,7 @@ endef
 
 LINUX_TARGET_CONFIG:=$(CURDIR)/config/$(ARCH)
 
-DEFAULT_PACKAGES += wpad-mini kmod-mac80211-hwsim
+DEFAULT_PACKAGES += wpad-mini 
 
 endif
 

--- a/target/linux/uml/base-files/etc/inittab
+++ b/target/linux/uml/base-files/etc/inittab
@@ -1,0 +1,4 @@
+# Copyright (c) 2013 The Linux Foundation. All rights reserved.
+::sysinit:/etc/init.d/rcS S boot
+::shutdown:/etc/init.d/rcS K shutdown
+tty0::askfirst:/usr/libexec/login.sh


### PR DESCRIPTION
Target is not generating working image.
Booting crashes with kernel panic, and console access is not enabled.