### PR TITLE
target/sdk: Switch to xz compression instead of bz2

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -65,7 +65,7 @@ KERNEL_FILES := $(patsubst $(TOPDIR)/%,%,$(wildcard $(addprefix $(LINUX_DIR)/,$(
 
 all: compile
 
-$(BIN_DIR)/$(SDK_NAME).tar.bz2: clean
+$(BIN_DIR)/$(SDK_NAME).tar.xz: clean
 	mkdir -p $(SDK_BUILD_DIR)/dl $(SDK_BUILD_DIR)/package
 	$(CP) -L $(INCLUDE_DIR) $(SCRIPT_DIR) $(TOPDIR)/docs $(SDK_BUILD_DIR)/
 	$(TAR) -cf - -C $(TOPDIR) \
@@ -123,13 +123,13 @@ $(BIN_DIR)/$(SDK_NAME).tar.bz2: clean
 	find $(SDK_BUILD_DIR) -name .svn | $(XARGS) rm -rf
 	find $(SDK_BUILD_DIR) -name CVS | $(XARGS) rm -rf
 	(cd $(BUILD_DIR); \
-		tar cfj $@ $(SDK_NAME); \
+		tar -I 'xz -7e' -cf $@ $(SDK_NAME); \
 	)
 
 download:
 prepare:
-compile: $(BIN_DIR)/$(SDK_NAME).tar.bz2
+compile: $(BIN_DIR)/$(SDK_NAME).tar.xz
 install: compile
 
 clean:
-	rm -rf $(SDK_BUILD_DIR) $(BIN_DIR)/$(SDK_NAME).tar.bz2
+	rm -rf $(SDK_BUILD_DIR) $(BIN_DIR)/$(SDK_NAME).tar.xz


### PR DESCRIPTION
Switch to xz compression instead of using bz2.
This makes a considerable difference in size, ar71xx SDK from 60M to 35M.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>