### PR TITLE
devel/strace: fix build on mpc85xx target

### DIFF
--- a/package/devel/strace/patches/100-workaround--pt-reg-collisions-ppc.patch
+++ b/package/devel/strace/patches/100-workaround--pt-reg-collisions-ppc.patch
@@ -1,0 +1,14 @@
+--- a/ptrace.h
++++ b/ptrace.h
+@@ -52,7 +52,10 @@ extern long ptrace(int, int, char *, long);
+ # define ptrace_peeksiginfo_args XXX_ptrace_peeksiginfo_args
+ #endif
+ 
++#include <linux/types.h>
++#define __ASSEMBLY__
+ #include <linux/ptrace.h>
++#undef __ASSEMBLY__
+ 
+ #ifdef HAVE_STRUCT_IA64_FPREG
+ # undef ia64_fpreg
+-- 


### PR DESCRIPTION
builbot faillog:
https://downloads.lede-project.org/snapshots/faillogs/powerpc_8540/base/strace/compile.txt

Seems that for PPC, the <linux/ptrace.h> header [from uapi] collides
with musl's <sys/user.h>, for the pt_regs struct.

Seems I tried to upstream this patch a while back:
https://lists.openwrt.org/pipermail/openwrt-devel/2016-April/041093.html

It seems to work on current LEDE trunk too.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>