### PR TITLE
toolchain: Fix for gcc built with glibc and gccgo

### DIFF
--- a/toolchain/gcc/patches/5.4.0/931-fix-MIPS-softfloat-build-issue.patch
+++ b/toolchain/gcc/patches/5.4.0/931-fix-MIPS-softfloat-build-issue.patch
@@ -1,0 +1,174 @@
+From 2b46f9187b6f994fc450628a7cd97fc703dd23e0 Mon Sep 17 00:00:00 2001
+From: BangLang Huang <banglang.huang@foxmail.com>
+Date: Wed, 9 Nov 2016 10:36:49 +0800
+Subject: [PATCH] fix MIPS softfloat build issue
+
+    This patch is backport from github/libffi #272
+
+Signed-off-by: BangLang Huang <banglang.huang@foxmail.com>
+---
+ libffi/src/mips/n32.S | 17 +++++++++++++++++
+ libffi/src/mips/o32.S | 17 +++++++++++++++++
+ 2 files changed, 34 insertions(+)
+
+diff --git a/libffi/src/mips/n32.S b/libffi/src/mips/n32.S
+index c6985d3..8f25994 100644
+--- a/libffi/src/mips/n32.S
++++ b/libffi/src/mips/n32.S
+@@ -107,6 +107,16 @@ loadregs:
+ 
+ 	REG_L	t6, 3*FFI_SIZEOF_ARG($fp)  # load the flags word into t6.
+ 
++#ifdef __mips_soft_float
++	REG_L	a0, 0*FFI_SIZEOF_ARG(t9)
++	REG_L	a1, 1*FFI_SIZEOF_ARG(t9)
++	REG_L	a2, 2*FFI_SIZEOF_ARG(t9)
++	REG_L	a3, 3*FFI_SIZEOF_ARG(t9)
++	REG_L	a4, 4*FFI_SIZEOF_ARG(t9)
++	REG_L	a5, 5*FFI_SIZEOF_ARG(t9)
++	REG_L	a6, 6*FFI_SIZEOF_ARG(t9)
++	REG_L	a7, 7*FFI_SIZEOF_ARG(t9)
++#else
+ 	and	t4, t6, ((1<<FFI_FLAG_BITS)-1)
+ 	REG_L	a0, 0*FFI_SIZEOF_ARG(t9)
+ 	beqz	t4, arg1_next
+@@ -193,6 +203,7 @@ arg7_next:
+ arg8_doublep:	
+  	l.d	$f19, 7*FFI_SIZEOF_ARG(t9)	
+ arg8_next:	
++#endif
+ 
+ callit:		
+ 	# Load the function pointer
+@@ -214,6 +225,7 @@ retint:
+ 	b	epilogue
+ 
+ retfloat:
++#ifndef __mips_soft_float
+ 	bne     t6, FFI_TYPE_FLOAT, retdouble
+ 	jal	t9
+ 	REG_L	t4, 4*FFI_SIZEOF_ARG($fp)
+@@ -272,6 +284,7 @@ retstruct_f_d:
+ 	s.s	$f0, 0(t4)
+ 	s.d	$f2, 8(t4)
+ 	b	epilogue
++#endif
+ 
+ retstruct_d_soft:
+ 	bne	t6, FFI_TYPE_STRUCT_D_SOFT, retstruct_f_soft
+@@ -429,6 +442,7 @@ ffi_closure_N32:
+ 	REG_S	a6, A6_OFF2($sp)
+ 	REG_S	a7, A7_OFF2($sp)
+ 
++#ifndef __mips_soft_float
+ 	# Store all possible float/double registers.
+ 	s.d	$f12, F12_OFF2($sp)
+ 	s.d	$f13, F13_OFF2($sp)
+@@ -438,6 +452,7 @@ ffi_closure_N32:
+ 	s.d	$f17, F17_OFF2($sp)
+ 	s.d	$f18, F18_OFF2($sp)
+ 	s.d	$f19, F19_OFF2($sp)
++#endif
+ 
+ 	# Call ffi_closure_mips_inner_N32 to do the real work.
+ 	LA	t9, ffi_closure_mips_inner_N32
+@@ -458,6 +473,7 @@ cls_retint:
+ 	b	cls_epilogue
+ 
+ cls_retfloat:
++#ifndef __mips_soft_float
+ 	bne     v0, FFI_TYPE_FLOAT, cls_retdouble
+ 	l.s	$f0, V0_OFF2($sp)
+ 	b	cls_epilogue
+@@ -500,6 +516,7 @@ cls_retstruct_f_d:
+ 	l.s	$f0, V0_OFF2($sp)
+ 	l.d	$f2, V1_OFF2($sp)
+ 	b	cls_epilogue
++#endif
+ 	
+ cls_retstruct_small2:	
+ 	REG_L	v0, V0_OFF2($sp)
+diff --git a/libffi/src/mips/o32.S b/libffi/src/mips/o32.S
+index eb27981..1aff4b1 100644
+--- a/libffi/src/mips/o32.S
++++ b/libffi/src/mips/o32.S
+@@ -82,13 +82,16 @@ sixteen:
+ 		
+ 	ADDU	$sp, 4 * FFI_SIZEOF_ARG		# adjust $sp to new args
+ 
++#ifndef __mips_soft_float
+ 	bnez	t0, pass_d			# make it quick for int
++#endif
+ 	REG_L	a0, 0*FFI_SIZEOF_ARG($sp)	# just go ahead and load the
+ 	REG_L	a1, 1*FFI_SIZEOF_ARG($sp)	# four regs.
+ 	REG_L	a2, 2*FFI_SIZEOF_ARG($sp)
+ 	REG_L	a3, 3*FFI_SIZEOF_ARG($sp)
+ 	b	call_it
+ 
++#ifndef __mips_soft_float
+ pass_d:
+ 	bne	t0, FFI_ARGS_D, pass_f
+ 	l.d	$f12, 0*FFI_SIZEOF_ARG($sp)	# load $fp regs from args
+@@ -130,6 +133,7 @@ pass_f_d:
+  #	bne	t0, FFI_ARGS_F_D, call_it
+ 	l.s	$f12, 0*FFI_SIZEOF_ARG($sp)	# load $fp regs from args
+ 	l.d	$f14, 2*FFI_SIZEOF_ARG($sp)	# passing double and float
++#endif
+ 
+ call_it:	
+ 	# Load the function pointer
+@@ -158,14 +162,23 @@ retfloat:
+ 	bne     t2, FFI_TYPE_FLOAT, retdouble
+ 	jalr	t9
+ 	REG_L	t0, SIZEOF_FRAME + 4*FFI_SIZEOF_ARG($fp)
++#ifndef __mips_soft_float
+ 	s.s	$f0, 0(t0)
++#else
++	REG_S v0, 0(t0)
++#endif
+ 	b	epilogue
+ 
+ retdouble:	
+ 	bne	t2, FFI_TYPE_DOUBLE, noretval
+ 	jalr	t9
+ 	REG_L	t0, SIZEOF_FRAME + 4*FFI_SIZEOF_ARG($fp)
++#ifndef __mips_soft_float
+ 	s.d	$f0, 0(t0)
++#else
++	REG_S v1, 4(t0)
++	REG_S v0, 0(t0)
++#endif
+ 	b	epilogue
+ 	
+ noretval:	
+@@ -261,9 +274,11 @@ $LCFI7:
+ 	li	$13, 1		# FFI_O32
+ 	bne	$16, $13, 1f	# Skip fp save if FFI_O32_SOFT_FLOAT
+ 	
++#ifndef __mips_soft_float
+ 	# Store all possible float/double registers.
+ 	s.d	$f12, FA_0_0_OFF2($fp)
+ 	s.d	$f14, FA_1_0_OFF2($fp)
++#endif
+ 1:	
+ 	# Call ffi_closure_mips_inner_O32 to do the work.
+ 	la	t9, ffi_closure_mips_inner_O32
+@@ -281,6 +296,7 @@ $LCFI7:
+ 	li	$13, 1		# FFI_O32
+ 	bne	$16, $13, 1f	# Skip fp restore if FFI_O32_SOFT_FLOAT
+ 
++#ifndef __mips_soft_float
+ 	li	$9, FFI_TYPE_FLOAT
+ 	l.s	$f0, V0_OFF2($fp)
+ 	beq	$8, $9, closure_done
+@@ -288,6 +304,7 @@ $LCFI7:
+ 	li	$9, FFI_TYPE_DOUBLE
+ 	l.d	$f0, V0_OFF2($fp)
+ 	beq	$8, $9, closure_done
++#endif
+ 1:	
+ 	REG_L	$3, V1_OFF2($fp)
+ 	REG_L	$2, V0_OFF2($fp)
+-- 
+2.7.4
+


### PR DESCRIPTION
When building gcc-5.4.0 with glibc with gccgo support on mt7621 target, it will occur below error:

libtool: compile:  /home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0-final/./gcc/xgcc -B/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0-final/./gcc/ -B/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/staging_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/mipsel-openwrt-linux-gnu/bin/ -B/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/staging_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/mipsel-openwrt-linux-gnu/lib/ -isystem /home/tymon/work/openwrt/official/lede/mtk/newifi-d1/staging_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/mipsel-openwrt-linux-gnu/include -isystem /home/tymon/work/openwrt/official/lede/mtk/newifi-d1/staging_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/mipsel-openwrt-linux-gnu/sys-include -DHAVE_CONFIG_H -I. -I/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi -I. -I/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/include -Iinclude -I/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src -I. -I/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/include -Iinclude -I/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src -Os -pipe -mno-branch-likely -mips32r2 -mtune=24kc -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -MT src/mips/o32.lo -MD -MP -MF src/mips/.deps/o32.Tpo -c /home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S  -fPIC -DPIC -o src/mips/.libs/o32.o
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S: Assembler messages:
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:94: Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.d $f12,0*4($sp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:101: Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.s $f12,0*4($sp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:109: **Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.d $f12,0*4($sp)'**
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:110: **Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.d $f14,2*4($sp)'**
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:115: Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.s $f12,0*4($sp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:116: Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.s $f14,1*4($sp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:123: Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.d $f12,0*4($sp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:124: Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.s $f14,2*4($sp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:131: Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.s $f12,0*4($sp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:132: Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.d $f14,2*4($sp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:161: Error: opcode not supported on this processor: mips32r2 (mips32r2) `s.s $f0,0($8)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:168: Error: opcode not supported on this processor: mips32r2 (mips32r2) `s.d $f0,0($8)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:265: Error: opcode not supported on this processor: mips32r2 (mips32r2) `s.d $f12,((14*4)-10*4)($fp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:266: Error: opcode not supported on this processor: mips32r2 (mips32r2) `s.d $f14,((14*4)-8*4)($fp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:285: Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.s $f0,((14*4)-6*4)($fp)'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0/libffi/src/mips/o32.S:289: ** Error: opcode not supported on this processor: mips32r2 (mips32r2) `l.d $f0,((14*4)-6*4)($fp)' **
Makefile:1177: recipe for target 'src/mips/o32.lo' failed
make[8]: *** [src/mips/o32.lo] Error 1
make[8]: Leaving directory '/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0-final/mipsel-openwrt-linux-gnu/libffi'
Makefile:1433: recipe for target 'all-recursive' failed
make[7]: *** [all-recursive] Error 1
make[7]: Leaving directory '/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0-final/mipsel-openwrt-linux-gnu/libffi'
Makefile:465: recipe for target 'all' failed
make[6]: *** [all] Error 2
make[6]: Leaving directory '/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0-final/mipsel-openwrt-linux-gnu/libffi'
Makefile:14051: recipe for target 'all-target-libffi' failed
make[5]: *** [all-target-libffi] Error 2
make[5]: Leaving directory '/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0-final'
Makefile:874: recipe for target 'all' failed
make[4]: *** [all] Error 2
make[4]: Leaving directory '/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0-final'
Makefile:86: recipe for target '/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0-final/.built' failed
make[3]: *** [/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/build_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/gcc-5.4.0-final/.built] Error 2
make[3]: Leaving directory '/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/toolchain/gcc/final'
toolchain/Makefile:90: recipe for target 'toolchain/gcc/final/compile' failed
make[2]: *** [toolchain/gcc/final/compile] Error 2
make[2]: Leaving directory '/home/tymon/work/openwrt/official/lede/mtk/newifi-d1'
toolchain/Makefile:89: recipe for target '/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/staging_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/stamp/.toolchain_install' failed
make[1]: *** [/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/staging_dir/toolchain-mipsel_24kc_gcc-5.4.0_glibc-2.24/stamp/.toolchain_install] Error 2
make[1]: Leaving directory '/home/tymon/work/openwrt/official/lede/mtk/newifi-d1'
/home/tymon/work/openwrt/official/lede/mtk/newifi-d1/include/toplevel.mk:194: recipe for target 'world' failed
make: *** [world] Error 2

This patch can fix the issue according to the [libffi #264](https://github.com/libffi/libffi/pull/264/commits/b74761126a209e779d0d23a74fe15d09ea69d72a)