### PR TITLE
toolchain: build fix for Ubuntu 16.10

### DIFF
--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -92,8 +92,8 @@ endif
 GCC_CONFIGURE:= \
 	SHELL="$(BASH)" \
 	$(if $(shell gcc --version 2>&1 | grep LLVM), \
-		CFLAGS="-O2 -fbracket-depth=512 -pipe" \
-		CXXFLAGS="-O2 -fbracket-depth=512 -pipe" \
+		CFLAGS="-O2 -fbracket-depth=512 -pipe -fno-pie" \
+		CXXFLAGS="-O2 -fbracket-depth=512 -pipe -fno-pie" \
 	) \
 	$(HOST_SOURCE_DIR)/configure \
 		--with-bugurl=$(BUGURL) \


### PR DESCRIPTION
Ubuntu 16.10 compiles with `-fpie' by default
This breaks toolchain cross compilation, add `-fno-pie' to override it