### PR TITLE
ipq806x: TP-Link Archer C2600: convert old usbdev trigger to new usbport

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -12,8 +12,8 @@ board=$(ipq806x_board_name)
 
 case "$board" in
 c2600)
-	ucidef_set_led_usbdev "usb1" "USB 1" "${board}:white:usb_2" "2-1"
-	ucidef_set_led_usbdev "usb2" "USB 2" "${board}:white:usb_4" "4-1"
+	ucidef_set_led_usbport "usb1" "USB 1" "${board}:white:usb_2" "usb1-port1" "usb2-port1"
+	ucidef_set_led_usbport "usb2" "USB 2" "${board}:white:usb_4" "usb3-port1" "usb4-port1"
 	ucidef_set_led_netdev "wan" "WAN" "${board}:white:wan" "eth0"
 	ucidef_set_led_netdev "lan" "LAN" "${board}:white:lan" "br-lan"
 	ucidef_set_led_default "general" "general" "${board}:white:ledgnr" "1"


### PR DESCRIPTION
Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>