### PR TITLE
lantiq: Fix BAR11MASK when specifying mem= parameter in cmdline neede…

### DIFF
--- a/target/linux/lantiq/patches-4.4/0154-lantiq-pci-bar11mask-fix.patch
+++ b/target/linux/lantiq/patches-4.4/0154-lantiq-pci-bar11mask-fix.patch
@@ -1,0 +1,40 @@
+diff --git a/arch/mips/pci/pci-lantiq.c b/arch/mips/pci/pci-lantiq.c
+index 6a15dbd..c10ca7d 100644
+--- a/arch/mips/pci/pci-lantiq.c
++++ b/arch/mips/pci/pci-lantiq.c
+@@ -62,6 +62,8 @@
+ #define ltq_pci_cfg_w32(x, y)	ltq_w32((x), ltq_pci_mapped_cfg + (y))
+ #define ltq_pci_cfg_r32(x)	ltq_r32(ltq_pci_mapped_cfg + (x))
+ 
++extern u32 max_low_pfn;
++
+ __iomem void *ltq_pci_mapped_cfg;
+ static __iomem void *ltq_pci_membase;
+ 
+@@ -82,13 +84,24 @@ static struct pci_controller pci_controller = {
+ 	.io_offset	= 0x00000000UL,
+ };
+ 
++static u32 round_up_to_next_power_of_two(u32 x)
++{
++    x--;
++    x |= x >> 1;
++    x |= x >> 2;
++    x |= x >> 4;
++    x |= x >> 8;
++    x |= x >> 16;
++    x++;
++    return x;
++}
++
+ static inline u32 ltq_calc_bar11mask(void)
+ {
+ 	u32 mem, bar11mask;
+ 
+ 	/* BAR11MASK value depends on available memory on system. */
+-	mem = get_num_physpages() * PAGE_SIZE;
+-	bar11mask = (0x0ffffff0 & ~((1 << (fls(mem) - 1)) - 1)) | 8;
++	bar11mask =((-round_up_to_next_power_of_two((max_low_pfn << PAGE_SHIFT))) & 0x0F000000) | 8;
+ 
+ 	return bar11mask;
+ }


### PR DESCRIPTION
…d by vr9 platform to support tapi/vmmc/vpe

As specified by [PATCH 0/8] lantiq: vr9 fxs support: Enable FXS support for VR9 based routers, f the VR9 based router provides FXS ports and they shoud enabled then the following must added to the kernel command line:
mem=[TOTALMEMSIZE-2M] vpe1_load_addr=ADDRESS vpe1_mem=2M

By adding mem= parameter a pci device stop working correctly.
pci-lantiq.c module use  get_num_physpages() to compute dinamically the memory amount of the board.
the mem= make the module to compute in the wrong way the BAR11MASK, so in this situation the mask is misaligned with the dma area that the hardware expects.

This patch is a port of what legacy ifxmips_pci.c does.

Signed-off-by: Eddi De Pieri <eddi@depieri.net>