### PR TITLE
ramips: Add support for ZBT-CPE102

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -318,6 +318,9 @@ zbt-ape522ii)
 	ucidef_set_led_netdev "sys1" "wlan1" "$board:green:sys1" "wlan1" "tx rx"
 	ucidef_set_led_netdev "sys2" "wlan0" "$board:green:sys2" "wlan0" "tx rx"
 	;;
+zbt-cpe102)
+	ucidef_set_led_default "power" "power" "$board:green:4g-0" "0"
+	;;
 zbt-wa05)
 	ucidef_set_led_default "power" "power" "$board:blue:power" "1"
 	set_wifi_led "$board:blue:air"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -53,6 +53,7 @@ ramips_setup_interfaces()
 	w150m|\
 	widora-neo|\
 	wnce2001|\
+	zbt-cpe102|\
 	zte-q7)
 		ucidef_add_switch "switch0"
 		ucidef_add_switch_attr "switch0" "enable" "false"

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -208,6 +208,9 @@ get_status_led() {
 	wrtnode)
 		status_led="wrtnode:blue:indicator"
 		;;
+	zbt-cpe102)
+		status_led="$board:green:4g-0"
+		;;
 	esac
 }
 

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -541,6 +541,9 @@ ramips_board_detect() {
 	*"ZBT-APE522II")
 		name="zbt-ape522ii"
 		;;
+	*"ZBT-CPE102")
+		name="zbt-cpe102"
+		;;
 	*"ZBT-WA05")
 		name="zbt-wa05"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -160,6 +160,7 @@ platform_check_image() {
 	y1|\
 	y1s|\
 	zbt-ape522ii|\
+	zbt-cpe102|\
 	zbt-wa05|\
 	zbt-we826|\
 	zbt-wg2626|\

--- a/target/linux/ramips/dts/ZBT-CPE102.dts
+++ b/target/linux/ramips/dts/ZBT-CPE102.dts
@@ -1,0 +1,118 @@
+/dts-v1/;
+
+#include "mt7620n.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-cpe102", "ralink,mt7620n-soc";
+	model = "Zbtlink ZBT-CPE102";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		4g-0 {
+			label = "zbt-cpe102:green:4g-0";
+			gpios = <&gpio1 14 1>;
+		};
+
+		4g-1 {
+			label = "zbt-cpe102:green:4g-1";
+			gpios = <&gpio0 2 1>;
+		};
+
+		4g-2 {
+			label = "zbt-cpe102:green:4g-2";
+			gpios = <&gpio1 15 1>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 1>;
+			linux,code = <0x198>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	en25q64@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80";
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x760000>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+	mediatek,portmap = "wllll";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "i2c", "spi refclk", "wled";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -358,6 +358,13 @@ define Device/zbt-ape522ii
 endef
 TARGET_DEVICES += zbt-ape522ii
 
+define Device/zbt-cpe102
+  DTS := ZBT-CPE102
+  DEVICE_TITLE := Zbtlink ZBT-CPE102
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += zbt-cpe102
+
 define Device/zbt-wa05
   DTS := ZBT-WA05
   DEVICE_TITLE := Zbtlink ZBT-WA05


### PR DESCRIPTION
- CPU: MT7620N 580MHz
- Flash: 8MB
- RAM: 64MB
- build-in minipcie slot for modem 3G/4G
- one ethernet port 10/100Mbps

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>