### PR TITLE
toolchain/kernel-headers: Fix toolchain kernel headers

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -79,6 +79,7 @@ else
 	ln -s $(CONFIG_EXTERNAL_KERNEL_TREE) $(LINUX_DIR)
   endef
 endif
+Kernel/Prepare?=$(Kernel/Prepare/Default)
 
 ifeq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),y)
   ifeq ($(strip $(CONFIG_EXTERNAL_CPIO)),"")
@@ -136,6 +137,7 @@ define Kernel/Configure/Default
 	$(_SINGLE) [ -d $(LINUX_DIR)/user_headers ] || $(MAKE) $(KERNEL_MAKEOPTS) INSTALL_HDR_PATH=$(LINUX_DIR)/user_headers headers_install
 	$(SH_FUNC) grep '=[ym]' $(LINUX_DIR)/.config.set | LC_ALL=C sort | md5s > $(LINUX_DIR)/.vermagic
 endef
+Kernel/Configure?=$(Kernel/Configure/Default)
 
 define Kernel/Configure/Initramfs
 	$(call Kernel/SetInitramfs)

--- a/toolchain/kernel-headers/Makefile
+++ b/toolchain/kernel-headers/Makefile
@@ -21,8 +21,8 @@ PKG_SOURCE_URL:=$(LINUX_SITE)
 HOST_BUILD_DIR:=$(KERNEL_BUILD_DIR)/linux-$(LINUX_VERSION)
 PKG_MD5SUM:=$(LINUX_KERNEL_MD5SUM)
 LINUX_DIR := $(HOST_BUILD_DIR)
-FILES_DIR := 
-PATCH_DIR := ./patches$(if $(wildcard ./patches-$(LINUX_VERSION)),-$(LINUX_VERSION))
+FILES_DIR := $(foreach dir,$(wildcard $(PLATFORM_DIR)/files $(PLATFORM_DIR)/files-$(LINUX_VERSION)),"$(dir)")
+PATCH_DIR := $(PLATFORM_DIR)/patches$(if $(wildcard $(PLATFORM_DIR)/patches-$(KERNEL_PATCHVER)),-$(KERNEL_PATCHVER))
 
 include $(INCLUDE_DIR)/toolchain-build.mk
 include $(INCLUDE_DIR)/kernel-defaults.mk

--- a/toolchain/kernel-headers/Makefile
+++ b/toolchain/kernel-headers/Makefile
@@ -27,6 +27,11 @@ PATCH_DIR := ./patches$(if $(wildcard ./patches-$(LINUX_VERSION)),-$(LINUX_VERSI
 include $(INCLUDE_DIR)/toolchain-build.mk
 include $(INCLUDE_DIR)/kernel-defaults.mk
 
+# toolchain-build sets STAGING_DIR_HOST to TOOLCHAIN_DIR which ripples through
+# to KERNEL_MAKEOPTS, therefor we have to correct HOST_LOADLIBES here to point
+# to the correct lib dir.
+KERNEL_MAKEOPTS += HOST_LOADLIBES="-L$(REAL_STAGING_DIR_HOST)/lib"
+
 ifeq ($(strip $(BOARD)),uml)
   LINUX_KARCH:=$(subst x86_64,x86,$(subst i386,x86,$(ARCH)))
 endif
@@ -46,9 +51,7 @@ KMAKE := $(MAKE) -C $(HOST_BUILD_DIR) \
 
 define Host/Configure/all
 	mkdir -p $(BUILD_DIR_TOOLCHAIN)/linux-dev
-	$(KMAKE) \
-		INSTALL_HDR_PATH="$(BUILD_DIR_TOOLCHAIN)/linux-dev/" \
-		headers_install
+	$(CP) $(LINUX_DIR)/user_headers/* $(BUILD_DIR_TOOLCHAIN)/linux-dev/
 endef
 
 # XXX: the following is needed to build lzma-loader
@@ -71,13 +74,14 @@ define Host/Configure/post/mipsel
 endef
 
 define Host/Prepare
-	$(call Kernel/Prepare/Default)
+	$(call Kernel/Prepare)
 	rm -f $(BUILD_DIR_TOOLCHAIN)/linux
 	ln -s linux-$(LINUX_VERSION) $(BUILD_DIR_TOOLCHAIN)/linux
 	$(SED) 's/@expr length/@-expr length/' $(HOST_BUILD_DIR)/Makefile
 endef
 
 define Host/Configure
+	$(call Kernel/Configure)
 	env
 	yes '' | $(KMAKE) oldconfig
 	$(call Host/Configure/all)


### PR DESCRIPTION
The build system was picking up the host system's kernel configuration as a default to prepare the kernel headers. Additionally the build system was only applying generic files/patches, while some targets might have target specific patches/files which might also be relevant for user space headers.

This is an old patch that was send to the openwrt-devel mailing list in March, see https://lists.openwrt.org/pipermail/openwrt-devel/2016-March/040541.html -- but that was the timeframe when the fork happened, so the patch never made it in.

Had to rework the patch a bit for the recent  HOST_LOADLIBES addition to the KERNEL_MAKEOPTS, which uses STAGING_HOST_DIR, but in the toolchain steps, that variable points to another location and the actual one is kept in REAL_STAGING_HOST_DIR, therefor the KERNEL_MAKEOPTS addition in the Makefile. Another way to solve it would be to use:

```
STAGING_HOST_DIR:=$(REAL_STAGING_HOST_DIR)
```

instead, but that might have unwanted side effects, hence the choice to go with adding HOST_LOADLIBES again to the KERNEL_MAKEOPTS.
