### PR TITLE
ramips: add support for MikroTik hEX v3 (RB750Gr3)

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -134,6 +134,7 @@ ramips_setup_interfaces()
 	jhr-n825r|\
 	jhr-n926r|\
 	mzk-wdpr|\
+	rb750gr3|\
 	rt-n14u|\
 	ubnt-erx|\
 	ur-326n4g|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -190,6 +190,9 @@ get_status_led() {
 	wr512-3gn)
 		status_led="$board:green:wps"
 		;;
+	rb750gr3)
+		status_led="$board:green:usr"
+		;;
 	sap-g3200u3)
 		status_led="$board:green:usb"
 		;;

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -367,6 +367,9 @@ ramips_board_detect() {
 	*"Q7")
 		name="zte-q7"
 		;;
+	*"RB750Gr3")
+		name="rb750gr3"
+		;;
 	*"RE6500")
 		name="re6500"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -105,6 +105,7 @@ platform_check_image() {
 	psg1218|\
 	psr-680w|\
 	px-4885|\
+	rb750gr3|\
 	re6500|\
 	rp-n53|\
 	rt5350f-olinuxino|\

--- a/target/linux/ramips/dts/RB750Gr3.dts
+++ b/target/linux/ramips/dts/RB750Gr3.dts
@@ -1,0 +1,121 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "mediatek,mt7621-eval-board", "mediatek,mt7621-soc";
+	model = "MikroTik RB750Gr3";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		usr {
+			label = "rb750gr3:green:usr";
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		mode {
+			label = "mode";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		res {
+			label = "res";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb {
+			gpio-export,name = "usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80";
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfb0000>;
+		};
+
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+	mtd-mac-address-increment = <1>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "rgmii2", "sdhci";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};
+
+&pcie {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -190,6 +190,14 @@ define Device/vr500
 endef
 TARGET_DEVICES += vr500
 
+define Device/rb750gr3
+  DTS := RB750Gr3
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := MikroTik RB750Gr3
+  DEVICE_PACKAGES := kmod-usb3 kmod-ledtrig-usbdev uboot-envtools -kmod-mt76 -kmod-rt2x00-lib -kmod-mac80211 -kmod-cfg80211 -wpad-mini -iwinfo
+endef
+TARGET_DEVICES += rb750gr3
+
 # FIXME: is this still needed?
 define Image/Prepare
 #define Build/Compile


### PR DESCRIPTION
Documentation on Wiki is forthcoming; device has to be flashed through SPI programmer due to proprietary bootloader.
Signed-off-by: Andrew Yong me@ndoo.sg
