### PR TITLE
package/kernel/modules: add scsi-fusion and update some crypto modules

### DIFF
--- a/package/kernel/linux/modules/block.mk
+++ b/package/kernel/linux/modules/block.mk
@@ -527,3 +527,26 @@ define KernelPackage/scsi-tape
 endef
 
 $(eval $(call KernelPackage,scsi-tape))
+
+
+define KernelPackage/scsi-fusion
+  SUBMENU:=$(BLOCK_MENU)
+  TITLE:=Kernel support Fusion MPT
+  DEPENDS:=+kmod-scsi-core +kmod-libsas
+  KCONFIG:= \
+    CONFIG_FUSION=y \
+    CONFIG_FUSION_SPI=y \
+    CONFIG_FUSION_SAS=y \
+    CONFIG_FUSION_CTL=n \
+    CONFIG_FUSION_LOGGING=n \
+    CONFIG_FUSION_MAX_SGE=128
+  FILES:= \
+    $(LINUX_DIR)/drivers/message/fusion/mptbase.ko \
+    $(LINUX_DIR)/drivers/message/fusion/mptscsih.ko \
+    $(LINUX_DIR)/drivers/message/fusion/mptspi.ko \
+    $(LINUX_DIR)/drivers/message/fusion/mptsas.ko \
+    $(LINUX_DIR)/drivers/scsi/scsi_transport_spi.ko
+  AUTOLOAD:=$(call AutoLoad,41,mptbase mptscsih mptspi mptsas scsi_transport_spi,1)
+endef
+
+$(eval $(call KernelPackage,scsi-fusion))

--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -552,7 +552,8 @@ define KernelPackage/crypto-sha1
   DEPENDS:=+kmod-crypto-hash
   KCONFIG:= \
 	CONFIG_CRYPTO_SHA1 \
-	CONFIG_CRYPTO_SHA1_OCTEON
+	CONFIG_CRYPTO_SHA1_OCTEON \
+	CONFIG_CRYPTO_SHA1_SSSE3
   FILES:=$(LINUX_DIR)/crypto/sha1_generic.ko
   AUTOLOAD:=$(call AutoLoad,09,sha1_generic)
   $(call AddDepends/crypto)
@@ -563,6 +564,11 @@ define KernelPackage/crypto-sha1/octeon
   AUTOLOAD:=$(call AutoLoad,09,octeon-sha1)
 endef
 
+define KernelPackage/crypto-sha1/x86_64
+  FILES+=$(LINUX_DIR)/arch/x86/crypto/sha1-ssse3.ko
+  AUTOLOAD:=$(call AutoLoad,09,sha1-ssse3)
+endef
+
 $(eval $(call KernelPackage,crypto-sha1))
 
 
@@ -571,7 +577,8 @@ define KernelPackage/crypto-sha256
   DEPENDS:=+kmod-crypto-hash
   KCONFIG:= \
 	CONFIG_CRYPTO_SHA256 \
-	CONFIG_CRYPTO_SHA256_OCTEON
+	CONFIG_CRYPTO_SHA256_OCTEON \
+	CONFIG_CRYPTO_SHA256_SSSE3
   FILES:=$(LINUX_DIR)/crypto/sha256_generic.ko
   AUTOLOAD:=$(call AutoLoad,09,sha256_generic)
   $(call AddDepends/crypto)
@@ -582,6 +589,11 @@ define KernelPackage/crypto-sha256/octeon
   AUTOLOAD:=$(call AutoLoad,09,octeon-sha256)
 endef
 
+define KernelPackage/crypto-sha256/x86_64
+  FILES+=$(LINUX_DIR)/arch/x86/crypto/sha256-ssse3.ko
+  AUTOLOAD:=$(call AutoLoad,09,sha256-ssse3)
+endef
+
 $(eval $(call KernelPackage,crypto-sha256))
 
 
@@ -590,7 +602,8 @@ define KernelPackage/crypto-sha512
   DEPENDS:=+kmod-crypto-hash
   KCONFIG:= \
 	CONFIG_CRYPTO_SHA512 \
-	CONFIG_CRYPTO_SHA512_OCTEON
+	CONFIG_CRYPTO_SHA512_OCTEON \
+	CONFIG_CRYPTO_SHA512_SSSE3
   FILES:=$(LINUX_DIR)/crypto/sha512_generic.ko
   AUTOLOAD:=$(call AutoLoad,09,sha512_generic)
   $(call AddDepends/crypto)
@@ -599,6 +612,11 @@ endef
 define KernelPackage/crypto-sha512/octeon
   FILES+=$(LINUX_DIR)/arch/mips/cavium-octeon/crypto/octeon-sha512.ko
   AUTOLOAD:=$(call AutoLoad,09,octeon-sha512)
+endef
+
+define KernelPackage/crypto-sha512/x86_64
+  FILES+=$(LINUX_DIR)/arch/x86/crypto/sha512-ssse3.ko
+  AUTOLOAD:=$(call AutoLoad,09,sha512-ssse3)
 endef
 
 $(eval $(call KernelPackage,crypto-sha512))

--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -314,6 +314,25 @@ endef
 $(eval $(call KernelPackage,crypto-hw-omap))
 
 
+define KernelPackage/crypto-aes-ni
+  TITLE:=AES-NI CryptoAPI module
+  DEPENDS:=@TARGET_x86_64
+  KCONFIG:=CONFIG_CRYPTO_AES_NI_INTEL
+  FILES+=$(LINUX_DIR)/arch/x86/crypto/aes-x86_64.ko \
+	$(LINUX_DIR)/arch/x86/crypto/aesni-intel.ko \
+	$(LINUX_DIR)/arch/x86/crypto/glue_helper.ko \
+	$(LINUX_DIR)/crypto/ablk_helper.ko \
+	$(LINUX_DIR)/crypto/cryptd.ko \
+	$(LINUX_DIR)/crypto/gf128mul.ko \
+	$(LINUX_DIR)/crypto/xts.ko \
+	$(LINUX_DIR)/crypto/lrw.ko
+  AUTOLOAD:=$(call AutoLoad,09,cryptd ablk_helper gf128mul xts lrw aesni-intel)
+  $(call AddDepends/crypto,+kmod-crypto-manager +kmod-crypto-wq)
+endef
+
+$(eval $(call KernelPackage,crypto-aes-ni))
+
+
 define KernelPackage/crypto-authenc
   TITLE:=Combined mode wrapper for IPsec
   DEPENDS:=+kmod-crypto-manager +LINUX_4_4:kmod-crypto-null


### PR DESCRIPTION
@uweber to approve

We've added these kernel modules to our tree a while.
The scsi-fusion kernel module to better support VMware.

And the crypto updates to help better support some Intel HW extensions for doing crypto with ipsec.

Not sure if the LEDE community would want them in the main tree.
Hence this PR.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@riverbed.com>