### PR TITLE
mdadm: move to Disc submenu

### DIFF
--- a/package/utils/mdadm/Makefile
+++ b/package/utils/mdadm/Makefile
@@ -24,6 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/mdadm
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Disc
   TITLE:=A tool for managing Soft RAID under Linux
   URL:=http://www.kernel.org/pub/linux/utils/raid/mdadm/
   DEPENDS:=+@KERNEL_DIRECT_IO


### PR DESCRIPTION
As in Disc there is also lvm2 and other hard drive tools in the Openwrt package feeds.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>