### PR TITLE
tools/firmware-utils: fix compilation on MacOS X

### DIFF
--- a/tools/firmware-utils/src/mkwrggimg.c
+++ b/tools/firmware-utils/src/mkwrggimg.c
@@ -8,6 +8,7 @@
  *
  */
 
+#define _ANSI_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
Looking into /usr/include/stdlib.h, there's a `devname()` function defined
under some #ifdef's.
Which conflicts with the `static char *devname` definition in `src/mkwrggimg.c`

Defining `_ANSI_SOURCE` in the `src/mkwrggimg.c` file, omits that part of the header.

Another more intrusive approach is to rename `devname` to something like `g_devname`
in `src/mkwrggimg.c`. But I think the `_ANSI_SOURCE` define should be enough.

Compilation error is:

```
src/mkwrggimg.c:64:14: error: redefinition of 'devname' as different kind of symbol
static char *devname;
             ^
/usr/include/stdlib.h:286:7: note: previous definition is here
char    *devname(dev_t, mode_t);
         ^
src/mkwrggimg.c:147:12: error: non-object type 'char *(dev_t, mode_t)' (aka 'char *(int, unsigned short)') is not assignable
                        devname = optarg;
                        ~~~~~~~ ^
src/mkwrggimg.c:192:6: warning: comparison of function 'devname' equal to a null pointer is always false [-Wtautological-pointer-compare]
        if (devname == NULL) {
            ^~~~~~~    ~~~~
src/mkwrggimg.c:192:6: note: prefix with the address-of operator to silence this warning
        if (devname == NULL) {
            ^
            &
src/mkwrggimg.c:251:27: warning: incompatible pointer types passing 'char *(dev_t, mode_t)' (aka 'char *(int, unsigned short)') to parameter of type 'const char *' [-Wincompatible-pointer-types]
        strncpy(header->devname, devname, sizeof(header->devname));
                                 ^~~~~~~
/usr/include/secure/_string.h:119:34: note: expanded from macro 'strncpy'
  __builtin___strncpy_chk (dest, src, len, __darwin_obsz (dest))
```

Signed-off-by: Alexandru Ardelean ardeleanalex@gmail.com
