### PR TITLE
lantiq: Fix buttons for ARV752DPW

### DIFF
--- a/target/linux/lantiq/dts/ARV752DPW.dts
+++ b/target/linux/lantiq/dts/ARV752DPW.dts
@@ -1,6 +1,9 @@
 /dts-v1/;
 
-/include/ "danube.dtsi"
+#include "danube.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
 
 / {
 	model = "ARV752DPW - Arcor 802";
@@ -25,7 +28,7 @@
 	sram@1F000000 {
 		vmmc@107000 {
 			status = "okay";
-			gpios = <&gpiomm 1 0>;
+			gpios = <&gpiomm 1 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
@@ -127,7 +130,7 @@
 
 		ifxhcd@E101000 {
 			status = "okay";
-			gpios = <&gpiomm 0 0>;
+			gpios = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
 		};
 
 		etop@E180000 {
@@ -138,7 +141,7 @@
 		pci@E105400 {
 			status = "okay";
 			lantiq,external-clock;
-			gpio-reset = <&gpio 21 0>;
+			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 			interrupt-map = <0x7000 0 0 1 &icu0 135>;
 			req-mask = <0x3>;
 		};
@@ -158,23 +161,23 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio 11 1>;
-			linux,code = <0x211>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
 		};
 		restart {
 			label = "restart";
-			gpios = <&gpio 12 1>;
-			linux,code = <0x100>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
 		};
 		dsl {
 			label = "dsl";
-			gpios = <&gpio 13 1>;
-			linux,code = <0x101>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
 		};
 		reset {
 			label = "reset";
-			gpios = <&gpio 30 1>;
-			linux,code = <0x198>;
+			gpios = <&gpio 30 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
 		};
 	};
 
@@ -182,52 +185,52 @@
 		compatible = "gpio-leds";
 		power_blue: power1 {
 			label = "arv752dpw:blue:power";
-			gpios = <&gpio 3 1>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
 		internet_red: internet {
 			label = "arv752dpw:red:internet";
-			gpios = <&gpio 4 1>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 		};
 		message {
 			label = "arv752dpw:red:message";
-			gpios = <&gpio 5 1>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
 		};
 		power_red: power {
 			label = "arv752dpw:red:power";
-			gpios = <&gpio 6 1>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
 			default-state = "keep";
 		};
 		voice1 {
 			label = "arv752dpw:red:voice";
-			gpios = <&gpio 8 1>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 		};
 		microphone {
 			label = "arv752dpw:red:umts";
-			gpios = <&gpiomm 3 1>;
+			gpios = <&gpiomm 3 GPIO_ACTIVE_LOW>;
 		};
 		wifi: wifi {
 			label = "arv752dpw:red:wifi";
-			gpios = <&gpiomm 4 1>;
+			gpios = <&gpiomm 4 GPIO_ACTIVE_LOW>;
 		};
 		fxs1 {
 			label = "arv752dpw:green:tae-n";
-			gpios = <&gpiomm 5 1>;
+			gpios = <&gpiomm 5 GPIO_ACTIVE_LOW>;
 		};
 		fxs2 {
 			label = "arv752dpw:green:tae-u";
-			gpios = <&gpiomm 6 1>;
+			gpios = <&gpiomm 6 GPIO_ACTIVE_LOW>;
 		};
 		fxo {
 			label = "arv752dpw:green:isdn";
-			gpios = <&gpiomm 7 1>;
+			gpios = <&gpiomm 7 GPIO_ACTIVE_LOW>;
 		};
 		internet2 {
 			label = "arv752dpw:blue:internet";
-			gpios = <&gpiomm 8 1>;
+			gpios = <&gpiomm 8 GPIO_ACTIVE_LOW>;
 		};
 		voice2 {
 			label = "arv752dpw:blue:voice";
-			gpios = <&gpiomm 9 1>;
+			gpios = <&gpiomm 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/lantiq/dts/ARV752DPW.dts
+++ b/target/linux/lantiq/dts/ARV752DPW.dts
@@ -156,24 +156,24 @@
 		#size-cells = <0>;
 		poll-interval = <100>;
 
-		/* wps {
+		wps {
 			label = "wps";
 			gpios = <&gpio 11 1>;
 			linux,code = <0x211>;
-		}; */
+		};
 		restart {
 			label = "restart";
 			gpios = <&gpio 12 1>;
-			linux,code = <0x110>;
+			linux,code = <0x100>;
 		};
 		dsl {
 			label = "dsl";
 			gpios = <&gpio 13 1>;
-			linux,code = <0x111>;
+			linux,code = <0x101>;
 		};
 		reset {
 			label = "reset";
-			gpios = <&gpio 28 1>;
+			gpios = <&gpio 30 1>;
 			linux,code = <0x198>;
 		};
 	};


### PR DESCRIPTION
- set correct GPIOs for buttons
- set correct input event codes
- include corresponding headers and use macros

The changes have been tested successfully.

Signed-off-by: Andreas Eberlein <foodeas@aeberlein.de>