### PR TITLE
ramips: Use MT7621 I2C driver for MT7628/MT7688

### DIFF
--- a/target/linux/ramips/modules.mk
+++ b/target/linux/ramips/modules.mk
@@ -47,7 +47,8 @@ I2C_RALINK_MODULES:= \
 define KernelPackage/i2c-ralink
   $(call i2c_defaults,$(I2C_RALINK_MODULES),59)
   TITLE:=Ralink I2C Controller
-  DEPENDS:=@TARGET_ramips @(!TARGET_ramips_mt7621) kmod-i2c-core
+  DEPENDS:=kmod-i2c-core @TARGET_ramips \
+	@!(TARGET_ramips_mt7621||TARGET_ramips_mt7628||TARGET_ramips_mt7688)
 endef
 
 define KernelPackage/i2c-ralink/description
@@ -63,7 +64,8 @@ I2C_MT7621_MODULES:= \
 define KernelPackage/i2c-mt7621
   $(call i2c_defaults,$(I2C_MT7621_MODULES),59)
   TITLE:=MT7621 I2C Controller
-  DEPENDS:=@TARGET_ramips @TARGET_ramips_mt7621 kmod-i2c-core
+  DEPENDS:=kmod-i2c-core \
+	@(TARGET_ramips_mt7621||TARGET_ramips_mt7628||TARGET_ramips_mt7688)
 endef
 
 define KernelPackage/i2c-mt7621/description


### PR DESCRIPTION
The i2c-ramips driver does not work for the MT7628/MT7688 SoCs, the
i2c-mt7621 driver does.

Signed-off-by: Sven Schwermer <sven.schwermer@arcor.de>