### PR TITLE
mvebu: fix sysupgrade

### DIFF
--- a/target/linux/mvebu/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/mvebu/base-files/lib/upgrade/linksys.sh
@@ -89,3 +89,5 @@ linksys_preupgrade() {
 	esac
 }
 
+append sysupgrade_pre_upgrade linksys_preupgrade
+


### PR DESCRIPTION
sysupgrade command fails due to missing U-Boot environment-processing binaries on sysupgrade ramdisk. The missing binaries result in the following output:
	Switching to ramdisk...
	Performing system upgrade...
	ash: /usr/sbin/fw_printenv: not found
	ash: fw_setenv: not found
	ash: touch: not found
	cannot find target partition

Fixes FS#197.

Signed-off-by: Aaron Curley <accwebs@gmail.com>