### PR TITLE
lantiq: cleanup dts files

### DIFF
--- a/target/linux/lantiq/dts/ARV4510PW.dts
+++ b/target/linux/lantiq/dts/ARV4510PW.dts
@@ -134,7 +134,6 @@
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 			req-mask = <0x7>;
 		};
-
 	};
 
 	gpio-keys-polled {

--- a/target/linux/lantiq/dts/ARV4518PWR01.dts
+++ b/target/linux/lantiq/dts/ARV4518PWR01.dts
@@ -4,12 +4,4 @@
 
 / {
 	model = "ARV4518PWR01 - SMC7908A-ISP";
-
-	fpi@10000000 {
-
-		pci@E105400 {
-			lantiq,internal-clock;
-		};
-
-	};
 };

--- a/target/linux/lantiq/dts/ARV4518PWR01.dtsi
+++ b/target/linux/lantiq/dts/ARV4518PWR01.dtsi
@@ -125,7 +125,6 @@
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 			req-mask = <0xf>;
 		};
-
 	};
 
 	gpio-keys-polled {

--- a/target/linux/lantiq/dts/ARV4518PWR01A.dts
+++ b/target/linux/lantiq/dts/ARV4518PWR01A.dts
@@ -6,10 +6,8 @@
 	model = "ARV4518PWR01A - SMC7908A-ISP, Airties WAV-221";
 
 	fpi@10000000 {
-
 		pci@E105400 {
 			lantiq,external-clock;
 		};
-
 	};
 };

--- a/target/linux/lantiq/dts/ARV4520PW.dts
+++ b/target/linux/lantiq/dts/ARV4520PW.dts
@@ -118,7 +118,7 @@
 
 		ifxhcd@E101000 {
 			status = "okay";
-                        gpios = <&gpio 28 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio 28 GPIO_ACTIVE_HIGH>;
 		};
 
 		pci@E105400 {
@@ -126,7 +126,6 @@
 			lantiq,external-clock;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 
 // gpiomm 10 - switch

--- a/target/linux/lantiq/dts/ARV4525PW.dts
+++ b/target/linux/lantiq/dts/ARV4525PW.dts
@@ -111,7 +111,6 @@
 			status = "okay";
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 
 /*

--- a/target/linux/lantiq/dts/ARV452CQW.dts
+++ b/target/linux/lantiq/dts/ARV452CQW.dts
@@ -135,7 +135,6 @@
 			lantiq,external-clock;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 
 /*

--- a/target/linux/lantiq/dts/ARV7518PW.dts
+++ b/target/linux/lantiq/dts/ARV7518PW.dts
@@ -144,7 +144,6 @@
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 			req-mask = <0xf>;
 		};
-
 	};
 
 /*

--- a/target/linux/lantiq/dts/ARV7519PW.dts
+++ b/target/linux/lantiq/dts/ARV7519PW.dts
@@ -125,7 +125,7 @@
 	ralink_eep {
 		compatible = "ralink,eeprom";
 		ralink,eeprom = "RT2860.eeprom";
-        };
+	};
 
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";

--- a/target/linux/lantiq/dts/ARV7519RW22.dts
+++ b/target/linux/lantiq/dts/ARV7519RW22.dts
@@ -91,11 +91,6 @@
 		pcie@d900000 {
 			status = "disabled";
 		};
-
-		pci@E105400 {
-			status = "disabled";
-			compatible = "lantiq,pci-xway";
-		};
 	};
 
 	gphy-xrx200 {

--- a/target/linux/lantiq/dts/ARV7525PW.dts
+++ b/target/linux/lantiq/dts/ARV7525PW.dts
@@ -100,9 +100,7 @@
 		pci@E105400 {
 			status = "okay";
 			interrupt-map = <0x7000 0 0 1 &icu0 135 1>;
-			req-mask = <0x1>;
 		};
-
 	};
 
 	gpio-keys-polled {

--- a/target/linux/lantiq/dts/ARV752DPW.dts
+++ b/target/linux/lantiq/dts/ARV752DPW.dts
@@ -143,7 +143,6 @@
 			interrupt-map = <0x7000 0 0 1 &icu0 135>;
 			req-mask = <0x3>;
 		};
-
 	};
 
 	ralink_eep {

--- a/target/linux/lantiq/dts/ARV752DPW22.dts
+++ b/target/linux/lantiq/dts/ARV752DPW22.dts
@@ -139,15 +139,14 @@
 			status = "okay";
 			lantiq,external-clock;
 			interrupt-map = <
-                                0x7000 0 0 1 &icu0 30
-		                0x7800 0 0 1 &icu0 135
-			        0x7800 0 0 2 &icu0 135
-			        0x7800 0 0 3 &icu0 135
+				0x7000 0 0 1 &icu0 30
+				0x7800 0 0 1 &icu0 135
+				0x7800 0 0 2 &icu0 135
+				0x7800 0 0 3 &icu0 135
 			>;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 			req-mask = <0x3>;
 		};
-
 	};
 
 	ralink_eep {

--- a/target/linux/lantiq/dts/ARV8539PW22.dts
+++ b/target/linux/lantiq/dts/ARV8539PW22.dts
@@ -72,7 +72,6 @@
 				ath,mac-increment = <1>;
 				ath,pci-slot = <14>;
 				ath,eep-endian;
-				ath,arv-ath9k-fix;
 			};
 		};
 
@@ -120,7 +119,6 @@
 			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 			lantiq,portmask = <0x3>;
 		};
-
 	};
 
 	gpio-keys-polled {

--- a/target/linux/lantiq/dts/BTHOMEHUBV2B.dts
+++ b/target/linux/lantiq/dts/BTHOMEHUBV2B.dts
@@ -30,15 +30,7 @@
 	};
 
 	fpi@10000000 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		localbus@0 {
-			#address-cells = <2>;
-			#size-cells = <1>;
-			ranges = <0 0 0x0 0x3ffffff /* addrsel0 */
-				1 0 0x4000000 0x4000010>; /* addsel1 */
-			compatible = "lantiq,localbus", "simple-bus";
-
 			nor-boot@0 {				/* NOR Flash: Spansion S29AL004D 512KB */
 				compatible = "lantiq,nor";	/* "AMD AM29LV400BB" compatible on 3.3.8 */
 				lantiq,cs = <0>;
@@ -111,7 +103,6 @@
 				};
 			};
 
-
 			ath9k_eep {
 				compatible = "ath9k,eeprom";
 				ath,eep-flash = <&ath9k_cal 0x0000>;
@@ -122,13 +113,8 @@
 		};
 
 		gpio: pinmux@E100B10 {
-			compatible = "lantiq,pinctrl-xway";
 			pinctrl-names = "default";
 			pinctrl-0 = <&state_default>;
-
-			#gpio-cells = <2>;
-			gpio-controller;
-			reg = <0xE100B10 0xA0>;
 
 			state_default: pinmux {
 				stp {
@@ -186,10 +172,6 @@
 		};
 
 		etop@E180000 {
-			compatible = "lantiq,etop-xway";
-			reg = <0xE180000 0x40000>;
-			interrupt-parent = <&icu0>;
-			interrupts = <73 78>;
 			phy-mode = "rmii";
 			mac-address = [ 00 11 22 33 44 55 ];
 		};
@@ -198,26 +180,14 @@
 			status = "okay";
 		};
 
-		stp0: stp@E100BB0 {
+		gpios: stp@E100BB0 {
 			status = "okay";
-			#gpio-cells = <2>;
-			compatible = "lantiq,gpio-stp-xway";
-			gpio-controller;
-			reg = <0xE100BB0 0x40>;
-
-			lantiq,shadow = <0xfff>;
-			lantiq,groups = <0x3>;
 		};
 
 		pci@E105400 {
 			status = "okay";
-			lantiq,bus-clock = <33333333>;
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <0x7000 0 0 1 &icu0 30 1>;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0x1>;		 /* GNT1 */
 		};
-
 	};
 
 	gpio-keys-polled {
@@ -248,52 +218,52 @@
 
 		upgrading-orange {
 			label = "bthomehubv2b:orange:upgrading";
-			gpios = <&stp0 5 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 5 GPIO_ACTIVE_HIGH>;
 		};
 
 		phone-orange {
 			label = "bthomehubv2b:orange:phone";
-			gpios = <&stp0 6 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 6 GPIO_ACTIVE_HIGH>;
 		};
 		phone-blue {
 			label = "bthomehubv2b:blue:phone";
-			gpios = <&stp0 7 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		wireless-orange {
 			label = "bthomehubv2b:orange:wireless";
-			gpios = <&stp0 8 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 8 GPIO_ACTIVE_HIGH>;
 		};
 		wireless_blue: wireless-blue {
 			label = "bthomehubv2b:blue:wireless";
-			gpios = <&stp0 9 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		broadband-red {
 			label = "bthomehubv2b:red:broadband";
-			gpios = <&stp0 10 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 10 GPIO_ACTIVE_HIGH>;
 		};
 		broadband-orange {
 			label = "bthomehubv2b:orange:broadband";
-			gpios = <&stp0 11 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 11 GPIO_ACTIVE_HIGH>;
 		};
 		broadband_blue: broadband-blue {
 			label = "bthomehubv2b:blue:broadband";
-			gpios = <&stp0 12 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 12 GPIO_ACTIVE_HIGH>;
 		};
 
 		power_red: power-red {
 			label = "bthomehubv2b:red:power";
-			gpios = <&stp0 13 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 13 GPIO_ACTIVE_HIGH>;
 		};
 		power_orange: power-orange {
 			label = "bthomehubv2b:orange:power";
-			gpios = <&stp0 14 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 14 GPIO_ACTIVE_HIGH>;
 			default-state = "keep";
 		};
 		power_blue: power-blue {
 			label = "bthomehubv2b:blue:power";
-			gpios = <&stp0 15 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpios 15 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/lantiq/dts/BTHOMEHUBV3A.dts
+++ b/target/linux/lantiq/dts/BTHOMEHUBV3A.dts
@@ -30,15 +30,7 @@
 	};
 
 	fpi@10000000 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		localbus@0 {
-			#address-cells = <2>;
-			#size-cells = <1>;
-			ranges = <0 0 0x0 0x3ffffff /* addrsel0 */
-				1 0 0x4000000 0x4000010>; /* addsel1 */
-			compatible = "lantiq,localbus", "simple-bus";
-
 			nand-parts@0 {		  /* NAND Flash: Samsung K9F5608U0D-JIB0 32MB */
 				compatible = "gen_nand", "lantiq,nand-xway";
 				lantiq,cs = <1>;
@@ -91,13 +83,8 @@
 		};
 
 		gpio: pinmux@E100B10 {
-			compatible = "lantiq,pinctrl-xr9";
 			pinctrl-names = "default";
 			pinctrl-0 = <&state_default>;
-
-			#gpio-cells = <2>;
-			gpio-controller;
-			reg = <0xE100B10 0xA0>;
 
 			state_default: pinmux {
 				nand_out {
@@ -150,7 +137,6 @@
 			status = "okay";
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 
 	gpio-keys-polled {
@@ -219,4 +205,3 @@
 		};
 	};
 };
-

--- a/target/linux/lantiq/dts/BTHOMEHUBV5A.dts
+++ b/target/linux/lantiq/dts/BTHOMEHUBV5A.dts
@@ -67,9 +67,6 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&state_default>;
 
-			interrupt-parent = <&icu0>;
-			interrupts = <166 135 66 40 41 42 38>;
-
 			state_default: pinmux {
 				mdio {
 					lantiq,groups = "mdio";
@@ -115,9 +112,6 @@
 
 		pci@E105400 {
 			status = "okay";
-			lantiq,bus-clock = <33333333>;
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <0x7000 0 0 1 &icu0 30 1>;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 		};
 	};

--- a/target/linux/lantiq/dts/DGN1000B.dts
+++ b/target/linux/lantiq/dts/DGN1000B.dts
@@ -104,6 +104,7 @@
 				};
 			};
 		};
+
 		ifxhcd@E101000 {
 			status = "okay";
 		};

--- a/target/linux/lantiq/dts/DGN3500.dtsi
+++ b/target/linux/lantiq/dts/DGN3500.dtsi
@@ -71,12 +71,7 @@
 
 		pci@E105400 {
 			status = "okay";
-
-			lantiq,bus-clock = <33333333>;
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <0x7000 0 0 1 &icu0 30 1>;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0x1>; /* GNT1 */
 		};
 	};
 
@@ -143,7 +138,7 @@
 			label = "dgn3500:red:power";
 			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
 		};
-        /*
+		/*
 			power amber is missing
 		*/
 		wifi: wifi {

--- a/target/linux/lantiq/dts/EASY50712.dts
+++ b/target/linux/lantiq/dts/EASY50712.dts
@@ -12,15 +12,7 @@
 	};
 
 	fpi@10000000 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		localbus@0 {
-			#address-cells = <2>;
-			#size-cells = <1>;
-			ranges = <0 0 0x0 0x3ffffff /* addrsel0 */
-				1 0 0x4000000 0x4000010>; /* addsel1 */
-			compatible = "lantiq,localbus", "simple-bus";
-
 			nor-boot@0 {
 				compatible = "lantiq,nor";
 				bank-width = <2>;
@@ -57,13 +49,8 @@
 		};
 
 		gpio: pinmux@E100B10 {
-			compatible = "lantiq,pinctrl-xway";
 			pinctrl-names = "default";
 			pinctrl-0 = <&state_default>;
-
-			#gpio-cells = <2>;
-			gpio-controller;
-			reg = <0xE100B10 0xA0>;
 
 			state_default: pinmux {
 				stp {
@@ -87,33 +74,8 @@
 		};
 
 		etop@E180000 {
-			compatible = "lantiq,etop-xway";
-			reg = <0xE180000 0x40000>;
-			interrupt-parent = <&icu0>;
-			interrupts = <73 78>;
 			phy-mode = "rmii";
 			mac-address = [ 00 11 22 33 44 55 ];
 		};
-
-		stp0: stp@E100BB0 {
-			#gpio-cells = <2>;
-			compatible = "lantiq,gpio-stp-xway";
-			gpio-controller;
-			reg = <0xE100BB0 0x40>;
-
-			lantiq,shadow = <0xfff>;
-			lantiq,groups = <0x3>;
-		};
-
-		pci@E105400 {
-			lantiq,bus-clock = <33333333>;
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <
-                                0x7000 0 0 1 &icu0 29 1 // slot 14, irq 29
-			>;
-			gpios-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0x1>;		/* GNT1 */
-		};
-
 	};
 };

--- a/target/linux/lantiq/dts/EASY50810.dts
+++ b/target/linux/lantiq/dts/EASY50810.dts
@@ -12,15 +12,7 @@
 	};
 
 	fpi@10000000 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		localbus@0 {
-			#address-cells = <2>;
-			#size-cells = <1>;
-			ranges = <0 0 0x0 0x3ffffff /* addrsel0 */
-				1 0 0x4000000 0x4000010>; /* addsel1 */
-			compatible = "lantiq,localbus", "simple-bus";
-
 			nor-boot@0 {
 				compatible = "lantiq,nor";
 				bank-width = <2>;
@@ -57,13 +49,8 @@
 		};
 
 		gpio: pinmux@E100B10 {
-			compatible = "lantiq,pinctrl-xr9";
 			pinctrl-names = "default";
 			pinctrl-0 = <&state_default>;
-
-			#gpio-cells = <2>;
-			gpio-controller;
-			reg = <0xE100B10 0xA0>;
 
 			state_default: pinmux {
 				stp {
@@ -87,11 +74,6 @@
 		};
 
 		etop@E180000 {
-			compatible = "lantiq,etop-xway";
-			reg = <0xE180000 0x40000
-				0xE108000 0x200>;
-			interrupt-parent = <&icu0>;
-			interrupts = <72 73>;
 			phy-mode = "rmii";
 			mac-address = [ 00 11 22 33 44 55 ];
 		};
@@ -105,16 +87,5 @@
 			lantiq,shadow = <0xfff>;
 			lantiq,groups = <0x3>;
 		};
-
-		pci@E105400 {
-			lantiq,bus-clock = <33333333>;
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <
-                                0x7000 0 0 1 &icu0 29 1 // slot 14, irq 29
-			>;
-			gpios-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0x1>;		/* GNT1 */
-		};
-
 	};
 };

--- a/target/linux/lantiq/dts/EASY80920.dtsi
+++ b/target/linux/lantiq/dts/EASY80920.dtsi
@@ -19,30 +19,9 @@
 	};
 
 	fpi@10000000 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "lantiq,fpi", "simple-bus";
-		ranges = <0x0 0x10000000 0xEEFFFFF>;
-		reg = <0x10000000 0xEF00000>;
-
-		localbus@0 {
-			#address-cells = <2>;
-			#size-cells = <1>;
-			compatible = "lantiq,localbus", "simple-bus";
-
-		};
-
 		gpio: pinmux@E100B10 {
-			compatible = "lantiq,pinctrl-xr9";
 			pinctrl-names = "default";
 			pinctrl-0 = <&state_default>;
-
-			interrupt-parent = <&icu0>;
-			interrupts = <166 135 66 40 41 42 38>;
-
-			#gpio-cells = <2>;
-			gpio-controller;
-			reg = <0xE100B10 0xA0>;
 
 			state_default: pinmux {
 				exin3 {
@@ -118,28 +97,6 @@
 			status = "okay";
 			gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 			lantiq,portmask = <0x3>;
-		};
-
-		pci@E105400 {
-			#address-cells = <3>;
-			#size-cells = <2>;
-			#interrupt-cells = <1>;
-			compatible = "lantiq,pci-xway1";
-			bus-range = <0x0 0x0>;
-			ranges = <0x2000000 0 0x8000000 0x8000000 0 0x2000000   /* pci memory */
-				0x1000000 0 0x00000000 0xAE00000 0 0x200000>; /* io space */
-			reg = <0x7000000 0x8000         /* config space */
-				0xE105400 0x400>;       /* pci bridge */
-			lantiq,bus-clock = <33333333>;
-			/*lantiq,external-clock;*/
-			lantiq,delay-hi = <0>; /* 0ns delay */
-			lantiq,delay-lo = <0>; /* 0.0ns delay */
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <
-				0x7000 0 0 1 &icu0 29 1 // slot 14, irq 29
-				>;
-			gpios-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0x1>;	/* GNT1 */
 		};
 	};
 

--- a/target/linux/lantiq/dts/FRITZ7320.dts
+++ b/target/linux/lantiq/dts/FRITZ7320.dts
@@ -106,11 +106,7 @@
 		pci@E105400 {
 			status = "okay";
 			req-mask = <0xf>;
-			lantiq,bus-clock = <33333333>;
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <0x7000 0 0 1 &icu0 30 1>;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0xf>; /* GNT1 */
 		};
 	};
 

--- a/target/linux/lantiq/dts/GIGASX76X.dts
+++ b/target/linux/lantiq/dts/GIGASX76X.dts
@@ -89,9 +89,7 @@
 
 		pci@E105400 {
 			status = "okay";
-			lantiq,internal-clock;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0x1>;
 		};
 	};
 

--- a/target/linux/lantiq/dts/P2601HNFX.dts
+++ b/target/linux/lantiq/dts/P2601HNFX.dts
@@ -24,15 +24,7 @@
 	};
 
 	fpi@10000000 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		localbus@0 {
-			#address-cells = <2>;
-			#size-cells = <1>;
-			ranges = <0 0 0x0 0x3ffffff
-				  1 0 0x4000000 0x4000010>;
-			compatible = "lantiq,localbus", "simple-bus";
-
 			nor-boot@0 {
 				compatible = "lantiq,nor";
 				bank-width = <2>;
@@ -66,13 +58,8 @@
 		};
 
 		gpio: pinmux@E100B10 {
-			compatible = "lantiq,pinctrl-xr9";
 			pinctrl-names = "default";
 			pinctrl-0 = <&state_default>;
-
-			#gpio-cells = <2>;
-			gpio-controller;
-			reg = <0xE100B10 0xA0>;
 
 			state_default: pinmux {
 				stp {
@@ -119,14 +106,6 @@
 
 			lantiq,shadow = <0xfff>;
 			lantiq,groups = <0x3>;
-		};
-
-		pci@E105400 {
-			lantiq,bus-clock = <33333333>;
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <0x7000 0 0 1 &icu0 29 1>;
-			gpios-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0x1>;
 		};
 	};
 

--- a/target/linux/lantiq/dts/P2812HNUF1.dts
+++ b/target/linux/lantiq/dts/P2812HNUF1.dts
@@ -44,6 +44,7 @@
 				};
 			};
 		};
+
 		pcie@d900000 {
 			status = "disabled";
 		};

--- a/target/linux/lantiq/dts/P2812HNUFX.dtsi
+++ b/target/linux/lantiq/dts/P2812HNUFX.dtsi
@@ -19,32 +19,10 @@
 		reg = <0x0 0x8000000>;
 	};
 
-        fpi@10000000 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "lantiq,fpi", "simple-bus";
-		ranges = <0x0 0x10000000 0xEEFFFFF>;
-		reg = <0x10000000 0xEF00000>;
-
-		localbus@0 {
-			#address-cells = <2>;
-			#size-cells = <1>;
-			ranges = <0 0 0x0 0x3ffffff /* addrsel0 */
-				1 0 0x4000000 0x4000010>; /* addsel1 */
-			compatible = "lantiq,localbus", "simple-bus";
-		};
-
+	fpi@10000000 {
 		gpio: pinmux@E100B10 {
-			compatible = "lantiq,pinctrl-xr9";
 			pinctrl-names = "default";
 			pinctrl-0 = <&state_default>;
-
-			interrupt-parent = <&icu0>;
-			interrupts = <166 135 66 40 41 42 38>;
-
-			#gpio-cells = <2>;
-			gpio-controller;
-			reg = <0xE100B10 0xA0>;
 
 			state_default: pinmux {
 				exin3 {
@@ -143,25 +121,7 @@
 
 		pci@E105400 {
 			status = "okay";
-			#address-cells = <3>;
-			#size-cells = <2>;
-			#interrupt-cells = <1>;
-			compatible = "lantiq,pci-xway";
-			bus-range = <0x0 0x0>;
-			ranges = <0x2000000 0 0x8000000 0x8000000 0 0x2000000   /* pci memory */
-				0x1000000 0 0x00000000 0xAE00000 0 0x200000>; /* io space */
-			reg = <0x7000000 0x8000         /* config space */
-				0xE105400 0x400>;       /* pci bridge */
-			lantiq,bus-clock = <33333333>;
-			/*lantiq,external-clock;*/
-			lantiq,delay-hi = <0>; /* 0ns delay */
-			lantiq,delay-lo = <0>; /* 0.0ns delay */
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <
-				0x7000 0 0 1 &icu0 30 1 // slot 14, irq 30
-				>;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0x1>;	/* GNT1 */
 		};
 	};
 

--- a/target/linux/lantiq/dts/TDW89X0.dtsi
+++ b/target/linux/lantiq/dts/TDW89X0.dtsi
@@ -120,7 +120,7 @@
 		compatible = "gpio-leds";
 		/*
 			power is not controllable via gpio
-        */
+		*/
 		dsl: dsl {
 			label = "tdw89x0:green:dsl";
 			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;

--- a/target/linux/lantiq/dts/VGV7510KW22.dtsi
+++ b/target/linux/lantiq/dts/VGV7510KW22.dtsi
@@ -77,13 +77,7 @@
 
 		pci@E105400 {
 			status = "okay";
-			lantiq,bus-clock = <33333333>;
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <
-				0x7000 0 0 1 &icu0 30 1 // slot 14, irq 30
-				>;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0x1>;	/* GNT1 */
 		};
 
 		pcie@d900000 {

--- a/target/linux/lantiq/dts/VGV7519.dtsi
+++ b/target/linux/lantiq/dts/VGV7519.dtsi
@@ -2,7 +2,7 @@
 
 / {
 
-    model = "VGV7519 - KPN Experiabox V8";
+	model = "VGV7519 - KPN Experiabox V8";
 
 	chosen {
 		bootargs = "console=ttyLTQ0,115200 init=/etc/preinit";
@@ -104,13 +104,7 @@
 
 		pci@E105400 {
 			status = "okay";
-			lantiq,bus-clock = <33333333>;
-			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <
-				0x7000 0 0 1 &icu0 30 1 // slot 14, irq 30
-				>;
 			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			req-mask = <0x1>;	/* GNT1 */
 		};
 
 		pcie@d900000 {

--- a/target/linux/lantiq/dts/danube.dtsi
+++ b/target/linux/lantiq/dts/danube.dtsi
@@ -197,8 +197,8 @@
 				0xE105400 0x400>;	/* pci bridge */
 			lantiq,bus-clock = <33333333>;
 			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-			interrupt-map = <0x7000 0 0 1 &icu0 30 1>;
-			req-mask = <0x1>;
+			interrupt-map = <0x7000 0 0 1 &icu0 30 1>; /* slot 14, irq 30 */
+			req-mask = <0x1>; /* GNT1 */
 		};
 	};
 

--- a/target/linux/lantiq/dts/vr9.dtsi
+++ b/target/linux/lantiq/dts/vr9.dtsi
@@ -219,6 +219,8 @@
 		};
 
 		pci0: pci@E105400 {
+			status = "disabled";
+
 			#address-cells = <3>;
 			#size-cells = <2>;
 			#interrupt-cells = <1>;
@@ -228,7 +230,10 @@
 				0x1000000 0 0x00000000 0xAE00000 0 0x200000>; /* io space */
 			reg = <0x7000000 0x8000         /* config space */
 				0xE105400 0x400>;       /* pci bridge */
-			status = "disabled";
+			lantiq,bus-clock = <33333333>;
+			interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
+			interrupt-map = <0x7000 0 0 1 &icu0 30 1>; /* slot 14, irq 30 */
+			req-mask = <0x1>; /* GNT1 */
 		};
 	};
 


### PR DESCRIPTION
- remove not existing properties
- remove properties having the same values as the included dtsi
- remove nodes which are disabled in the included dtsi and not enabled
  in dts
- replace the deprecated pinctrl-* compatible strings
- use the same labels for nodes as the included dtsi
- move common used vr9 pci properties to vr9.dtsi
- fix spaces vs. tabs and remove superfluous linebreaks