### PR TITLE
dslite: Quote resolveip hostname argument

### DIFF
--- a/package/network/ipv6/ds-lite/Makefile
+++ b/package/network/ipv6/ds-lite/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ds-lite
 PKG_VERSION:=7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/ipv6/ds-lite/files/dslite.sh
+++ b/package/network/ipv6/ds-lite/files/dslite.sh
@@ -26,16 +26,20 @@ proto_dslite_setup() {
 
 	( proto_add_host_dependency "$cfg" "::" "$tunlink" )
 
-	remoteip6=$(resolveip -6 $peeraddr)
+	remoteip6=$(resolveip -6 "$peeraddr")
 	if [ -z "$remoteip6" ]; then
 		sleep 3
-		remoteip6=$(resolveip -6 $peeraddr)
+		remoteip6=$(resolveip -6 "$peeraddr")
 		if [ -z "$remoteip6" ]; then
 			proto_notify_error "$cfg" "AFTR_DNS_FAIL"
 			return
 		fi
 	fi
-	peeraddr="${remoteip6%% *}"
+
+	for ip6 in $remoteip6; do
+		peeraddr=$ip6
+		break
+	done
 
 	[ -z "$ip6addr" ] && {
 		local wanif="$tunlink"


### PR DESCRIPTION
Quote resolveip hostname argument to avoid bad shell injections.
While at it fix pattern match logic in case multiple IPv6 addresses
are returned for a hostname as they're seperated by newline by
resolveip and not a white space

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>