### PR TITLE
ipq806x: add support for indicating the boot and upgrade state using four leds 2

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -12,11 +12,11 @@ board=$(ipq806x_board_name)
 
 case "$board" in
 c2600)
-	ucidef_set_led_usbdev "usb1" "USB 1" "${board}:blue:usb_2" "2-1"
-	ucidef_set_led_usbdev "usb2" "USB 2" "${board}:blue:usb_4" "4-1"
-	ucidef_set_led_netdev "wan" "WAN" "${board}:blue:wan" "eth0"
-	ucidef_set_led_netdev "lan" "LAN" "${board}:blue:lan" "br-lan"
-	ucidef_set_led_default "general" "general" "${board}:blue:ledgnr" "1"
+	ucidef_set_led_usbdev "usb1" "USB 1" "${board}:white:usb_2" "2-1"
+	ucidef_set_led_usbdev "usb2" "USB 2" "${board}:white:usb_4" "4-1"
+	ucidef_set_led_netdev "wan" "WAN" "${board}:white:wan" "eth0"
+	ucidef_set_led_netdev "lan" "LAN" "${board}:white:lan" "br-lan"
+	ucidef_set_led_default "general" "general" "${board}:white:ledgnr" "1"
 	;;
 d7800 |\
 r7500 |\

--- a/target/linux/ipq806x/base-files/etc/diag.sh
+++ b/target/linux/ipq806x/base-files/etc/diag.sh
@@ -1,34 +1,45 @@
 #!/bin/sh
+# Copyright (C) 2016 Henryk Heisig hyniu@o2.pl
 
 . /lib/functions/leds.sh
 . /lib/ipq806x.sh
 
-get_status_led() {
-	case $(ipq806x_board_name) in
-	c2600)
-		status_led="c2600:blue:status"
-		;;
-	ea8500)
-		status_led="ea8500:white:power"
-		;;
-	esac
-}
+boot="$(ipq806x_get_dt_led boot)"
+failsafe="$(ipq806x_get_dt_led failsafe)"
+running="$(ipq806x_get_dt_led running)"
+upgrade="$(ipq806x_get_dt_led upgrade)"
 
 set_state() {
-	get_status_led
+	status_led="$boot"
 
 	case "$1" in
 	preinit)
 		status_led_blink_preinit
 		;;
 	failsafe)
+		status_led_off
+		[ -n "$running" ] && {
+			status_led="$running"
+			status_led_off
+		}
+		status_led="$failsafe"
 		status_led_blink_failsafe
 		;;
 	preinit_regular)
 		status_led_blink_preinit_regular
 		;;
+	upgrade)
+		[ -n "$running" ] && {
+			status_led="$upgrade"
+			status_led_blink_preinit_regular
+		}
+		;;
 	done)
-		status_led_on
+		status_led_off
+		[ -n "$running" ] && {
+			status_led="$running"
+			status_led_on
+		}
 		;;
 	esac
 }

--- a/target/linux/ipq806x/base-files/lib/ipq806x.sh
+++ b/target/linux/ipq806x/base-files/lib/ipq806x.sh
@@ -59,3 +59,15 @@ ipq806x_board_name() {
 
 	echo "$name"
 }
+
+ipq806x_get_dt_led() {
+	local label
+	local ledpath
+	local basepath="/sys/firmware/devicetree/base"
+	local nodepath="$basepath/aliases/led-$1"
+
+	[ -f "$nodepath" ] && ledpath=$(cat "$nodepath")
+	[ -n "$ledpath" ] && label=$(cat "$basepath$ledpath/label")
+
+	echo "$label"
+}

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -59,3 +59,9 @@ platform_do_upgrade() {
 		;;
 	esac
 }
+
+blink_led() {
+	. /etc/diag.sh; set_state upgrade
+}
+
+append sysupgrade_pre_upgrade blink_led

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
@@ -381,32 +381,31 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "c2600:blue:lan";
+			label = "c2600:white:lan";
 			gpios = <&qcom_pinmux 6 0>;
 		};
 		usb4 {
-			label = "c2600:blue:usb_4";
+			label = "c2600:white:usb_4";
 			gpios = <&qcom_pinmux 7 0>;
 		};
 		usb2 {
-			label = "c2600:blue:usb_2";
+			label = "c2600:white:usb_2";
 			gpios = <&qcom_pinmux 8 0>;
 		};
 		wps {
-			label = "c2600:blue:wps";
+			label = "c2600:white:wps";
 			gpios = <&qcom_pinmux 9 0>;
 		};
 		wan_blue {
-			label = "c2600:blue:wan";
+			label = "c2600:white:wan";
 			gpios = <&qcom_pinmux 33 1>;
 		};
 		power: status {
-			label = "c2600:blue:status";
+			label = "c2600:white:status";
 			gpios = <&qcom_pinmux 53 0>;
-			default-state = "on";
 		};
 		ledgnr: ledgnr {
-			label = "c2600:blue:ledgnr";
+			label = "c2600:white:ledgnr";
 			gpios = <&qcom_pinmux 66 0>;
 		};
 	};

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
@@ -23,6 +23,11 @@
 	aliases {
 		serial0 = &uart4;
 		mdio-gpio0 = &mdio0;
+
+		led-boot = &power;
+		led-failsafe = &ledgnr;
+		led-running = &power;
+		led-upgrade = &ledgnr;
 	};
 
 	chosen {
@@ -395,12 +400,12 @@
 			label = "c2600:blue:wan";
 			gpios = <&qcom_pinmux 33 1>;
 		};
-		status {
+		power: status {
 			label = "c2600:blue:status";
 			gpios = <&qcom_pinmux 53 0>;
 			default-state = "on";
 		};
-		ledgnr {
+		ledgnr: ledgnr {
 			label = "c2600:blue:ledgnr";
 			gpios = <&qcom_pinmux 66 0>;
 		};

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
@@ -24,6 +24,11 @@
 	aliases {
 		serial0 = &uart4;
 		mdio-gpio0 = &mdio0;
+
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
 	};
 
 	chosen {
@@ -365,7 +370,7 @@
 			default-state = "off";
 		};
 
-		power {
+		power: power {
 			label = "ea8500:white:power";
 			gpios = <&qcom_pinmux 6 1>;
 			default-state = "off";


### PR DESCRIPTION
Tested on Archer C2600.

Signed-off-by: Henryk Heisig hyniu@o2.pl