### PR TITLE
mbedtls: enable NIST curves optimisation.

### DIFF
--- a/package/libs/mbedtls/patches/200-config.patch
+++ b/package/libs/mbedtls/patches/200-config.patch
@@ -1,5 +1,7 @@
---- a/include/mbedtls/config.h
-+++ b/include/mbedtls/config.h
+Index: mbedtls-2.3.0/include/mbedtls/config.h
+===================================================================
+--- mbedtls-2.3.0.orig/include/mbedtls/config.h
++++ mbedtls-2.3.0/include/mbedtls/config.h
 @@ -185,7 +185,7 @@
   *
   * Uncomment to get errors on using deprecated functions.
@@ -36,15 +38,6 @@
  #define MBEDTLS_ECP_DP_SECP256K1_ENABLED
  #define MBEDTLS_ECP_DP_BP256R1_ENABLED
  #define MBEDTLS_ECP_DP_BP384R1_ENABLED
-@@ -457,7 +457,7 @@
-  *
-  * Comment this macro to disable NIST curves optimisation.
-  */
--#define MBEDTLS_ECP_NIST_OPTIM
-+//#define MBEDTLS_ECP_NIST_OPTIM
- 
- /**
-  * \def MBEDTLS_ECDSA_DETERMINISTIC
 @@ -517,7 +517,7 @@
   *      MBEDTLS_TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA
   *      MBEDTLS_TLS_DHE_PSK_WITH_RC4_128_SHA


### PR DESCRIPTION
luci using ustream-mbedtls is extremely slow vs ustream-polarssl.
polarssl alias mbedtls v1 is configured to use NIST prime speed
optimisation, so no longer disable the default optimisation for
mbedtls v2.

Compile & run tested: Archer C7v2

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>