### PR TITLE
[RFC] include/netfilter.mk: add optional 'netfilter-user.mk' inclusion

### DIFF
--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -373,4 +373,6 @@ IPT_BUILTIN += $(EBTABLES_IP4-y)
 IPT_BUILTIN += $(EBTABLES_IP6-y)
 IPT_BUILTIN += $(EBTABLES_WATCHERS-y)
 
+-include $(INCLUDE_DIR)/netfilter-user.mk
+
 endif # __inc_netfilter


### PR DESCRIPTION
I don't have a better idea at the moment with this.
Bottom line is, we'd want to extend 'include/netfilter.mk' without
patching it (internally).

And wrapping 'netfilter.mk' with a 'my-netfilter.mk' would work,
but it creates a risk of running out of sync between kernel modules
enabled, and what 'iptables' has configured.

The shortest/simplest fix is to add a simple '-include/netfilter-user.mk'
in 'netfilter.mk'.
And 'netfilter-user.mk' would live in an internal tree.
This makes it a bit easier when upgrading the OpenWrt/LEDE base.

Replacing with kernel config symbols is also a bit tricky, since
a lot of stuff in 'netfilter.mk' is interdependent.

I'm open to other ideas.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>