### PR TITLE
fconfig: move to Boot Loaders submenu

### DIFF
--- a/package/boot/fconfig/Makefile
+++ b/package/boot/fconfig/Makefile
@@ -22,6 +22,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/fconfig
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Boot Loaders
   TITLE:=RedBoot configuration editor
   URL:=http://andrzejekiert.ovh.org/software.html.en
 endef


### PR DESCRIPTION
as it's there that boot loader utilities belong, not just in Utilities.
Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>