### PR TITLE
yamonenv: move to Boot Loaders submenu

### DIFF
--- a/package/boot/yamonenv/Makefile
+++ b/package/boot/yamonenv/Makefile
@@ -22,6 +22,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/yamonenv
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Boot Loaders
   DEPENDS:=@TARGET_au1000
   TITLE:=YAMON configuration utility
   URL:=http://meshcube.org/nylon/stable/sources/


### PR DESCRIPTION
Boot Loaders submenu is the place where all other boot loaders are.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>