### PR TITLE
comgt: move to WWAN submenu, fixed link

### DIFF
--- a/package/network/utils/comgt/Makefile
+++ b/package/network/utils/comgt/Makefile
@@ -24,15 +24,16 @@ PKG_CHECK_FORMAT_SECURITY:=0
 include $(INCLUDE_DIR)/package.mk
 
 define Package/comgt/Default
-  SECTION:=utils
-  CATEGORY:=Utilities
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=WWAN
 endef
 
 define Package/comgt
 $(call Package/comgt/Default)
   TITLE:=Option/Vodafone 3G/GPRS control tool
   DEPENDS:=+chat
-  URL:=http://www.pharscape.org/comgt.html
+  URL:=http://manpages.ubuntu.com/manpages/trusty/man1/comgt.1.html
 endef
 
 define Package/comgt-directip


### PR DESCRIPTION
moving comgt and its modules to WWAN submenu to join uqmi as both are tools for WWAN modems.

I replaced the link with comgt's ubuntu manpage because the old link isn't working anymore.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>