### PR TITLE
kmod-sched-cake: Update to include latest features 

### DIFF
--- a/package/kernel/kmod-sched-cake/Makefile
+++ b/package/kernel/kmod-sched-cake/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=sched-cake
-PKG_SOURCE_VERSION:=747954dd0bde66bb28d2b6c2c109597c9abbe5c5
-PKG_VERSION:=2016-06-29-$(PKG_SOURCE_VERSION)
+PKG_SOURCE_VERSION:=4f62bd17fa34036cb3c8fd4800a709b2734c3de3
+PKG_VERSION:=2016-10-02-$(PKG_SOURCE_VERSION)
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
@@ -27,6 +27,7 @@ define KernelPackage/sched-cake
   URL:=https://github.com/dtaht/sch_cake
   FILES:=$(PKG_BUILD_DIR)/sch_cake.ko
   AUTOLOAD:=$(call AutoLoad,75,sch_cake)
+  DEPENDS:=+kmod-ipt-conntrack
 endef
 
 include $(INCLUDE_DIR)/kernel-defaults.mk

--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iproute2
 PKG_VERSION:=4.4.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/net/iproute2

--- a/package/network/utils/iproute2/patches/950-add-cake-to-tc.patch
+++ b/package/network/utils/iproute2/patches/950-add-cake-to-tc.patch
@@ -1,6 +1,6 @@
 --- a/include/linux/pkt_sched.h
 +++ b/include/linux/pkt_sched.h
-@@ -850,4 +850,56 @@ struct tc_pie_xstats {
+@@ -850,4 +850,57 @@ struct tc_pie_xstats {
  	__u32 maxq;             /* maximum queue size */
  	__u32 ecn_mark;         /* packets marked with ecn*/
  };
@@ -17,6 +17,7 @@
 +	TCA_CAKE_TARGET,
 +	TCA_CAKE_AUTORATE,
 +	TCA_CAKE_MEMORY,
++	TCA_CAKE_NAT,
 +	__TCA_CAKE_MAX
 +};
 +#define TCA_CAKE_MAX	(__TCA_CAKE_MAX - 1)
@@ -69,7 +70,7 @@
  
 --- /dev/null
 +++ b/tc/q_cake.c
-@@ -0,0 +1,600 @@
+@@ -0,0 +1,643 @@
 +/*
 + * Common Applications Kept Enhanced  --  CAKE
 + *
@@ -126,8 +127,8 @@
 +	fprintf(stderr, "Usage: ... cake [ bandwidth RATE | unlimited* | autorate_ingress ]\n"
 +	                "                [ rtt TIME | datacentre | lan | metro | regional | internet* | oceanic | satellite | interplanetary ]\n"
 +	                "                [ besteffort | precedence | diffserv8 | diffserv4* ]\n"
-+	                "                [ flowblind | srchost | dsthost | hosts | flows* | dual-srchost | dual-dsthost | triple-isolate ]\n"
-+	                "                [ atm | noatm* ] [ overhead N | conservative | raw* ]\n"
++	                "                [ flowblind | srchost | dsthost | hosts | flows* | dual-srchost | dual-dsthost | triple-isolate ] [ nat | nonat* ]\n"
++	                "                [ ptm | atm | noatm* ] [ overhead N | conservative | raw* ]\n"
 +	                "                [ memlimit LIMIT ]\n"
 +	                "    (* marks defaults)\n");
 +}
@@ -144,6 +145,7 @@
 +	int  overhead = 0;
 +	bool overhead_set = false;
 +	int flowmode = -1;
++	int nat = -1;
 +	int atm = -1;
 +	int autorate = -1;
 +	struct rtattr *tail;
@@ -228,6 +230,13 @@
 +		} else if (strcmp(*argv, "triple-isolate") == 0) {
 +			flowmode = 7;
 +
++		} else if (strcmp(*argv, "nat") == 0) {
++			nat = 1;
++		} else if (strcmp(*argv, "nonat") == 0) {
++			nat = 0;
++
++		} else if (strcmp(*argv, "ptm") == 0) {
++			atm = 2;
 +		} else if (strcmp(*argv, "atm") == 0) {
 +			atm = 1;
 +		} else if (strcmp(*argv, "noatm") == 0) {
@@ -247,7 +256,29 @@
 +			overhead = 48;
 +			overhead_set = true;
 +
-+		/* Various ADSL framing schemes */
++		/*
++		 * DOCSIS overhead figures courtesy of Greg White @ CableLabs.
++		 * The "-ip" versions include the Ethernet frame header, in case
++		 * you are shaping an IP interface instead of an Ethernet one.
++		 */
++		} else if (strcmp(*argv, "docsis-downstream-ip") == 0) {
++			atm = 0;
++			overhead += 35;
++			overhead_set = true;
++		} else if (strcmp(*argv, "docsis-downstream") == 0) {
++			atm = 0;
++			overhead += 35 - 14;
++			overhead_set = true;
++		} else if (strcmp(*argv, "docsis-upstream-ip") == 0) {
++			atm = 0;
++			overhead += 28;
++			overhead_set = true;
++		} else if (strcmp(*argv, "docsis-upstream") == 0) {
++			atm = 0;
++			overhead += 28 - 14;
++			overhead_set = true;
++
++		/* Various ADSL framing schemes, all over ATM cells */
 +		} else if (strcmp(*argv, "ipoa-vcmux") == 0) {
 +			atm = 1;
 +			overhead += 8;
@@ -281,20 +312,23 @@
 +			overhead += 40;
 +			overhead_set = true;
 +
-+		/* Typical VDSL2 framing schemes */
-+		/* NB: PTM includes HDLC's 0x7D/7E expansion, adds extra 1/128 */
++		/* Typical VDSL2 framing schemes, both over PTM */
++		/* PTM has 64b/65b coding which absorbs some bandwidth */
 +		} else if (strcmp(*argv, "pppoe-ptm") == 0) {
-+			atm = 0;
++			atm = 2;
 +			overhead += 27;
++			overhead_set = true;
 +		} else if (strcmp(*argv, "bridged-ptm") == 0) {
-+			atm = 0;
++			atm = 2;
 +			overhead += 19;
++			overhead_set = true;
 +
 +		} else if (strcmp(*argv, "via-ethernet") == 0) {
 +			/*
 +			 * The above overheads are relative to an IP packet,
-+			 * but if the physical interface is Ethernet, Linux
-+			 * includes Ethernet framing overhead already.
++			 * but Linux includes Ethernet framing overhead already
++			 * if we are shaping an Ethernet interface rather than
++			 * an IP interface.
 +			 */
 +			overhead -= 14;
 +			overhead_set = true;
@@ -371,6 +405,8 @@
 +		addattr_l(n, 1024, TCA_CAKE_AUTORATE, &autorate, sizeof(autorate));
 +	if (memlimit)
 +		addattr_l(n, 1024, TCA_CAKE_MEMORY, &memlimit, sizeof(memlimit));
++	if (nat != -1)
++		addattr_l(n, 1024, TCA_CAKE_NAT, &nat, sizeof(nat));
 +
 +	tail->rta_len = (void *) NLMSG_TAIL(n) - (void *) tail;
 +	return 0;
@@ -387,6 +423,7 @@
 +	unsigned memlimit = 0;
 +	int overhead = 0;
 +	int atm = 0;
++	int nat = 0;
 +	int autorate = 0;
 +	SPRINT_BUF(b1);
 +	SPRINT_BUF(b2);
@@ -439,6 +476,8 @@
 +	if (tb[TCA_CAKE_FLOW_MODE] &&
 +	    RTA_PAYLOAD(tb[TCA_CAKE_FLOW_MODE]) >= sizeof(__u32)) {
 +		flowmode = rta_getattr_u32(tb[TCA_CAKE_FLOW_MODE]);
++		nat = !!(flowmode & 64);
++		flowmode &= ~64;
 +		switch(flowmode) {
 +		case 0:
 +			fprintf(f, "flowblind ");
@@ -468,6 +507,9 @@
 +			fprintf(f, "(?flowmode?) ");
 +			break;
 +		};
++
++		if(nat)
++			fprintf(f, "nat ");
 +	}
 +	if (tb[TCA_CAKE_ATM] &&
 +	    RTA_PAYLOAD(tb[TCA_CAKE_ATM]) >= sizeof(__u32)) {
@@ -485,8 +527,10 @@
 +	if (interval)
 +		fprintf(f, "rtt %s ", sprint_time(interval, b2));
 +
-+	if (atm)
++	if (atm == 1)
 +		fprintf(f, "atm ");
++	else if (atm == 2)
++		fprintf(f, "ptm ");
 +	else if (overhead)
 +		fprintf(f, "noatm ");
 +


### PR DESCRIPTION
A number of updates/improvements to the cake qdisc with matching update to iproute's tc to enable them.

New feature: nat/nonat keywords.  This allows cake to query the conntrack table to determine internal IP addresses when in a masqueraded environment as is typical in a home router.  When used with host related keywords (dual-srchost, dual-dsthost, triple-isolate, srchost, dsthost) bandwidth is shared fairly between IP addresses.  Typical usage on a WAN facing interface would involve 'dual-dsthost nat' on the ingress interface, with 'dual-srchost nat' on egress.

Enhancement: Support for PTM overhead: 'ptm' enables PTM 'framing' overheads, whilst 'pppoe-ptm' & 'bridged-ptm' enable that along with typical packet overheads.

Enhancement: Support for various DOCSIS related overheads: docsis-downstream, docsis-upstream, docsis-downstream-ip, docsis-upstream-ip.

Enhancement: diffserv4 thresholds & queuing weights updated to reflect changes in internal bandwidth allocation.