### PR TITLE
tools/patchelf: Update to 0.9 and remove patch

### DIFF
--- a/tools/patchelf/Makefile
+++ b/tools/patchelf/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=patchelf
-PKG_VERSION:=0.8
+PKG_VERSION:=0.9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://nixos.org/releases/patchelf/patchelf-$(PKG_VERSION)
-PKG_MD5SUM:=5b151e3c83b31f5931b4a9fc01635bfd
+PKG_MD5SUM:=d02687629c7e1698a486a93a0d607947
 
 HOST_BUILD_PARALLEL:=1
 HOST_FIXUP:=autoreconf

--- a/tools/patchelf/patches/100-portability.patch
+++ b/tools/patchelf/patches/100-portability.patch
@@ -1,8 +1,0 @@
---- a/configure.ac
-+++ b/configure.ac
-@@ -1,4 +1,4 @@
--AC_INIT([patchelf], m4_esyscmd([echo -n $(cat ./version)]))
-+AC_INIT([patchelf], m4_esyscmd([printf $(cat ./version)]))
- AC_CONFIG_SRCDIR([src/patchelf.cc])
- AC_CONFIG_AUX_DIR([build-aux])
- AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign color-tests parallel-tests])


### PR DESCRIPTION
Updates patchelf to 0.9
Patch removed, upstreamed.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>