### PR TITLE
gre,vti: add empty install rules

### DIFF
--- a/package/network/config/gre/Makefile
+++ b/package/network/config/gre/Makefile
@@ -60,6 +60,14 @@ define Package/gre/install
 	$(INSTALL_BIN) ./files/gre.sh $(1)/lib/netifd/proto/gre.sh
 endef
 
+define Package/grev4/install
+	:
+endef
+
+define Package/grev6/install
+	:
+endef
+
 $(eval $(call BuildPackage,gre))
 $(eval $(call BuildPackage,grev4))
 $(eval $(call BuildPackage,grev6))

--- a/package/network/config/vti/Makefile
+++ b/package/network/config/vti/Makefile
@@ -60,6 +60,14 @@ define Package/vti/install
 	$(INSTALL_BIN) ./files/vti.sh $(1)/lib/netifd/proto/vti.sh
 endef
 
+define Package/vtiv4/install
+	:
+endef
+
+define Package/vtiv6/install
+	:
+endef
+
 $(eval $(call BuildPackage,vti))
 $(eval $(call BuildPackage,vtiv4))
 $(eval $(call BuildPackage,vtiv6))


### PR DESCRIPTION
@dedeckeh for gre
@nbd168 for vti  ; the code was submitted from the email list, so I could not track the submitter's github account

I mostly tested this with `gre` and applied the same pattern to `vti`.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>