### PR TITLE
Allow initscripts to start one daemon instance at a time. Signed-off-by: Pierre Lebleu <pme.lebleu@gmail.com>

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -102,9 +102,11 @@ ${INIT_TRACE:+set -x}
 	. $IPKG_INSTROOT/lib/functions/procd.sh
 	basescript=$(readlink "$initscript")
 	rc_procd() {
+		local method="set"
+		[ -n "$2" ] && method="add"
 		procd_open_service "$(basename ${basescript:-$initscript})" "$initscript"
 		"$@"
-		procd_close_service
+		procd_close_service "$method"
 	}
 
 	start() {

--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -76,7 +76,7 @@ _procd_close_service() {
 	_procd_open_trigger
 	service_triggers
 	_procd_close_trigger
-	_procd_ubus_call set
+	_procd_ubus_call ${1:-set}
 }
 
 _procd_add_array_data() {


### PR DESCRIPTION
The procd daemon does not handle correctly the instances.

root@mygateway:~# ps | grep dns
 7121 dnsmasq   1560 S    /usr/sbin/dnsmasq -C /var/etc/dnsmasq.conf.main -k -x /var/run/dnsmasq dnsmasq.main.pid
 7124 root      1556 S    /usr/sbin/dnsmasq -C /var/etc/dnsmasq.conf.main -k -x /var/run/dnsmasq/dnsmasq.main.pid
 7199 dnsmasq   1556 S    /usr/sbin/dnsmasq -C /var/etc/dnsmasq.conf.second -k -x /var/run/dnsmasq/dnsmasq.second.pid
 7529 root      1712 R    grep dnsmasq

root@mygateway:~# /etc/init.d/dnsmasq  stop second
root@mygateway:~# ps w | grep -w dnsmasq
 7121 dnsmasq   1560 S    /usr/sbin/dnsmasq -C /var/etc/dnsmasq.conf.main -k -x /var/run/dnsmasq/dnsmasq.main.pid
 7124 root      1556 S    /usr/sbin/dnsmasq -C /var/etc/dnsmasq.conf.main -k -x /var/run/dnsmasq/dnsmasq.main.pid
 7553 root      1712 S    grep -w dnsmasq

root@mygateway:~# /etc/init.d/dnsmasq  start second
root@mygateway:~# ps w | grep -w dnsmasq
 7623 dnsmasq   1556 S    /usr/sbin/dnsmasq -C /var/etc/dnsmasq.conf.second -k -x /var/run/dnsmasq/dnsmasq.second.pid
 7627 root      1712 R    grep -w dnsmasq

With this patch, I am able to start the second instance without killing the main.