### PR TITLE
ustream-ssl: sanitize ssl library selection & building

### DIFF
--- a/package/libs/ustream-ssl/Makefile
+++ b/package/libs/ustream-ssl/Makefile
@@ -47,7 +47,7 @@ endef
 define Package/libustream-polarssl
   $(Package/libustream/default)
   TITLE += (polarssl)
-  DEPENDS += +libpolarssl
+  DEPENDS += +PACKAGE_libustream-polarssl:libpolarssl
   VARIANT:=polarssl
   DEFAULT_VARIANT:=1
 endef
@@ -55,9 +55,8 @@ endef
 define Package/libustream-mbedtls
   $(Package/libustream/default)
   TITLE += (mbedtls)
-  DEPENDS += +libmbedtls
+  DEPENDS += +PACKAGE_libustream-mbedtls:libmbedtls
   VARIANT:=mbedtls
-  DEFAULT_VARIANT:=1
 endef
 
 ifeq ($(BUILD_VARIANT),cyassl)


### PR DESCRIPTION
Both polarssl & mbedtls were selected as the default build variant.
Only build the selected variant/s.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>