### PR TITLE
ppp: split the ppp-up for the IPv6 part

### DIFF
--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -206,6 +206,7 @@ define Package/ppp/install
 	$(INSTALL_DIR) $(1)/lib/netifd/proto
 	$(INSTALL_BIN) ./files/ppp.sh $(1)/lib/netifd/proto/
 	$(INSTALL_BIN) ./files/lib/netifd/ppp-up $(1)/lib/netifd/
+	$(INSTALL_BIN) ./files/lib/netifd/ppp6-up $(1)/lib/netifd/
 	$(INSTALL_BIN) ./files/lib/netifd/ppp-down $(1)/lib/netifd/
 endef
 Package/ppp-multilink/install=$(Package/ppp/install)

--- a/package/network/services/ppp/files/lib/netifd/ppp-up
+++ b/package/network/services/ppp/files/lib/netifd/ppp-up
@@ -7,7 +7,6 @@ proto_set_keep 1
 [ -n "$PPP_IPPARAM" ] && {
 	[ -n "$IPLOCAL" ] && proto_add_ipv4_address "$IPLOCAL" 32 "" "${IPREMOTE:-2.2.2.2}"
 	[ -n "$IPREMOTE" ] && proto_add_ipv4_route 0.0.0.0 0 "$IPREMOTE"
-	[ -n "$LLLOCAL" ] && proto_add_ipv6_address "$LLLOCAL" 128
 	[ -n "$DNS1" ] && proto_add_dns_server "$DNS1"
 	[ -n "$DNS2" -a "$DNS1" != "$DNS2" ] && proto_add_dns_server "$DNS2"
 }
@@ -19,13 +18,3 @@ proto_send_update "$PPP_IPPARAM"
 		[ -x "$SCRIPT" ] && "$SCRIPT" "$@"
 	done
 }
-
-if [ -n "$AUTOIPV6" ]; then
-	json_init
-	json_add_string name "${PPP_IPPARAM}_6"
-	json_add_string ifname "@$PPP_IPPARAM"
-	json_add_string proto "dhcpv6"
-	[ -n "$EXTENDPREFIX" ] && json_add_string extendprefix 1
-	json_close_object
-	ubus call network add_dynamic "$(json_dump)"
-fi

--- a/package/network/services/ppp/files/lib/netifd/ppp6-up
+++ b/package/network/services/ppp/files/lib/netifd/ppp6-up
@@ -1,0 +1,27 @@
+#!/bin/sh
+PPP_IPPARAM="$6"
+
+. /lib/netifd/netifd-proto.sh
+proto_init_update "$IFNAME" 1 1
+proto_set_keep 1
+[ -n "$PPP_IPPARAM" ] && {
+	[ -n "$LLLOCAL" ] && proto_add_ipv6_address "$LLLOCAL" 128
+}
+proto_send_update "$PPP_IPPARAM"
+
+[ -d /etc/ppp/ip-up.d ] && {
+	for SCRIPT in /etc/ppp/ip-up.d/*
+	do
+		[ -x "$SCRIPT" ] && "$SCRIPT" "$@"
+	done
+}
+
+if [ -n "$AUTOIPV6" ]; then
+	json_init
+	json_add_string name "${PPP_IPPARAM}_6"
+	json_add_string ifname "@$PPP_IPPARAM"
+	json_add_string proto "dhcpv6"
+	[ -n "$EXTENDPREFIX" ] && json_add_string extendprefix 1
+	json_close_object
+	ubus call network add_dynamic "$(json_dump)"
+fi

--- a/package/network/services/ppp/files/ppp.sh
+++ b/package/network/services/ppp/files/ppp.sh
@@ -144,7 +144,7 @@ ppp_generic_setup() {
 		${connect:+connect "$connect"} \
 		${disconnect:+disconnect "$disconnect"} \
 		ip-up-script /lib/netifd/ppp-up \
-		ipv6-up-script /lib/netifd/ppp-up \
+		ipv6-up-script /lib/netifd/ppp6-up \
 		ip-down-script /lib/netifd/ppp-down \
 		ipv6-down-script /lib/netifd/ppp-down \
 		${mtu:+mtu $mtu mru $mtu} \


### PR DESCRIPTION
Signed-off-by: Pierre Lebleu pme.lebleu@gmail.com
#445 This is the same commit based on the LEDE branch.

If the IPv6 link over a PPPOE is established before the IPv4, it results that the IPv4 DNS servers are overwritten. The "resolv.conf" file will have duplicated IPv4 DNS servers. The main issue is that clients are not able to resolve IPv6 domain anymore.

The idea behind this fix is to split the file "/lib/netifd/ppp-up" in two parts : one for IPv4 and one for IPv6. Indeed, the IPv6 DNS servers will be updated only for the IPv6 link and the IPv4 DNS servers will be also updated only with the IPv4 link.

@jow- 
I give you the tests that I ran :

network configuration

```
config interface 'wan'
        option proto 'pppoe'
        option ifname 'eth4.835'
        option demand '0'
        option keepalive '4,30'
        option graceful_restart '1'
        option peerdns '1'
        option reqopts '1 3 6 15 33 42 51 121 249'
        option keepalive_adaptive '0'
        option release '1'
        option username 'user@domain'
        option password 'password'
        option ipv6 '1'
```

before the fix

```
cat /tmp/resolv.conf.auto 
# Interface wan
nameserver x.x.x.x
nameserver y.y.y.y
nameserver x.x.x.x
nameserver y.y.y.y
# Interface wan6
nameserver 2001:dead:beef:aaaa::11:c001
nameserver 2001:dead:beef:aaaa::11:c002
```

after the fix

```
cat /tmp/resolv.conf.auto 
# Interface wan
nameserver x.x.x.x
nameserver y.y.y.y
# Interface wan6
nameserver 2001:dead:beef:aaaa::11:c001
nameserver 2001:dead:beef:aaaa::11:c002
```

I understand your worries about the commit and I can run extra tests if you want. Please, let me know.

Cheers
