### PR TITLE
[RFC] add powerpc64 support

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -70,6 +70,8 @@ else ifneq (,$(findstring $(ARCH) , armeb ))
   LINUX_KARCH := arm
 else ifneq (,$(findstring $(ARCH) , mipsel mips64 mips64el ))
   LINUX_KARCH := mips
+else ifneq (,$(findstring $(ARCH) , powerpc64 ))
+  LINUX_KARCH := powerpc
 else ifneq (,$(findstring $(ARCH) , sh2 sh3 sh4 ))
   LINUX_KARCH := sh
 else ifneq (,$(findstring $(ARCH) , i386 x86_64 ))

--- a/include/site/powerpc64
+++ b/include/site/powerpc64
@@ -1,0 +1,26 @@
+#!/bin/sh
+. $TOPDIR/include/site/linux
+ac_cv_c_littleendian=${ac_cv_c_littleendian=no}
+ac_cv_c_bigendian=${ac_cv_c_bigendian=yes}
+
+ac_cv_sizeof_char=${ac_cv_sizeof_char=1}
+ac_cv_sizeof_char_p=${ac_cv_sizeof_char_p=8}
+ac_cv_sizeof_double=${ac_cv_sizeof_double=8}
+ac_cv_sizeof_float=${ac_cv_sizeof_float=4}
+ac_cv_sizeof_int=${ac_cv_sizeof_int=4}
+ac_cv_sizeof_long=${ac_cv_sizeof_long=8}
+ac_cv_sizeof_long_double=${ac_cv_sizeof_long_double=16}
+ac_cv_sizeof_long_int=${ac_cv_sizeof_long_int=8}
+ac_cv_sizeof_long_long=${ac_cv_sizeof_long_long=8}
+ac_cv_sizeof_long_long_int=${ac_cv_sizeof_long_long_int=8}
+ac_cv_sizeof_short=${ac_cv_sizeof_short=2}
+ac_cv_sizeof_short_int=${ac_cv_sizeof_short_int=2}
+ac_cv_sizeof_signed_char=${ac_cv_sizeof_signed_char=1}
+ac_cv_sizeof_unsigned_char=${ac_cv_sizeof_unsigned_char=1}
+ac_cv_sizeof_unsigned_int=${ac_cv_sizeof_unsigned_int=4}
+ac_cv_sizeof_unsigned_long=${ac_cv_sizeof_unsigned_long=8}
+ac_cv_sizeof_unsigned_long_int=${ac_cv_sizeof_unsigned_long_int=8}
+ac_cv_sizeof_unsigned_long_long_int=${ac_cv_sizeof_unsigned_long_long_int=8}
+ac_cv_sizeof_unsigned_short=${ac_cv_sizeof_unsigned_short=2}
+ac_cv_sizeof_unsigned_short_int=${ac_cv_sizeof_unsigned_short_int=2}
+ac_cv_sizeof_void_p=${ac_cv_sizeof_void_p=8}

--- a/include/target.mk
+++ b/include/target.mk
@@ -205,6 +205,10 @@ ifeq ($(DUMP),1)
     CPU_CFLAGS_440:=-mcpu=440
     CPU_CFLAGS_464fp:=-mcpu=464fp
   endif
+  ifeq ($(ARCH),powerpc64)
+    CPU_TYPE ?= powerpc64
+    CPU_CFLAGS_powerpc64:=-mcpu=powerpc64
+  endif
   ifeq ($(ARCH),sparc)
     CPU_TYPE = sparc
     CPU_CFLAGS_ultrasparc = -mcpu=ultrasparc

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -32,7 +32,6 @@ sub target_config_features(@) {
 		/fpu/ and $ret .= "\tselect HAS_FPU\n";
 		/spe_fpu/ and $ret .= "\tselect HAS_SPE_FPU\n";
 		/ramdisk/ and $ret .= "\tselect USES_INITRAMFS\n";
-		/powerpc64/ and $ret .= "\tselect powerpc64\n";
 		/nommu/ and $ret .= "\tselect NOMMU\n";
 		/mips16/ and $ret .= "\tselect HAS_MIPS16\n";
 		/rfkill/ and $ret .= "\tselect RFKILL_SUPPORT\n";

--- a/target/Config.in
+++ b/target/Config.in
@@ -198,6 +198,7 @@ config ARCH
 	default "mips64"    if mips64
 	default "mips64el"  if mips64el
 	default "powerpc"   if powerpc
+	default "powerpc64" if powerpc64
 	default "sh3"       if sh3
 	default "sh3eb"     if sh3eb
 	default "sh4"       if sh4

--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -168,7 +168,6 @@ menuconfig EXTRA_TARGET_ARCH
 	bool
 	prompt "Enable an extra toolchain target architecture" if TOOLCHAINOPTS
 	depends on !sparc
-	default y	if powerpc64
 	default n
 	help
 	  Some builds may require a 'biarch' toolchain. This option
@@ -178,7 +177,6 @@ menuconfig EXTRA_TARGET_ARCH
 
 	config EXTRA_TARGET_ARCH_NAME
 		string
-		default "powerpc64"	if powerpc64
 		prompt "Extra architecture name" if EXTRA_TARGET_ARCH
 		help
 		  Specify the cpu name (eg powerpc64 or x86_64) of the
@@ -186,7 +184,6 @@ menuconfig EXTRA_TARGET_ARCH
 
 	config EXTRA_TARGET_ARCH_OPTS
 		string
-		default "-m64"		if powerpc64
 		prompt "Extra architecture compiler options" if EXTRA_TARGET_ARCH
 		help
 		  If you're specifying an addition target architecture,

--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -238,6 +238,7 @@ comment "C Library"
 choice
 	prompt "C Library implementation" if TOOLCHAINOPTS
 	default LIBC_USE_UCLIBC if arc
+	default LIBC_USE_GLIBC if powerpc64
 	default LIBC_USE_MUSL
 	help
 	  Select the C library implementation.
@@ -250,13 +251,13 @@ choice
 	config LIBC_USE_UCLIBC
 		select USE_UCLIBC
 		bool "Use uClibc"
-		depends on !(aarch64 || aarch64_be)
+		depends on !(aarch64 || aarch64_be || powerpc64)
 		depends on BROKEN || !(arm || armeb || i386 || x86_64 || mips || mipsel || mips64 || mips64el || powerpc)
 
 	config LIBC_USE_MUSL
 		select USE_MUSL
 		bool "Use musl"
-		depends on !(arc)
+		depends on !(arc || powerpc64)
 
 endchoice
 
@@ -283,6 +284,7 @@ config INSIGHT
 	  Enable if you want to build insight-gdb.
 
 config USE_GLIBC
+	default y if !TOOLCHAINOPTS && !EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN && (powerpc64)
 	bool
 
 config USE_UCLIBC
@@ -290,7 +292,7 @@ config USE_UCLIBC
 	bool
 
 config USE_MUSL
-	default y if !TOOLCHAINOPTS && !EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN && !(arc)
+	default y if !TOOLCHAINOPTS && !EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN && !(arc || powerpc64)
 	bool
 
 config USE_EXTERNAL_LIBC


### PR DESCRIPTION
Add support for building a pure 64 bit powerpc kernel and userland.

I'm planning to add support for the T4 family of Freescale CPUs/the T4240RDB and having ppc64-support is a prerequisite for that.

This is based on glibc because musl only has working powerpc64le-support right now, which doesn't seem to have caught on in the embedded word yet; at least for the T4240RDB, it is impossible to support without a lot of low-level restructuring.

I've looked at the way other architectures were added and tried to cover the important bits (I can build a firmware for the T4240RDB using this), but I probably have missed something, thus flagging this as RFC.