### PR TITLE
px5g-standalone: move to Encryption submenu and fix Title

### DIFF
--- a/package/utils/px5g-standalone/Makefile
+++ b/package/utils/px5g-standalone/Makefile
@@ -17,7 +17,8 @@ include $(INCLUDE_DIR)/package.mk
 define Package/px5g-standalone
   SECTION:=utils
   CATEGORY:=Utilities
-  TITLE:=Standalone X.509 certificate generator (standalone version)
+  SUBMENU:=Encryption
+  TITLE:=X.509 certificate generator (standalone version)
   MAINTAINER:=Jo-Philipp Wich <xm@subsignal.org>
 endef
 


### PR DESCRIPTION
moved px5g-standalone to Encryption submenu of Utilities.
Fixed title by removing the first "standalone" word from title. 
The name is now consistent with other px5g packages, it is also shorter and will be shown in make menuconfig.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>