### PR TITLE
px5g: move to Encryption submenu

### DIFF
--- a/package/utils/px5g/Makefile
+++ b/package/utils/px5g/Makefile
@@ -19,6 +19,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/px5g/Template
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Encryption
   TITLE:=X.509 certificate generator (using $(1))
   MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
   DEPENDS:=+lib$(1)


### PR DESCRIPTION
moved px5g to Encryption submenu of Utilities, in an effort to tidy up a bit the Utilities section of make menuconfig.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>