### PR TITLE
[patch]layerscape: uboot: using perl script:byte_swap.pl to replace tcl scri…

### DIFF
--- a/package/boot/uboot-layerscape/patches/0094-using-perl-script-byte_swap.pl-to-replace-tcl-script.patch
+++ b/package/boot/uboot-layerscape/patches/0094-using-perl-script-byte_swap.pl-to-replace-tcl-script.patch
@@ -1,0 +1,72 @@
+From 61cf7655f6f165645d1659c7b256be4397d67572 Mon Sep 17 00:00:00 2001
+From: Yutang Jiang <yutang.jiang@nxp.com>
+Date: Tue, 15 Nov 2016 20:57:37 +0800
+Subject: [PATCH 94/94] using perl script:byte_swap.pl to replace tcl
+ script:byte_swap.tcl
+
+Signed-off-by: Yutang Jiang <yutang.jiang@nxp.com>
+---
+ Makefile     |    2 +-
+ byte_swap.pl |   37 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 38 insertions(+), 1 deletion(-)
+ create mode 100755 byte_swap.pl
+
+diff --git a/Makefile b/Makefile
+index b73375f..5293bc5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -836,7 +836,7 @@ dtbs dts/dt.dtb: checkdtc u-boot
+ 
+ u-boot-dtb.bin: u-boot.bin dts/dt.dtb FORCE
+ 	$(call if_changed,cat)
+-	tclsh byte_swap.tcl u-boot-dtb.bin u-boot-swap.bin 8
++	perl byte_swap.pl u-boot-dtb.bin u-boot-swap.bin 8
+ 
+ %.imx: %.bin
+ 	$(Q)$(MAKE) $(build)=arch/arm/imx-common $@
+diff --git a/byte_swap.pl b/byte_swap.pl
+new file mode 100755
+index 0000000..1707139
+--- /dev/null
++++ b/byte_swap.pl
+@@ -0,0 +1,37 @@
++#!/usr/bin/perl
++#
++# Copyright (C) 2016 Jiang Yutang <jiangyutang1978@gmail.com>
++#
++# This is free software, licensed under the GNU General Public License v2.
++# See /LICENSE for more information.
++#
++open F_I, '<', $ARGV[0] or die "Error:$!\n";
++open F_O, '>', $ARGV[1] or die "Error:$!\n";
++$i_size = (stat $ARGV[0])[7];
++
++undef $/;
++$str_i=<F_I>;
++(@ary_i)=unpack("C$i_size", $str_i);
++
++if ( ($i_size % $ARGV[2]) != 0 )
++{
++	for ($i=0; $i<$ARGV[2] - ($i_size % $ARGV[2]); $i++)
++	{
++		$ary_i[$i_size + $i]=0;
++	}
++	$i_size=$i_size + ($ARGV[2] - ($i_size % $ARGV[2]));
++}
++
++for ($i=0; $i<$i_size; $i += $ARGV[2])
++{
++	for ($j=0; $j<$ARGV[2]; $j++)
++	{
++		$ary_o[$i+$j]=$ary_i[$i+$ARGV[2]-$j-1];
++	}
++}
++
++binmode F_O;
++print(F_O pack("C$i_size", @ary_o));
++
++close F_I;
++close F_O;
+-- 
+1.7.9.5
+


### PR DESCRIPTION
The uboot-layerscape component uses a TCL script to process the final binary but tclsh is no build requirement of the LEDE buildroot.

Jo-Philipp Wich give me advice: Rewriting that byte_swap.tcl script in Perl.

Now I have studied TCL and Perl then rewriting it.