### PR TITLE
toolchain/musl: fix parsing of < > quoted time zone names

### DIFF
--- a/toolchain/musl/patches/400-fix_quoted_timezone.patch
+++ b/toolchain/musl/patches/400-fix_quoted_timezone.patch
@@ -1,0 +1,11 @@
+--- a/src/time/__tz.c
++++ b/src/time/__tz.c
+@@ -87,7 +87,7 @@
+ 	int i;
+ 	if (**p == '<') {
+ 		++*p;
+-		for (i=0; **p!='>' && i<TZNAME_MAX; i++)
++		for (i=0; (*p)[i]!='>' && i<TZNAME_MAX; i++)
+ 			d[i] = (*p)[i];
+ 		++*p;
+ 	} else {


### PR DESCRIPTION
fix parsing of the < > quoted time zone names. Compare the correct character instead of repeatedly comparing the first character.

This PR will enable updating time zone info embedded in LuCI from 2016b to 2016h. 

Musl has a bug in handling < > quoted time zone names, and IANA is gradually changing all time zones to that format. So far 47 time zones are named with the new format (where invented abbreviations are dropped and the time offset is used as the name. E.g. '<+02>' instead of 'EET' )

This patch has been submitted to musl upstream as http://www.openwall.com/lists/musl/2016/10/24/3

Longer explanation below,  from http://www.openwall.com/lists/musl/2016/10/19/1 

Reference also to https://github.com/openwrt/luci/issues/675
---

musl fails to parse timezone string if the zone name is defined in the quoted form with <>.
Example:

```
root@...nWrt:~# cat /etc/TZ
<+04>-4
root@...nWrt:~# date
Wed Mar 30 08:02:59 +04>-4 2016
```

All new timezones & changes to old ones since zoneinfo 2016b seem to adopt the new way, and old zone name abbreviations (like EET) are being gradually removed. Currently already 47 timezones have numeric names inside < >. Examples of new timezone strings (after 2016g):

```
'Antarctica/Troll', '<+00>0<+02>-2,M3.5.0/1,M10.5.0/3'
'Asia/Baku', '<+04>-4'
'Europe/Istanbul', '<+03>-3'
'Europe/Minsk', '<+03>-3'
```

I think that I have now found the bug in musl and fixed it.

The core reason is a fault in the logic for quoted timezone names in function "getname" in __tz.c. The name string evaluation loop forgets to push the pointer forward to get the next character. The pointer "*p" is explicitly moved one char forward to skip the "<" (and afterwards for ">"), but during the actual name evaluation loop the same "*p" is used until "i" reaches TZNAME_MAX and breaks the loop. After the loop, at the end of the function "*p" is increased by the (wrongly detected) length. _POSIX_TZNAME_MAX=6, so the name in the previous example is thought to be "+04>-4" as the whole loop evaluates against the first char "+" and does not notice the name end marker ">".

http://git.musl-libc.org/cgit/musl/tree/src/time/__tz.c#n87

```
    if (**p == '<') {
        ++*p;
        for (i=0; **p!='>' && i<TZNAME_MAX; i++)   <---- culprit: **p remains constant
            d[i] = (*p)[i];
        ++*p;
    } else {
        for (i=0; ((*p)[i]|32)-'a'<26U && i<TZNAME_MAX; i++)
            d[i] = (*p)[i];
    }
    *p += i;
    d[i] = 0;
```

Function "do_tzset" uses "getname" to both find the string and to move the pointer "s" forward. As the end of the timezone name is evaluated wrongly, the offset calculation & DST detection will also fail, as they start from the wrong place.

http://git.musl-libc.org/cgit/musl/tree/src/time/__tz.c#n219

```
    getname(std_name, &s);
    __tzname[0] = std_name;
    __timezone = getoff(&s);
    getname(dst_name, &s);
    __tzname[1] = dst_name;
```

I patched "getname" by replacing **p with (*p)[i] to make it to evaluate the correct character:

```
--- a/src/time/__tz.c
+++ b/src/time/__tz.c
@@ -87,7 +87,7 @@
     int i;
     if (**p == '<') {
         ++*p;
-        for (i=0; **p!='>' && i<TZNAME_MAX; i++)
+        for (i=0; (*p)[i]!='>' && i<TZNAME_MAX; i++)
             d[i] = (*p)[i];
         ++*p;
     } else {

```

I am not sure if the fix is optimal, but it seems to work.

After that change I am finally able to select timezones with quoted names and see correct times:

```
root@lede:~# cat /etc/TZ ; date
EET-2EEST,M3.5.0/3,M10.5.0/4
Tue Oct 18 21:46:41 EEST 2016

root@lede:~# echo "UTC" > /etc/TZ
root@lede:~# cat /etc/TZ ; date
UTC
Tue Oct 18 18:46:53 UTC 2016

root@lede:~# echo "<+04>-4" > /etc/TZ
root@lede:~# cat /etc/TZ ; date
<+04>-4
Tue Oct 18 22:47:17 +04 2016

root@lede:~# echo "<+00>0<+02>-2,M3.5.0/1,M10.5.0/3" > /etc/TZ
root@lede:~# cat /etc/TZ ; date
<+00>0<+02>-2,M3.5.0/1,M10.5.0/3
Tue Oct 18 20:48:10 +02 2016

root@lede:~# echo "<-03>3" > /etc/TZ
root@lede:~# cat /etc/TZ ; date
<-03>3
Tue Oct 18 15:48:41 -03 2016
```
