### PR TITLE
 arm64: boot-wrapper: Add mirror

### DIFF
--- a/target/linux/arm64/image/boot-wrapper/Makefile
+++ b/target/linux/arm64/image/boot-wrapper/Makefile
@@ -12,7 +12,9 @@ PKG_VERSION:=2013-01-10
 PKG_RELEASE:=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/mark/boot-wrapper-aarch64.git
+PKG_SOURCE_URL:=\
+		https://kernel.googlesource.com/pub/scm/linux/kernel/git/mark/boot-wrapper-aarch64 \
+		https://git.kernel.org/pub/scm/linux/kernel/git/mark/boot-wrapper-aarch64.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=c51dde817b5ed5b8f741b67ac51bd67bd87b4a2a
 PKG_MIRROR_MD5SUM:=2f029a20c906af68e9fe067c1b0ed394e4c455e142454a039f41d1d82d6e17c8


### PR DESCRIPTION
Adds Google's mirror as primary source and kernel.org as fallback.
Same as commit 0d4f02dfd650612aac6c11860139be03a0f54bee

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>