### PR TITLE
ipq806x: fix build errors

### DIFF
--- a/target/linux/ipq806x/patches-4.4/011-1-fix-bld-errs-hwmon-sch56xx-Drop-watchdog-driver-data-reference-count-callbacks.patch
+++ b/target/linux/ipq806x/patches-4.4/011-1-fix-bld-errs-hwmon-sch56xx-Drop-watchdog-driver-data-reference-count-callbacks.patch
@@ -1,0 +1,95 @@
+From 3b8d058cfe6a3b14abee324f4c4b33e64bf61aeb Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Fri, 25 Dec 2015 16:01:45 -0800
+Subject: hwmon: (sch56xx) Drop watchdog driver data reference count callbacks
+
+Reference counting is now implemented in the watchdog core and no longer
+required in watchdog drivers.
+
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Signed-off-by: Wim Van Sebroeck <wim@iguana.be>
+---
+ drivers/hwmon/sch56xx-common.c | 31 +------------------------------
+ 1 file changed, 1 insertion(+), 30 deletions(-)
+
+--- a/drivers/hwmon/sch56xx-common.c
++++ b/drivers/hwmon/sch56xx-common.c
+@@ -30,7 +30,6 @@
+ #include <linux/watchdog.h>
+ #include <linux/miscdevice.h>
+ #include <linux/uaccess.h>
+-#include <linux/kref.h>
+ #include <linux/slab.h>
+ #include "sch56xx-common.h"
+ 
+@@ -67,7 +66,6 @@ MODULE_PARM_DESC(nowayout, "Watchdog can
+ struct sch56xx_watchdog_data {
+ 	u16 addr;
+ 	struct mutex *io_lock;
+-	struct kref kref;
+ 	struct watchdog_info wdinfo;
+ 	struct watchdog_device wddev;
+ 	u8 watchdog_preset;
+@@ -258,15 +256,6 @@ EXPORT_SYMBOL(sch56xx_read_virtual_reg12
+  * Watchdog routines
+  */
+ 
+-/* Release our data struct when we're unregistered *and*
+-   all references to our watchdog device are released */
+-static void watchdog_release_resources(struct kref *r)
+-{
+-	struct sch56xx_watchdog_data *data =
+-		container_of(r, struct sch56xx_watchdog_data, kref);
+-	kfree(data);
+-}
+-
+ static int watchdog_set_timeout(struct watchdog_device *wddev,
+ 				unsigned int timeout)
+ {
+@@ -395,28 +384,12 @@ static int watchdog_stop(struct watchdog
+ 	return 0;
+ }
+ 
+-static void watchdog_ref(struct watchdog_device *wddev)
+-{
+-	struct sch56xx_watchdog_data *data = watchdog_get_drvdata(wddev);
+-
+-	kref_get(&data->kref);
+-}
+-
+-static void watchdog_unref(struct watchdog_device *wddev)
+-{
+-	struct sch56xx_watchdog_data *data = watchdog_get_drvdata(wddev);
+-
+-	kref_put(&data->kref, watchdog_release_resources);
+-}
+-
+ static const struct watchdog_ops watchdog_ops = {
+ 	.owner		= THIS_MODULE,
+ 	.start		= watchdog_start,
+ 	.stop		= watchdog_stop,
+ 	.ping		= watchdog_trigger,
+ 	.set_timeout	= watchdog_set_timeout,
+-	.ref		= watchdog_ref,
+-	.unref		= watchdog_unref,
+ };
+ 
+ struct sch56xx_watchdog_data *sch56xx_watchdog_register(struct device *parent,
+@@ -448,7 +421,6 @@ struct sch56xx_watchdog_data *sch56xx_wa
+ 
+ 	data->addr = addr;
+ 	data->io_lock = io_lock;
+-	kref_init(&data->kref);
+ 
+ 	strlcpy(data->wdinfo.identity, "sch56xx watchdog",
+ 		sizeof(data->wdinfo.identity));
+@@ -494,8 +466,7 @@ EXPORT_SYMBOL(sch56xx_watchdog_register)
+ void sch56xx_watchdog_unregister(struct sch56xx_watchdog_data *data)
+ {
+ 	watchdog_unregister_device(&data->wddev);
+-	kref_put(&data->kref, watchdog_release_resources);
+-	/* Don't touch data after this it may have been free-ed! */
++	kfree(data);
+ }
+ EXPORT_SYMBOL(sch56xx_watchdog_unregister);
+ 

--- a/target/linux/ipq806x/patches-4.4/011-2-fix-bld-errs-watchdog-da9052_wdt-Drop-reference-counting.patch
+++ b/target/linux/ipq806x/patches-4.4/011-2-fix-bld-errs-watchdog-da9052_wdt-Drop-reference-counting.patch
@@ -1,0 +1,87 @@
+From 756d1e9247dff6d416b0c9e073247f5e808bb5fa Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Fri, 25 Dec 2015 16:01:43 -0800
+Subject: watchdog: da9052_wdt: Drop reference counting
+
+Reference counting is now implemented in the watchdog core and no longer
+required in watchdog drivers.
+
+Since it was implememented a no-op, and since the local memory is allocated
+with devm_kzalloc(), the reference counting code in the driver really did
+not really work anyway, and this patch effectively fixes a bug which could
+cause a crash on unloading if the watchdog device was still open.
+
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Signed-off-by: Wim Van Sebroeck <wim@iguana.be>
+---
+ drivers/watchdog/da9052_wdt.c | 24 ------------------------
+ 1 file changed, 24 deletions(-)
+
+--- a/drivers/watchdog/da9052_wdt.c
++++ b/drivers/watchdog/da9052_wdt.c
+@@ -31,7 +31,6 @@
+ struct da9052_wdt_data {
+ 	struct watchdog_device wdt;
+ 	struct da9052 *da9052;
+-	struct kref kref;
+ 	unsigned long jpast;
+ };
+ 
+@@ -51,10 +50,6 @@ static const struct {
+ };
+ 
+ 
+-static void da9052_wdt_release_resources(struct kref *r)
+-{
+-}
+-
+ static int da9052_wdt_set_timeout(struct watchdog_device *wdt_dev,
+ 				  unsigned int timeout)
+ {
+@@ -104,20 +99,6 @@ static int da9052_wdt_set_timeout(struct
+ 	return 0;
+ }
+ 
+-static void da9052_wdt_ref(struct watchdog_device *wdt_dev)
+-{
+-	struct da9052_wdt_data *driver_data = watchdog_get_drvdata(wdt_dev);
+-
+-	kref_get(&driver_data->kref);
+-}
+-
+-static void da9052_wdt_unref(struct watchdog_device *wdt_dev)
+-{
+-	struct da9052_wdt_data *driver_data = watchdog_get_drvdata(wdt_dev);
+-
+-	kref_put(&driver_data->kref, da9052_wdt_release_resources);
+-}
+-
+ static int da9052_wdt_start(struct watchdog_device *wdt_dev)
+ {
+ 	return da9052_wdt_set_timeout(wdt_dev, wdt_dev->timeout);
+@@ -170,8 +151,6 @@ static const struct watchdog_ops da9052_
+ 	.stop = da9052_wdt_stop,
+ 	.ping = da9052_wdt_ping,
+ 	.set_timeout = da9052_wdt_set_timeout,
+-	.ref = da9052_wdt_ref,
+-	.unref = da9052_wdt_unref,
+ };
+ 
+ 
+@@ -198,8 +177,6 @@ static int da9052_wdt_probe(struct platf
+ 	da9052_wdt->parent = &pdev->dev;
+ 	watchdog_set_drvdata(da9052_wdt, driver_data);
+ 
+-	kref_init(&driver_data->kref);
+-
+ 	ret = da9052_reg_update(da9052, DA9052_CONTROL_D_REG,
+ 				DA9052_CONTROLD_TWDSCALE, 0);
+ 	if (ret < 0) {
+@@ -225,7 +202,6 @@ static int da9052_wdt_remove(struct plat
+ 	struct da9052_wdt_data *driver_data = platform_get_drvdata(pdev);
+ 
+ 	watchdog_unregister_device(&driver_data->wdt);
+-	kref_put(&driver_data->kref, da9052_wdt_release_resources);
+ 
+ 	return 0;
+ }

--- a/target/linux/ipq806x/patches-4.4/011-3-fix-bld-errs-watchdog-da9055_wdt-Drop-reference-counting.patch
+++ b/target/linux/ipq806x/patches-4.4/011-3-fix-bld-errs-watchdog-da9055_wdt-Drop-reference-counting.patch
@@ -1,0 +1,80 @@
+From 43f676ace2e0591718ff493d290bc49b35ec2ffc Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Fri, 25 Dec 2015 16:01:44 -0800
+Subject: watchdog: da9055_wdt: Drop reference counting
+
+Reference counting is now implemented in the watchdog core and no longer
+required in watchdog drivers.
+
+Since it was implememented a no-op, and since the local memory is allocated
+with devm_kzalloc(), the reference counting code in the driver really did
+not really work anyway, and this patch effectively fixes a bug which could
+cause a crash on unloading if the watchdog device was still open.
+
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Signed-off-by: Wim Van Sebroeck <wim@iguana.be>
+---
+ drivers/watchdog/da9055_wdt.c | 24 ------------------------
+ 1 file changed, 24 deletions(-)
+
+--- a/drivers/watchdog/da9055_wdt.c
++++ b/drivers/watchdog/da9055_wdt.c
+@@ -35,7 +35,6 @@ MODULE_PARM_DESC(nowayout,
+ struct da9055_wdt_data {
+ 	struct watchdog_device wdt;
+ 	struct da9055 *da9055;
+-	struct kref kref;
+ };
+ 
+ static const struct {
+@@ -99,24 +98,6 @@ static int da9055_wdt_ping(struct watchd
+ 				 DA9055_WATCHDOG_MASK, 1);
+ }
+ 
+-static void da9055_wdt_release_resources(struct kref *r)
+-{
+-}
+-
+-static void da9055_wdt_ref(struct watchdog_device *wdt_dev)
+-{
+-	struct da9055_wdt_data *driver_data = watchdog_get_drvdata(wdt_dev);
+-
+-	kref_get(&driver_data->kref);
+-}
+-
+-static void da9055_wdt_unref(struct watchdog_device *wdt_dev)
+-{
+-	struct da9055_wdt_data *driver_data = watchdog_get_drvdata(wdt_dev);
+-
+-	kref_put(&driver_data->kref, da9055_wdt_release_resources);
+-}
+-
+ static int da9055_wdt_start(struct watchdog_device *wdt_dev)
+ {
+ 	return da9055_wdt_set_timeout(wdt_dev, wdt_dev->timeout);
+@@ -138,8 +119,6 @@ static const struct watchdog_ops da9055_
+ 	.stop = da9055_wdt_stop,
+ 	.ping = da9055_wdt_ping,
+ 	.set_timeout = da9055_wdt_set_timeout,
+-	.ref = da9055_wdt_ref,
+-	.unref = da9055_wdt_unref,
+ };
+ 
+ static int da9055_wdt_probe(struct platform_device *pdev)
+@@ -165,8 +144,6 @@ static int da9055_wdt_probe(struct platf
+ 	watchdog_set_nowayout(da9055_wdt, nowayout);
+ 	watchdog_set_drvdata(da9055_wdt, driver_data);
+ 
+-	kref_init(&driver_data->kref);
+-
+ 	ret = da9055_wdt_stop(da9055_wdt);
+ 	if (ret < 0) {
+ 		dev_err(&pdev->dev, "Failed to stop watchdog, %d\n", ret);
+@@ -189,7 +166,6 @@ static int da9055_wdt_remove(struct plat
+ 	struct da9055_wdt_data *driver_data = platform_get_drvdata(pdev);
+ 
+ 	watchdog_unregister_device(&driver_data->wdt);
+-	kref_put(&driver_data->kref, da9055_wdt_release_resources);
+ 
+ 	return 0;
+ }


### PR DESCRIPTION
Add missing patches that broke LEDE builder while updating WDT driver.