### PR TITLE
[patch] layerscape: optimize IMAGE/xx.bin variables composition

### DIFF
--- a/target/linux/layerscape/image/Makefile
+++ b/target/linux/layerscape/image/Makefile
@@ -58,7 +58,7 @@ ifeq ($(SUBTARGET),32b)
 endif
   IMAGE/firmware.bin = append-ls-rcw $(1) | pad-to 1M | append-ls-uboot $(1) | pad-to 3M | \
   					append-ls-fman $(1) | pad-to 4M | append-ls-dtb $$(DEVICE_DTS) | pad-to 5M | \
-  					append-kernel | pad-to 10M | append-rootfs | pad-to 64M | check-size 67108865
+  					append-kernel | pad-to 10M | append-rootfs | pad-rootfs | check-size 67108865
 endef
 TARGET_DEVICES += ls1043ardb
 

--- a/target/linux/layerscape/image/Makefile
+++ b/target/linux/layerscape/image/Makefile
@@ -73,10 +73,6 @@ ifeq ($(SUBTARGET),32b)
 endif
   IMAGE/firmware.bin = append-ls-rcw $(1) | pad-to 1M | append-ls-uboot $(1) | pad-to 3M | \
   					append-ls-dtb $$(DEVICE_DTS) | pad-to 4M | append-kernel | pad-to 9M | \
-  					append-rootfs | pad-to 32M | check-size 33554433
-  IMAGES += firmware.ext4.bin
-  IMAGE/firmware.ext4.bin = append-ls-rcw $(1) | pad-to 1M | append-ls-uboot $(1) | pad-to 3M | \
-  					append-ls-dtb $$(DEVICE_DTS) | pad-to 4M | append-kernel | pad-to 9M | \
   					append-ls-rootfs-ext4 $(1) 23M | check-size 33554433
 endef
 TARGET_DEVICES += ls1012ardb


### PR DESCRIPTION
[PATCH 1/2]layerscape: ls1043ardb: add pad-rootfs to reduce the size of firmware.bin
[PATCH 2/2]layerscape: ls1012ardb: only reserve ext4 fs as default firmware.bin

