### PR TITLE
devel/strace: fix build only on powerpc arch

### DIFF
--- a/package/devel/strace/patches/100-workaround--pt-reg-collisions-ppc.patch
+++ b/package/devel/strace/patches/100-workaround--pt-reg-collisions-ppc.patch
@@ -1,0 +1,19 @@
+diff --git a/ptrace.h b/ptrace.h
+index ddb46cb..48a54b8 100644
+--- a/ptrace.h
++++ b/ptrace.h
+@@ -55,7 +55,14 @@ extern long ptrace(int, int, char *, long);
+ # define ptrace_peeksiginfo_args XXX_ptrace_peeksiginfo_args
+ #endif
+ 
++#if POWERPC
++#include <linux/types.h>
++#define __ASSEMBLY__
++#endif
+ #include <linux/ptrace.h>
++#if POWERPC
++#undef __ASSEMBLY__
++#endif
+ 
+ #ifdef HAVE_STRUCT_IA64_FPREG
+ # undef ia64_fpreg


### PR DESCRIPTION
Reboot of 519a199cbcc0930e229ddd7087309326a846bdce
Which broke other builds.

This time, added compile flags to build only for POWERPC archs

Tested on mpc85xx, ar71xx and bcm2708.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>