### PR TITLE
fconfig: move to Boot Loaders submenu of Utilities

### DIFF
--- a/package/boot/fconfig/Makefile
+++ b/package/boot/fconfig/Makefile
@@ -22,6 +22,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/fconfig
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Boot Loaders
   TITLE:=RedBoot configuration editor
   URL:=http://andrzejekiert.ovh.org/software.html.en
 endef


### PR DESCRIPTION
Boot Loaders submenu of Utilities is the most logical place to find fconfig and other bootloader tools.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>