### PR TITLE
comgt: Fix  'mode' option for proto ncm

### DIFF
--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -118,7 +118,7 @@ proto_ncm_setup() {
 	[ -n "$mode" ] && {
 		json_select modes
 		json_get_var setmode "$mode"
-		COMMAND="$setmode" gcom -d "$device" -s /etc/gcom/runcommand.gcom || {
+		eval COMMAND="$setmode" gcom -d "$device" -s /etc/gcom/runcommand.gcom || {
 			echo "Failed to set operating mode"
 			proto_notify_error "$interface" SETMODE_FAILED
 			return 1


### PR DESCRIPTION
For Huawei devices like E3372 proper command for set lte mode is:

`AT^SYSCFGEX="03",3fffffff,2,4,7fffffffffffffff,,`

Eval is required for proper quotation.

Without this fix:

```
Fri Nov  4 19:07:49 2016 daemon.notice netifd: Interface 'wan' is setting up now
Fri Nov  4 19:07:52 2016 daemon.notice netifd: wan (2060): sending -> AT
Fri Nov  4 19:07:52 2016 daemon.notice netifd: wan (2060): sending -> ATZ
Fri Nov  4 19:07:53 2016 daemon.notice netifd: wan (2060): sending -> ATQ0
Fri Nov  4 19:07:53 2016 daemon.notice netifd: wan (2060): sending -> ATV1
Fri Nov  4 19:07:54 2016 daemon.notice netifd: wan (2060): sending -> ATE1
Fri Nov  4 19:07:55 2016 daemon.notice netifd: wan (2060): sending -> ATS0=0
Fri Nov  4 19:07:55 2016 daemon.notice netifd: wan (2060): sending -> AT+CGDCONT=1,"IP","internet"
Fri Nov  4 19:07:57 2016 daemon.notice netifd: wan (2060): sending -> AT^SYSCFGEX=\"03\",3fffffff,2,4,7fffffffffffffff,,
Fri Nov  4 19:07:58 2016 daemon.notice netifd: wan (2060): Error running AT-command
Fri Nov  4 19:07:58 2016 daemon.notice netifd: wan (2060): Failed to set operating mode
Fri Nov  4 19:07:58 2016 daemon.notice netifd: wan (2092): Stopping network
...
```

With this fix:

```
Fri Nov  4 19:10:59 2016 daemon.notice netifd: Interface 'wan' is setting up now
Fri Nov  4 19:11:01 2016 daemon.notice netifd: wan (2539): sending -> AT
Fri Nov  4 19:11:01 2016 daemon.notice netifd: wan (2539): sending -> ATZ
Fri Nov  4 19:11:02 2016 daemon.notice netifd: wan (2539): sending -> ATQ0
Fri Nov  4 19:11:03 2016 daemon.notice netifd: wan (2539): sending -> ATV1
Fri Nov  4 19:11:03 2016 daemon.notice netifd: wan (2539): sending -> ATE1
Fri Nov  4 19:11:04 2016 daemon.notice netifd: wan (2539): sending -> ATS0=0
Fri Nov  4 19:11:05 2016 daemon.notice netifd: wan (2539): sending -> AT+CGDCONT=1,"IP","internet"
Fri Nov  4 19:11:06 2016 daemon.notice netifd: wan (2539): sending -> AT^SYSCFGEX="03",3fffffff,2,4,7fffffffffffffff,,
Fri Nov  4 19:11:07 2016 daemon.notice netifd: wan (2539): sending -> AT^NDISDUP=1,1,"internet"
Fri Nov  4 19:11:08 2016 daemon.notice netifd: wan (2539): Connected, starting DHCP on wwan0
Fri Nov  4 19:11:08 2016 daemon.notice netifd: Interface 'wan' is now up
Fri Nov  4 19:11:08 2016 daemon.notice netifd: Network device 'wwan0' link is up
Fri Nov  4 19:11:08 2016 daemon.notice netifd: Network alias 'wwan0' link is up
Fri Nov  4 19:11:08 2016 daemon.notice netifd: Interface 'wan_4' is enabled
Fri Nov  4 19:11:08 2016 daemon.notice netifd: Interface 'wan_4' has link connectivity
Fri Nov  4 19:11:08 2016 daemon.notice netifd: Interface 'wan_4' is setting up now
...
```

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>