### PR TITLE
Add metric, defaultroute and peerdns in ncm, directip, mbim and qmi protocols

### DIFF
--- a/package/network/utils/comgt/files/directip.sh
+++ b/package/network/utils/comgt/files/directip.sh
@@ -15,14 +15,15 @@ proto_directip_init_config() {
 	proto_config_add_string "auth"
 	proto_config_add_string "username"
 	proto_config_add_string "password"
+	proto_config_add_defaults
 }
 
 proto_directip_setup() {
 	local interface="$1"
 	local chat devpath devname
 
-	local device apn pincode ifname auth username password
-	json_get_vars device apn pincode auth username password
+	local device apn pincode ifname auth username password $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn pincode auth username password $PROTO_DEFAULT_OPTIONS
 
 	[ -n "$ctl_device" ] && device=$ctl_device
 
@@ -80,6 +81,7 @@ proto_directip_setup() {
 	json_add_string name "${interface}_4"
 	json_add_string ifname "@$interface"
 	json_add_string proto "dhcp"
+	proto_add_dynamic_defaults
 	ubus call network add_dynamic "$(json_dump)"
 
 	json_init
@@ -87,6 +89,7 @@ proto_directip_setup() {
 	json_add_string ifname "@$interface"
 	json_add_string proto "dhcpv6"
 	json_add_string extendprefix 1
+	proto_add_dynamic_defaults
 	ubus call network add_dynamic "$(json_dump)"
 
 	return 0

--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -19,6 +19,7 @@ proto_ncm_init_config() {
 	proto_config_add_string mode
 	proto_config_add_string pdptype
 	proto_config_add_boolean ipv6
+	proto_config_add_defaults
 }
 
 proto_ncm_setup() {
@@ -26,8 +27,8 @@ proto_ncm_setup() {
 
 	local manufacturer initialize setmode connect ifname devname devpath
 
-	local device apn auth username password pincode delay mode pdptype ipv6
-	json_get_vars device apn auth username password pincode delay mode pdptype ipv6
+	local device apn auth username password pincode delay mode pdptype ipv6 $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn auth username password pincode delay mode pdptype ipv6 $PROTO_DEFAULT_OPTIONS
 	
 	if [ "$ipv6" = 0 ]; then
 		ipv6=""
@@ -141,6 +142,7 @@ proto_ncm_setup() {
 	json_add_string name "${interface}_4"
 	json_add_string ifname "@$interface"
 	json_add_string proto "dhcp"
+	proto_add_dynamic_defaults
 	ubus call network add_dynamic "$(json_dump)"
 
 	[ -n "$ipv6" ] && {
@@ -149,6 +151,7 @@ proto_ncm_setup() {
 		json_add_string ifname "@$interface"
 		json_add_string proto "dhcpv6"
 		json_add_string extendprefix 1
+		proto_add_dynamic_defaults
 		ubus call network add_dynamic "$(json_dump)"
 	}
 }

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -17,6 +17,7 @@ proto_mbim_init_config() {
 	proto_config_add_string auth
 	proto_config_add_string username
 	proto_config_add_string password
+	proto_config_add_defaults
 }
 
 _proto_mbim_setup() {
@@ -24,8 +25,8 @@ _proto_mbim_setup() {
 	local tid=2
 	local ret
 
-	local device apn pincode delay
-	json_get_vars device apn pincode delay auth username password
+	local device apn pincode delay $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn pincode delay auth username password $PROTO_DEFAULT_OPTIONS
 
 	[ -n "$ctl_device" ] && device=$ctl_device
 
@@ -130,6 +131,7 @@ _proto_mbim_setup() {
 	json_add_string name "${interface}_4"
 	json_add_string ifname "@$interface"
 	json_add_string proto "dhcp"
+	proto_add_dynamic_defaults
 	json_close_object
 	ubus call network add_dynamic "$(json_dump)"
 
@@ -138,6 +140,7 @@ _proto_mbim_setup() {
 	json_add_string ifname "@$interface"
 	json_add_string proto "dhcpv6"
 	json_add_string extendprefix 1
+	proto_add_dynamic_defaults
 	ubus call network add_dynamic "$(json_dump)"
 }
 


### PR DESCRIPTION
Adds generic network options for ncm, directip, mbim and qmi protocol dynamic interfaces.

This depends on netifd patch https://patchwork.ozlabs.org/patch/686820/.