### PR TITLE
utils/busybox: Add mkfs/fsck commands (scripts)

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -116,6 +116,9 @@ define Package/busybox/install
 	$(INSTALL_BIN) ./files/sysntpd $(1)/etc/init.d/sysntpd
 	$(INSTALL_BIN) ./files/ntpd-hotplug $(1)/usr/sbin/ntpd-hotplug
 	-rm -rf $(1)/lib64
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) ./files/mkfs $(1)/sbin/mkfs
+	ln -sf mkfs $(1)/sbin/fsck
 endef
 
 $(eval $(call BuildPackage,busybox))

--- a/package/utils/busybox/files/mkfs
+++ b/package/utils/busybox/files/mkfs
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -x
+
+. /lib/functions.sh
+
+parameters=
+fstype=
+skiplast=false
+numargs=$#
+i=0
+
+val="$1"
+
+if [ "$numargs" -lt 1 ]; then
+	echo "Usage: $0 [options ] [-t fstype] device"
+	exit 1
+fi
+
+for i in $(seq 1 ${numargs}); do
+	if [ "$i" -eq "${numargs}" ] && [ "$skiplast" = "true" ]; then
+		break
+	fi
+	val="$1"
+	shift 2>/dev/null
+	if [ "$val" = "-t" ]; then
+		fstype="$1"
+		skiplast=true
+		shift
+	else
+		append parameters "'$val'"
+	fi
+done
+
+if [ -n "$fstype" ]; then
+	eval mkfs.$fstype $parameters
+else
+	eval mkfs.ext4 $parameters
+fi


### PR DESCRIPTION
Some packages depend on the mkfs -t fstype or fsck -t fstype
command, but they aren't included in busybox.  Add trivial
wrapper that allow these commands to work.

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>