### PR TITLE
ar71xx: tl-wpa8630: Use dynamic parsing of the firmware partition

### DIFF
--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -87,7 +87,7 @@ case "$FIRMWARE" in
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
 	tl-wpa8630)
-		ath10kcal_extract "ART" 20480 2116
+		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
 		;;
 	unifiac-lite | \

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wpa8630.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wpa8630.c
@@ -40,8 +40,14 @@
 #define TL_WPA8630_WMAC_CALDATA_OFFSET	0x1000
 #define TL_WPA8630_PCI_CALDATA_OFFSET	0x5000
 
+static const char *tl_wpa8630_part_probes[] = {
+	"tp-link-64k",
+	NULL,
+};
+
 static struct flash_platform_data tl_wpa8630_flash_data = {
-	.type = "s25fl064k",
+	.part_probes	= tl_wpa8630_part_probes,
+	.type		= "s25fl064k",
 };
 
 static struct gpio_led tl_wpa8630_leds_gpio[] __initdata = {

--- a/target/linux/ar71xx/image/tp-link.mk
+++ b/target/linux/ar71xx/image/tp-link.mk
@@ -378,8 +378,6 @@ define Device/tl-wpa8630
     BOARDNAME := TL-WPA8630
     DEVICE_PROFILE := TL-WPA8630
     TPLINK_HWID := 0x86300001
-    MTDPARTS = spi0.0:64k(u-boot)ro,1344k(kernel),6656k(rootfs),64k(mib0)ro,64k(ART)ro,8000k@0x10000(firmware)
-    IMAGE/sysupgrade.bin := append-rootfs | mktplinkfw sysupgrade -a 0x10000
 endef
 TARGET_DEVICES += tl-wpa8630
 


### PR DESCRIPTION
Now is working correctly:
```
[...]
[    0.577430] m25p80 spi0.0: s25fl064k (8192 Kbytes)
[    0.583112] 5 tp-link-64k partitions found on MTD device spi0.0
[    0.589225] Creating 5 MTD partitions on "spi0.0":
[    0.594199] 0x000000000000-0x000000010000 : "u-boot"
[    0.600913] 0x000000010000-0x000000154328 : "kernel"
[    0.607406] 0x000000154328-0x0000007f0000 : "rootfs"
[    0.613881] mtd: device 2 (rootfs) set to be root filesystem
[    0.619787] 1 squashfs-split partitions found on MTD device rootfs
[    0.626217] 0x0000003d0000-0x0000007f0000 : "rootfs_data"
[    0.633152] 0x0000007f0000-0x000000800000 : "art"
[    0.639327] 0x000000010000-0x0000007f0000 : "firmware"
[    0.654834] switch0: Atheros AR8337 rev. 2 switch registered on ag71xx-mdio.0
[    0.734202] libphy: ag71xx_mdio: probed
[...]

```
Signed-off-by: Henryk Heisig <hyniu@o2.pl>