### PR TITLE
ramips: Add support for Wavlink WL-WN575A3

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -312,6 +312,12 @@ whr-600d)
 	ucidef_set_led_default "power" "power" "$board:green:power" "1"
 	ucidef_set_led_default "router" "router" "$board:green:router" "1"
 	;;
+wl-wn575a3)
+	ucidef_set_rssimon "wlan1" "40000" "1"
+	ucidef_set_led_rssi "wifi-low" "wifi-low" "$board:green:wifi-low" "wlan1" "1" "49" "0" "1"
+	ucidef_set_led_rssi "wifi-med" "wifi-med" "$board:green:wifi-med" "wlan1" "50" "84" "0" "1"
+	ucidef_set_led_rssi "wifi-high" "wifi-high" "$board:green:wifi-high" "wlan1" "85" "100" "0" "1"
+	;;
 wrh-300cr)
 	set_wifi_led "$board:green:wlan"
 	ucidef_set_led_netdev "lan" "lan" "$board:green:ethernet" "eth0"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -90,6 +90,7 @@ ramips_setup_interfaces()
 	whr-300hp2|\
 	whr-600d|\
 	witi|\
+	wl-wn575a3|\
 	wndr3700v5|\
 	wsr-1166|\
 	wsr-600|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -499,6 +499,9 @@ ramips_board_detect() {
 	*"WL-351 v1 002")
 		name="wl-351"
 		;;
+	*"WL-WN575A3")
+		name="wl-wn575a3"
+		;;
 	*"WLI-TX4-AG300N")
 		name="wli-tx4-ag300n"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -145,6 +145,7 @@ platform_check_image() {
 	wl-330n3g|\
 	wl-341v3|\
 	wl-351|\
+	wl-wn575a3|\
 	wli-tx4-ag300n|\
 	wmr-300|\
 	wnce2001|\

--- a/target/linux/ramips/dts/WL-WN575A3.dts
+++ b/target/linux/ramips/dts/WL-WN575A3.dts
@@ -1,0 +1,130 @@
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7628an.dtsi"
+
+/ {
+	compatible = "wavlink,wl-wn575a3", "mediatek,mt7628an-soc";
+	model = "Wavlink WL-WN575A3";
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wifi-high {
+			label = "wl-wn575a3:green:wifi-high";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-med {
+			label = "wl-wn575a3:green:wifi-med";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-low {
+			label = "wl-wn575a3:green:wifi-low";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wl-wn575a3:green:wps";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+	pcie-bridge {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			mediatek,2ghz = <0>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80", "en25q64";
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x7b0000>;
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	ralink,mtd-eeprom = <&factory 0x4>;
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x2e>;
+	ralink,port-map = "llllw";
+};

--- a/target/linux/ramips/image/mt7628.mk
+++ b/target/linux/ramips/image/mt7628.mk
@@ -19,6 +19,13 @@ define Device/miwifi-nano
 endef
 TARGET_DEVICES += miwifi-nano
 
+define Device/wl-wn575a3
+  DTS := WL-WN575A3
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  DEVICE_TITLE := Wavlink WL-WN575A3
+endef
+TARGET_DEVICES += wl-wn575a3
+
 define Device/wrtnode2p
   DTS := WRTNODE2P
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
This commit adds support for the Wavlink WL-WN575A3, a dual-band wall-plug
wireless router with the following specifications:

 - CPU: MediaTek MT7628AN 580MHz
 - Flash: 8MB
 - RAM: 64MB
 - Ethernet: 2x 10/100 Mbps (switched)
 - 2.4 GHz: 802.11b/g/n SoC, MIMO 2x2, 20 dBm
 - 5 GHz: 802.11a/n/ac MT7612E, MIMO 2x2, 20 dBm
 - Antennas: 4x external (2 per radio), non-detachable
 - LEDs: 4 programmable + LAN, WAN, POWER
 - Buttons: reset, WPS

Flashing instructions:

Factory U-boot launches a TFTP client if WPS button is pressed during power-on.
Rename the sysupgrade file and configure a TFTP as follows:

 - Client (WL-WN575A3) IP: 192.168.10.101
 - Server IP: 192.168.10.100
 - Filename: firmware.bin

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>