### PR TITLE
ar71xx: Add net config for MR12 & MR16

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -73,6 +73,8 @@ ar71xx_setup_interfaces()
 	loco-m-xw|\
 	mr1750|\
 	mr1750v2|\
+	mr12|\
+	mr16|\
 	mr18|\
 	mr600|\
 	mr600v2|\


### PR DESCRIPTION
Both the MR12 and MR16 are single gigabit ethernet devices, similar to the MR18. This change gives them the correct network config on a fresh install.

Signed-off-by: Chris Blake chrisrblake93@gmail.com
