### PR TITLE
dnsmasq: Support add-mac option

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.76
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -659,6 +659,12 @@ dnsmasq_start()
 		append_bool "$cfg" dnsseccheckunsigned "--dnssec-check-unsigned"
 	}
 
+	config_get addmac "$cfg" addmac 0
+	[ "$addmac" != "0" ] && {
+		[ "$addmac" = "1" ] && addmac=
+		xappend "--add-mac${addmac:+="$addmac"}"
+	}
+
 	dhcp_option_add "$cfg" "" 0
 
 	xappend "--dhcp-broadcast=tag:needs-broadcast"


### PR DESCRIPTION
Adds the mac address of the DNS requestor to DNS queries which
are forwarded upstream and can be used to do filtering by the
upstream servers. This only works if the requestor is on the
same subnet as the dnsmasq server

The addmac parameter can hold the following values:
	0 : mac address is not added
	1 : mac address is added in binary format
	base64 : mac address is added base64 encoded
	text: : mac address is added in human readable format
		as hex and colons

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>