### PR TITLE
kernel: remove pipetypes unused var warning

### DIFF
--- a/target/linux/generic/patches-4.4/821-usb-Remove-annoying-warning-about-bogus-URB.patch
+++ b/target/linux/generic/patches-4.4/821-usb-Remove-annoying-warning-about-bogus-URB.patch
@@ -54,7 +54,17 @@ Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>
 
 --- a/drivers/usb/core/urb.c
 +++ b/drivers/usb/core/urb.c
-@@ -443,11 +443,6 @@ int usb_submit_urb(struct urb *urb, gfp_
+@@ -323,9 +323,6 @@ EXPORT_SYMBOL_GPL(usb_unanchor_urb);
+  */
+ int usb_submit_urb(struct urb *urb, gfp_t mem_flags)
+ {
+-	static int			pipetypes[4] = {
+-		PIPE_CONTROL, PIPE_ISOCHRONOUS, PIPE_BULK, PIPE_INTERRUPT
+-	};
+ 	int				xfertype, max;
+ 	struct usb_device		*dev;
+ 	struct usb_host_endpoint	*ep;
+@@ -443,11 +440,6 @@ int usb_submit_urb(struct urb *urb, gfp_
  	 * cause problems in HCDs if they get it wrong.
  	 */
  


### PR DESCRIPTION
Update patch to remove pipetypes var declaration which was throwing
unused variable warning due to the original patch removing the only use.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>