### PR TITLE
Experiabox Vgv7519 voice support

### DIFF
--- a/package/kernel/lantiq/ltq-vmmc/Config.in
+++ b/package/kernel/lantiq/ltq-vmmc/Config.in
@@ -24,7 +24,7 @@ choice
 endchoice
 
 choice
-	depends on PACKAGE_kmod-ltq-vmmc
+	depends on (PACKAGE_kmod-ltq-vmmc && VOICE_VMMC_WITH_DEVICE_FALCON)
 	prompt "FXS coefficients"
 	default LTQ_VOICE_CPE_VMMC_COEF_FALCON_ETSI
 	help

--- a/target/linux/lantiq/dts/VGV7519.dtsi
+++ b/target/linux/lantiq/dts/VGV7519.dtsi
@@ -7,7 +7,7 @@
 	model = "VGV7519 - KPN Experiabox V8";
 
 	chosen {
-		bootargs = "console=ttyLTQ0,115200 init=/etc/preinit";
+		bootargs = "console=ttyLTQ0,115200 init=/etc/preinit mem=62M vpe1_load_addr=0x83e00000 vpe1_mem=2M maxvpes=1 maxtcs=1";
 	};
 
 	aliases {
@@ -18,6 +18,15 @@
 		led-dsl = &broadband_green;
 		led-internet = &internet_green;
 		led-wifi = &wireless_green;
+	};
+
+	sram@1F000000 {
+	        vmmc@107000 {
+	                status = "okay";
+	                gpios = <&gpio 30 GPIO_ACTIVE_HIGH  //fxs relay
+	                         &gpio 31 GPIO_ACTIVE_HIGH  //still unknown
+	                         &gpio 3  GPIO_ACTIVE_HIGH>; //reset_slic?
+	        };
 	};
 
 	memory@0 {

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -565,7 +565,7 @@ TARGET_DEVICES += VGV7510KW22BRN
 define Device/VGV7519NOR
   IMAGE_SIZE := 15360k
   DEVICE_TITLE := Experiabox 8 VGV7519
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-mini kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-mini kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
 endef
 TARGET_DEVICES += VGV7519NOR
 
@@ -576,7 +576,7 @@ define Device/VGV7519BRN
   MAGIC := 0x12345678
   CRC32_POLY := 0x2083b8ed
   DEVICE_TITLE := Experiabox 8 VGV7519 (BRN)
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-mini kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-mini kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
 endef
 TARGET_DEVICES += VGV7519BRN
 


### PR DESCRIPTION
This series of patch enable tapi/vmmc on VGV7519.

- lantiq: disable VMMC_COEF for non FALCON device 
disable the menuconfig entry for VMMC_COEF since we use fixed coef (and is not actually used)

- lantiq: enable VMMC for VGV7519
add dts entry needed to use vmmc. We can add this by default since actually we fixed the pci/dma issue that messed up wifi on OpenwrtBB

- lantiq: add tapi/vmmc to VGV7519 defaults 
add tapi/vmmc driver to the firmware image by default
