### PR TITLE
uhttpd: revert to preferring px5g for certificate creation, create self-signed certificates with unique subjects 

### DIFF
--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -46,12 +46,13 @@ generate_keys() {
 
 	# Prefer px5g for certificate generation (existence evaluated last)
 	local GENKEY_CMD=""
+	local UNIQUEID=$(dd if=/dev/urandom bs=1 count=4 | hexdump -e '1/1 "%02x"')
 	[ -x "$OPENSSL_BIN" ] && GENKEY_CMD="$OPENSSL_BIN req -x509 -outform der -nodes"
 	[ -x "$PX5G_BIN" ] && GENKEY_CMD="$PX5G_BIN selfsigned -der"
 	[ -n "$GENKEY_CMD" ] && {
 		$GENKEY_CMD \
 			-days ${days:-730} -newkey rsa:${bits:-2048} -keyout "${UHTTPD_KEY}.new" -out "${UHTTPD_CERT}.new" \
-			-subj /C="${country:-DE}"/ST="${state:-Saxony}"/L="${location:-Leipzig}"/CN="${commonname:-Lede}"
+			-subj /C="${country:-DE}"/ST="${state:-Saxony}"/L="${location:-Leipzig}"/O="${commonname:-Lede}$UNIQUEID"/CN="${commonname:-Lede}"
 		sync
 		mv "${UHTTPD_KEY}.new" "${UHTTPD_KEY}"
 		mv "${UHTTPD_CERT}.new" "${UHTTPD_CERT}"

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -44,10 +44,10 @@ generate_keys() {
 	config_get location   "$cfg" location
 	config_get commonname "$cfg" commonname
 
-	# Prefer OpenSSL for certificate generation (existence evaluated last)
+	# Prefer px5g for certificate generation (existence evaluated last)
 	local GENKEY_CMD=""
-	[ -x "$PX5G_BIN" ] && GENKEY_CMD="$PX5G_BIN selfsigned -der"
 	[ -x "$OPENSSL_BIN" ] && GENKEY_CMD="$OPENSSL_BIN req -x509 -outform der -nodes"
+	[ -x "$PX5G_BIN" ] && GENKEY_CMD="$PX5G_BIN selfsigned -der"
 	[ -n "$GENKEY_CMD" ] && {
 		$GENKEY_CMD \
 			-days ${days:-730} -newkey rsa:${bits:-2048} -keyout "${UHTTPD_KEY}.new" -out "${UHTTPD_CERT}.new" \


### PR DESCRIPTION
@jow- 

I noticed today that Firefox seems to somewhat dislike OpenSSL-created certificates. Chrome, IE and Edge seem to use them happily, but Firefox forms the initial connection slowly and viewing the certificate details in Firefox is slow.

So, to avoid trouble and a decreased user experience for users who have installed openssl-util in their build, change the preference to be for px5g, for now.

After this change, the old px5g is used for the cert creation unless the user has explicitly removed px5g from luci-ssl(-openssl) collection or has manually deleted it from the image. Normal users will create the certs with px5g just as before.

But testing for a pure OpenSSL-based build is possible. And I will try to figure out how Firefox can be made to like the OpenSSL certs. Likely some creation parameters need to be added or changed.