### PR TITLE
ramips: Archer C50: dts fix

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -85,11 +85,11 @@ c20i)
 	ucidef_set_led_wlan "wlan" "wlan" "$board:blue:wlan" "phy0radio"
 	;;
 c50)
-	ucidef_set_led_default "power" "power" "$board:blue:power" "0"
-	ucidef_set_led_netdev "lan" "lan" "$board:blue:lan" "eth0.2"
-	set_usb_led "$board:blue:usb"
-	ucidef_set_led_wlan "wlan2g" "wlan2g" "$board:blue:wlan2g" "phy1radio"
-	ucidef_set_led_wlan "wlan5g" "wlan5g" "$board:blue:wlan5g" "phy0radio"
+	ucidef_set_led_switch "lan" "lan" "$board:green:lan" "switch0" "0x1e"
+	ucidef_set_led_switch "wan" "wan" "$board:green:wan" "switch0" "0x01"
+	set_usb_led "$board:green:usb"
+	ucidef_set_led_netdev "wlan2g" "wlan2g" "$board:green:wlan2g" wlan1
+	set_wifi_led "$board:green:wlan5g"
 	;;
 cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "$board:white:ethernet" eth0.1

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -19,6 +19,7 @@ get_status_led() {
 	asl26555|\
 	br-6425|\
 	br-6475nd|\
+	c50|\
 	dch-m225|\
 	dir-860l-b1|\
 	e1700|\
@@ -86,9 +87,6 @@ get_status_led() {
 	sk-wb8|\
 	wrh-300cr)
 		status_led="$board:green:wps"
-		;;
-	c50)
-		status_led="tp-link:blue:power"
 		;;
 	cf-wr800n|\
 	psg1208)

--- a/target/linux/ramips/dts/ArcherC50.dts
+++ b/target/linux/ramips/dts/ArcherC50.dts
@@ -1,4 +1,6 @@
 /dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
 
 #include "mt7620a.dtsi"
 
@@ -14,28 +16,43 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "c50:blue:lan";
-			gpios = <&gpio0 1 1>;
+			label = "c50:green:lan";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
-			label = "c50:blue:power";
-			gpios = <&gpio0 7 0>;
+			label = "c50:green:power";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
-			label = "c50:blue:usb";
-			gpios = <&gpio0 9 1>;
+			label = "c50:green:usb";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "c50:green:wan";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "c50:orange:wan";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan5g {
-			label = "c50:blue:wlan5g";
-			gpios = <&gpio0 11 1>;
+			label = "c50:green:wlan5g";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan2g {
-			label = "c50:blue:wlan2g";
-			gpios = <&gpio3 0 1>;
+			label = "c50:green:wlan2g";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "c50:green:wps";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -47,15 +64,19 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 13 1>;
-			linux,code = <0x198>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
 		};
 
 		rfkill {
 			label = "rfkill";
-			gpios = <&gpio0 2 1>;
-			linux,code = <0xf7>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
 		};	};
+};
+
+&gpio1 {
+	status = "okay";
 };
 
 &gpio2 {
@@ -91,21 +112,25 @@
 		partition@7c0000 {
 			label = "config";
 			reg = <0x7c0000 0x10000>;
+			read-only;
 		};
 
 		rom: partition@7d0000 {
 			label = "rom";
 			reg = <0x7d0000 0x10000>;
+			read-only;
 		};
 
 		partition@7e0000 {
 			label = "romfile";
 			reg = <0x7e0000 0x10000>;
+			read-only;
 		};
 
 		radio: partition@7f0000 {
 			label = "radio";
 			reg = <0x7f0000 0x10000>;
+			read-only;
 		};
 	};
 };
@@ -113,15 +138,19 @@
 &pinctrl {
 	state_default: pinctrl0 {
 		gpio {
-			ralink,group = "i2c", "uartf", "rgmii1", "rgmii2", "wled", "nd_sd";
+			ralink,group = "i2c", "uartf", "rgmii1", "rgmii2", "wled", "ephy", "spi refclk", "mdio", "wdt", "nd_sd";
 			ralink,function = "gpio";
+		};
+
+		pa {
+			ralink,group = "pa";
+			ralink,function = "pa";
 		};
 	};
 };
 
 &ethernet {
 		pinctrl-names = "default";
-		pinctrl-0 = <&ephy_pins>;
 		mtd-mac-address = <&rom 0xf100>;
 		mediatek,portmap = "wllll";
 	};
@@ -151,6 +180,8 @@
 			device_type = "pci";
 			mediatek,mtd-eeprom = <&radio 32768>;
 			mediatek,2ghz = <0>;
+			mtd-mac-address = <&rom 0xf100>;
+			mtd-mac-address-increment = <(-1)>;
 		};
 	};
 };


### PR DESCRIPTION
- setting read-only flag to important partitions
- enabling PA to improve 2.4 GHz signal strength
- add missing leds
- rename colour led
- add mac adress to 5GHz wlan interface
- included <dt-bindings/input/input.h> and <dt-bindings/gpio/gpio.h>

Signed-off-by: Henryk Heisig hyniu@o2.pl
