### PR TITLE
build: drop `trapret` function from non-Linux HOST_TAR variant

### DIFF
--- a/include/shell.sh
+++ b/include/shell.sh
@@ -14,21 +14,6 @@ isset() {
 	[ -n "$var" ]
 }
 
-trapret() {(
-	local retvals="$1"; shift
-	local cmd="$1"; shift
-	for retval in $(echo $retvals); do
-		local trap_$retval=1
-	done
-	"$cmd" "$@" || {
-		local retval="$?"
-		eval "trapped=\${trap_$retval}"
-		[ -n "$trapped" ] || {
-			return $retval
-		}
-	}
-)}
-
 md5s() {
 	cat "$@" | (
 		md5sum 2>/dev/null ||

--- a/include/unpack.mk
+++ b/include/unpack.mk
@@ -5,12 +5,7 @@
 # See /LICENSE for more information.
 #
 
-# unpacking files with +s may break on some platforms. this typically emits error code 2
-ifneq ($(HOST_OS),Linux)
-  HOST_TAR:=trapret 2 $(TAR)
-else
-  HOST_TAR:=$(TAR)
-endif
+HOST_TAR:=$(TAR)
 TAR_CMD=$(HOST_TAR) -C $(1)/.. $(TAR_OPTIONS)
 UNZIP_CMD=unzip -d $(1)/.. $(DL_DIR)/$(PKG_SOURCE)
 


### PR DESCRIPTION
Looks like this was meant to workaround some limitations with
non-GNU tar variants (like BSD-tar which are present on Mac os BSD hosts).

Though, I cannot find any use of that `+s` option that's mentioned
in the comment.

Last hash of this I found was 24faf55360271cd0bfc4751753384f9210d52f7f

In my case, it now this fails for `python-setuptools` on Mac OS X (the host-build with):
```
trapret 2 tar -C <home-dir>/work/sources-work/lede/build_dir/target-i386_pentium4_musl-1.1.15/python-setuptools-27.2.0 --strip-components=1 -xzf <home-dir>/work/sources-work/lede/dl/setuptools-27.2.0.tar.gz
bash: trapret: command not found
```

So, I was thinking maybe it's time to remove this workaround (9 years later).
I could also fix the `python-setuptools` host build. If that's more preferred.

[ Btw, I just recently transitioned to a Mac machine for dev-ing,
  so a lot of (this Mac) stuff I'm finding out is new to me too. ]

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>