### PR TITLE
ipq806x: R7800 LEDs: switch to usbport and fix trigger port numbering

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -29,8 +29,8 @@ r7500v2)
 	ucidef_set_led_default "rfkill" "rfkill" "${board}:white:rfkill" "0"
 	;;
 r7800)
-	ucidef_set_led_usbdev "usb1" "USB 1" "${board}:white:usb1" "2-1"
-	ucidef_set_led_usbdev "usb2" "USB 2" "${board}:white:usb2" "4-1"
+	ucidef_set_led_usbport "usb1" "USB 1" "${board}:white:usb1" "usb1-port1" "usb2-port1"
+	ucidef_set_led_usbport "usb2" "USB 2" "${board}:white:usb2" "usb3-port1" "usb4-port1"
 	ucidef_set_led_netdev "wan" "WAN" "${board}:white:wan" "eth0"
 	ucidef_set_led_ide "esata" "eSATA" "${board}:white:esata"
 	ucidef_set_led_wlan "wps" "WPS" "${board}:white:wps" "phy0tpt"


### PR DESCRIPTION
* Switch Netgear R7800 USB LED definition from the old usbdev to usbport.

* Fix port numbering for LEDs. The ports get recognised as 1-1 and 3-1 (instead of 2-1 and 4-1). Leave also the previous numbering in case some devices detect the ports that way.

  Additional background: I am not quite sure if https://github.com/lede-project/source/commit/bf7166e54569266a7d7525742f3216b4e3064825 has been 100% correct, That commit reorganised the USB LED numbering. Earlier they were usb1 and usb3 in devicetree, which matches how the OS detects the ports. The names were changed in that commit from usb1 and usb3 to usb1 and usb2 (matching the physical USB ports outside?), and trigger were changed from 1-1 and 3-1 to 2-1 and 4-1. At least for my brand-new R7800 the ports get recognised as 1-1 and 3-1 and those triggers work. But just to err on the cautious side, let's leave both 1-1 + 2-1 as the triggers for the first port, and 3-1 + 4-1 for the second. 

  That is similar that was done for Archer C2600 in https://github.com/lede-project/source/commit/dafbc94f95141655f358fdd015a552921b3a66a3 , so I wonder if there is some variation how the ipq806x devices recognise/number the USB ports with usbdev & usbport.

Compile- and run-tested with LEDE  r2152
