### PR TITLE
ar71xx: Add separate device for Archer C7 v2 IL

### DIFF
--- a/target/linux/ar71xx/image/tp-link.mk
+++ b/target/linux/ar71xx/image/tp-link.mk
@@ -217,6 +217,16 @@ define Device/archer-c7-v2
     IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
 endef
 
+define Device/archer-c7-v2-il
+    $(Device/tplink-16mlzma)
+    DEVICE_TITLE := TP-LINK Archer C7 v2 IL
+    DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ledtrig-usbdev kmod-ath10k ath10k-firmware-qca988x
+    BOARDNAME := ARCHER-C7-V2
+    DEVICE_PROFILE := ARCHERC7
+    TPLINK_HWID := 0xc7000002
+    TPLINK_HWREV := 0x494c0001
+endef
+
 define Device/tl-wdr7500-v3
     $(Device/tplink-8mlzma)
     DEVICE_TITLE := TP-LINK Archer C7 v3
@@ -225,7 +235,7 @@ define Device/tl-wdr7500-v3
     DEVICE_PROFILE := ARCHERC7
     TPLINK_HWID := 0x75000003
 endef
-TARGET_DEVICES += archer-c5-v1 archer-c7-v1 archer-c7-v2 tl-wdr7500-v3
+TARGET_DEVICES += archer-c5-v1 archer-c7-v1 archer-c7-v2 archer-c7-v2-il tl-wdr7500-v3
 
 define Device/tl-mr10u-v1
     $(Device/tplink-4mlzma)


### PR DESCRIPTION
In discussion in commit https://github.com/lede-project/source/commit/fa0096f6cc236e1346a344d3edf467945aa4a27e, @NeoRaider said:

> I had a quick look at the stock firmware images from the TP-Link IL website, and they don't use the same region coding mechanism as the US/EU images. Instead of setting the region, they set the TPLINK_HWREV to 0x494c0001. To properly support the IL version, a separate Device/... definition should be added.

I am attempting to add the device myself, but this is my first time working with this code base, so help and review are appreciated. Currently, when I run `make menuconfig`, I don't see the new device as an option. Can someone guide me on what else should be done?