### PR TITLE
Vgv7510kw22 voice support

### DIFF
--- a/target/linux/lantiq/dts/VGV7510KW22.dtsi
+++ b/target/linux/lantiq/dts/VGV7510KW22.dtsi
@@ -6,7 +6,7 @@
 	model = "VGV7510KW22 - o2 Box 6431";
 
 	chosen {
-		bootargs = "console=ttyLTQ0,115200 init=/etc/preinit";
+		bootargs = "console=ttyLTQ0,115200 init=/etc/preinit mem=62M vpe1_load_addr=0x83e00000 vpe1_mem=2M maxvpes=1 maxtcs=1";
 	};
 
 	aliases {
@@ -17,6 +17,15 @@
 		led-dsl = &dsl;
 		led-internet = &internet_green;
 		led-wifi = &wifi;
+	};
+
+	sram@1F000000 {
+		vmmc@107000 {
+			status = "okay";
+			gpios = <&gpio 30 GPIO_ACTIVE_HIGH  //fxs relay
+					 &gpio 31 GPIO_ACTIVE_HIGH  //still unknown
+					 &gpio 3  GPIO_ACTIVE_HIGH>; //reset_slic?
+		};
 	};
 
 	memory@0 {

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -547,7 +547,7 @@ TARGET_DEVICES += WBMR300
 define Device/VGV7510KW22NOR
   IMAGE_SIZE := 15232k
   DEVICE_TITLE := o2 Box 6431 / Arcadyan VGV7510KW22 (NOR)
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-mini kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-mini kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
 endef
 TARGET_DEVICES += VGV7510KW22NOR
 
@@ -558,7 +558,7 @@ define Device/VGV7510KW22BRN
   MAGIC := 0x12345678
   CRC32_POLY := 0x2083b8ed
   DEVICE_TITLE := o2 Box 6431 / Arcadyan VGV7510KW22 (BRN)
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-mini kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-mini kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
 endef
 TARGET_DEVICES += VGV7510KW22BRN
 


### PR DESCRIPTION
This series of patch enable tapi/vmmc on Vgv7510kw22.

-lantiq: enable VMMC for Vgv7510kw22 
add dts entry needed to use vmmc. We can add this by default since actually we fixed the pci/dma issue that messed up wifi on OpenwrtBB

-lantiq: add tapi/vmmc to Vgv7510kw22 defaults
add tapi/vmmc driver to the firmware image by default

@kochstefan already confirmed to me that the configuration is identical to vgv7519