### PR TITLE
ramips: Xiaomi MiWiFi Nano: fix status led

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -206,8 +206,7 @@ miniembplug)
 	set_wifi_led "$board:red:wlan"
 	set_usb_led "$board:green:mobile"
 	;;
-miwifi-mini|\
-miwifi-nano)
+miwifi-mini)
 	ucidef_set_led_default "power" "power" "$board:red:status" "1"
 	;;
 miwifi-nano)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -143,6 +143,7 @@ get_status_led() {
 		status_led="$board:blue:status"
 		;;
 	miwifi-mini|\
+	miwifi-nano|\
 	zte-q7)
 		status_led="$board:red:status"
 		;;


### PR DESCRIPTION
- add status led for Xiaomi MiWiFi Nano
- revert https://github.com/lede-project/source/commit/af1e70b4a730e91ce1668d506ebc5c1c8cf5abf5 , this should not be added.

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>