### PR TITLE
linux/modules/fs: Fix missing vfat dependencies

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -426,7 +426,7 @@ define KernelPackage/fs-vfat
 	$(LINUX_DIR)/fs/fat/fat.ko \
 	$(LINUX_DIR)/fs/fat/vfat.ko
   AUTOLOAD:=$(call AutoLoad,30,fat vfat)
-  $(call AddDepends/nls)
+  $(call AddDepends/nls,cp437 iso8859-1 utf8)
 endef
 
 define KernelPackage/fs-vfat/description


### PR DESCRIPTION
vfat filesystem fails to mount without cp437 and iso8859-1 nls modules,
therefore make these required dependencies for vfat kernel module.

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>