### PR TITLE
ppp: Remove the proto_set_keep in /lib/netifd/ppp-up

### DIFF
--- a/package/network/services/ppp/files/lib/netifd/ppp-up
+++ b/package/network/services/ppp/files/lib/netifd/ppp-up
@@ -3,7 +3,6 @@ PPP_IPPARAM="$6"
 
 . /lib/netifd/netifd-proto.sh
 proto_init_update "$IFNAME" 1 1
-proto_set_keep 1
 [ -n "$PPP_IPPARAM" ] && {
 	[ -n "$IPLOCAL" ] && proto_add_ipv4_address "$IPLOCAL" 32 "" "${IPREMOTE:-2.2.2.2}"
 	[ -n "$IPREMOTE" ] && proto_add_ipv4_route 0.0.0.0 0 "$IPREMOTE"


### PR DESCRIPTION
It fixes the issue when the PPP IPv4 link is coming up before
the PPP IPv6 link on the same interface. Indeed, the IPv4
name servers were duplicated in the resolv.conf file.

Signed-off-by: Pierre Lebleu pme.lebleu@gmail.com
