### PR TITLE
uboot-zynq: fix compile error for be short of dtc

### DIFF
--- a/package/boot/uboot-zynq/Makefile
+++ b/package/boot/uboot-zynq/Makefile
@@ -6,6 +6,7 @@
 #
 
 include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/image.mk
 
 PKG_NAME:=u-boot
 PKG_VERSION:=2016.03
@@ -81,7 +82,7 @@ endef
 
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
-		CROSS_COMPILE=$(TARGET_CROSS)
+		CROSS_COMPILE=$(TARGET_CROSS) DTC=$(LINUX_DIR)/scripts/dtc/dtc
 endef
 
 define Package/uboot/install/default


### PR DESCRIPTION
While enable zynq uboot:
CONFIG_PACKAGE_uboot-zynq-zc702
CONFIG_PACKAGE_uboot-zynq-zed
CONFIG_PACKAGE_uboot-zynq-zybo

make will arise dtc error:
./scripts/dtc-version.sh: line 17: dtc: command not found
./scripts/dtc-version.sh: line 18: dtc: command not found
*** Your dtc is too old, please upgrade to dtc 1.4 or newer
make[4]: *** [checkdtc] Error 1

Pass the kernel dtc to uboot for compile.

Signed-off-by: Yutang Jiang <yutang.jiang@nxp.com>