### PR TITLE
[RFC] ipq806x: workaround memory issue in Netgear R7800

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
@@ -7,8 +7,12 @@
 	compatible = "netgear,r7800", "qcom,ipq8065";
 
 	memory@0 {
-		reg = <0x42000000 0x1e000000>;
+		reg = <0x42000000 0x1de00000>;
 		device_type = "memory";
+		/*
+		 * Reducing memory size by 2 MiBs solves the problem with 
+		 * appearing kernel bug: bad_pag_state in process ... 
+		 */
 	};
 
 	reserved-memory {

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
@@ -7,12 +7,8 @@
 	compatible = "netgear,r7800", "qcom,ipq8065";
 
 	memory@0 {
-		reg = <0x42000000 0x1de00000>;
+		reg = <0x42000000 0x1e000000>;
 		device_type = "memory";
-		/*
-		 * Reducing memory size by 2 MiBs solves the problem with 
-		 * appearing kernel bug: bad_pag_state in process ... 
-		 */
 	};
 
 	reserved-memory {
@@ -22,6 +18,11 @@
 		rsvd@41200000 {
 			reg = <0x41200000 0x300000>;
 			no-map;
+		};
+
+		rsvd@5fe00000 {
+			reg = <0x5fe00000 0x200000>;
+			reusable;
 		};
 	};
 


### PR DESCRIPTION
KERNEL BUG: BAD_PAGE_STATE in process appears here and there during intensive memory usage.

https://bugs.lede-project.org/index.php?do=details&task_id=175

Reducing available memory by 2 MiBs workarounds the issue until further investigation.

Without these changes that bug appears rock steady at the same stage of boot process every boot.
Reducing total memory by 1 Mib moves the appearance of the bug onto later stage steadily again.
Reducing by 2 MiBs seems to solve the bug completely, at least i haven't met it for 3 days.
Also tested by crossflashing builds with different parameters to check if it's just a coincidence, but the above commit works in 100% cases, while other versions keep producing the above bug. I have even asked a panda to flash the device.

I have no idea what's in the end of the memory region or it just shifts memory usage somewhere in the middle.
