### PR TITLE
ar71xx: fix ethernet on wpj344 board

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-wpj344.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-wpj344.c
@@ -98,6 +98,7 @@ static struct ar8327_pad_cfg wpj344_ar8327_pad0_cfg = {
 	.rxclk_delay_en = true,
 	.txclk_delay_sel = AR8327_CLK_DELAY_SEL1,
 	.rxclk_delay_sel = AR8327_CLK_DELAY_SEL2,
+	.mac06_exchange_dis = true,
 };
 
 static struct ar8327_led_cfg wpj344_ar8327_led_cfg = {


### PR DESCRIPTION
In 814d70b2 the member mac06_exchange_en of struct
ar8327_pad_cfg was changed to mac06_exchange_dis,
but wpj344 was not adopted to stay in sync.

Signed-off-by: Christian Mehlis christian@m3hlis.de
Reported-by: Nick Dennis ndennis@rapiduswireless.com
