### PR TITLE
ramips: Add support for Phicomm K2 PSG1218

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -256,6 +256,9 @@ pbr-m1)
 psg1208)
 	set_wifi_led "$board:white:wlan2g"
 	;;
+psg1218)
+        set_wifi_led "$board:white:wlan2g"
+        ;;
 px-4885)
 	set_wifi_led "$board:orange:wifi"
 	set_usb_led "$board:blue:storage"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -84,6 +84,7 @@ ramips_setup_interfaces()
 	oy-0001|\
 	pbr-m1|\
 	psg1208|\
+        psg1218|\
 	sap-g3200u3|\
 	sk-wb8|\
 	wf-2881|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -93,6 +93,9 @@ get_status_led() {
 	psg1208)
 		status_led="$board:white:wps"
 		;;
+        psg1218)
+                status_led="$board:white:wps"
+                ;;
 	cy-swr1100|\
 	w502u)
 		status_led="$board:blue:wps"

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -349,6 +349,9 @@ ramips_board_detect() {
 	*"PSG1208")
 		name="psg1208"
 		;;
+        *"PSG1218")
+                name="psg1218"
+                ;;
 	*"PSR-680W"*)
 		name="psr-680w"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -103,6 +103,7 @@ platform_check_image() {
 	pbr-d1|\
 	pbr-m1|\
 	psg1208|\
+        psg1218|\
 	psr-680w|\
 	px-4885|\
 	re6500|\

--- a/target/linux/ramips/dts/PSG1218.dts
+++ b/target/linux/ramips/dts/PSG1218.dts
@@ -1,0 +1,121 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+/ {
+	compatible = "PSG1218", "ralink,mt7620a-soc";
+	model = "Phicomm PSG1218";
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		red {
+			label = "phicomm:red:status";
+			gpios = <&gpio0 8 1>;
+		};
+
+		blue {
+			label = "phicomm:blue:status";
+			gpios = <&gpio0 10 0>;
+		};
+
+		yellow {
+			label = "phicomm:yellow:status";
+			gpios = <&gpio0 11 0>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 1>;
+			linux,code = <0x198>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80", "en25q64";
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@30000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "firmware";
+			reg = <0x50000 0x7b0000>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uartf", "rgmii1", "rgmii2", "ephy", "wled", "nd_sd";
+			ralink,function = "gpio";
+		};
+		pa {
+			ralink,group = "pa";
+			ralink,function = "pa";
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&ephy_pins>;
+	mtd-mac-address = <&factory 0x28>;
+	mediatek,portmap = "llllw";
+};
+
+&pcie {
+	status = "okay";
+
+	pcie-bridge {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			mediatek,2ghz = <0>;
+		};
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -259,6 +259,13 @@ define Device/psg1208
 endef
 TARGET_DEVICES += psg1208
 
+define Device/psg1218
+  DTS := PSG1218
+  DEVICE_TITLE := Phicomm PSG1218
+  DEVICE_PACKAGES := kmod-mt76
+endef
+TARGET_DEVICES += psg1218
+
 define Device/y1
   DTS := Y1
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
 - CPU: MT7620A 580MHz
 - Flash: 8MB
 - RAM: 64MB
 - External PA+LNA on both WLAN2.4 and WLAN5
 - one ethernet port 10/100Mbps

Signed-off-by: Biercenter <xuefulin@gmail.com>