### PR TITLE
px5g-standalone: move to Encryption submenu

### DIFF
--- a/package/utils/px5g-standalone/Makefile
+++ b/package/utils/px5g-standalone/Makefile
@@ -17,6 +17,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/px5g-standalone
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Encryption
   TITLE:=Standalone X.509 certificate generator (standalone version)
   MAINTAINER:=Jo-Philipp Wich <xm@subsignal.org>
 endef


### PR DESCRIPTION
Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>