### PR TITLE
ipq806x: fix pcie reset gpios

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
@@ -830,7 +830,7 @@
 			pinctrl-0 = <&pcie0_pins>;
 			pinctrl-names = "default";
 
-			perst-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_LOW>;
+			perst-gpios = <&qcom_pinmux 3 GPIO_ACTIVE_LOW>;
 
 			status = "disabled";
 		};
@@ -882,7 +882,7 @@
 			pinctrl-0 = <&pcie1_pins>;
 			pinctrl-names = "default";
 
-			perst-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_LOW>;
+			perst-gpios = <&qcom_pinmux 48 GPIO_ACTIVE_LOW>;
 
 			status = "disabled";
 		};
@@ -934,7 +934,7 @@
 			pinctrl-0 = <&pcie2_pins>;
 			pinctrl-names = "default";
 
-			perst-gpio = <&qcom_pinmux 63 GPIO_ACTIVE_LOW>;
+			perst-gpios = <&qcom_pinmux 63 GPIO_ACTIVE_LOW>;
 
 			status = "disabled";
 		};

--- a/target/linux/ipq806x/patches-4.4/112-ARM-dts-qcom-add-pcie-nodes-to-ipq806x-platforms.patch
+++ b/target/linux/ipq806x/patches-4.4/112-ARM-dts-qcom-add-pcie-nodes-to-ipq806x-platforms.patch
@@ -143,7 +143,7 @@ Signed-off-by: Mathieu Olivari <mathieu@codeaurora.org>
 +			pinctrl-0 = <&pcie0_pins>;
 +			pinctrl-names = "default";
 +
-+			perst-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_LOW>;
++			perst-gpios = <&qcom_pinmux 3 GPIO_ACTIVE_LOW>;
 +
 +			status = "disabled";
 +		};
@@ -189,7 +189,7 @@ Signed-off-by: Mathieu Olivari <mathieu@codeaurora.org>
 +			pinctrl-0 = <&pcie1_pins>;
 +			pinctrl-names = "default";
 +
-+			perst-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_LOW>;
++			perst-gpios = <&qcom_pinmux 48 GPIO_ACTIVE_LOW>;
 +
 +			status = "disabled";
 +		};
@@ -235,7 +235,7 @@ Signed-off-by: Mathieu Olivari <mathieu@codeaurora.org>
 +			pinctrl-0 = <&pcie2_pins>;
 +			pinctrl-names = "default";
 +
-+			perst-gpio = <&qcom_pinmux 63 GPIO_ACTIVE_LOW>;
++			perst-gpios = <&qcom_pinmux 63 GPIO_ACTIVE_LOW>;
 +
 +			status = "disabled";
 +		};


### PR DESCRIPTION
Fix perst-gpios property in accordance to the driver, so it stops spamming that it can't parse it.

Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>