### PR TITLE
ipq806x: Initial support for TP-Link Archer VR2600v

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -45,6 +45,13 @@ nbg6817)
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:amber:wifi5" "phy0radio"
 	ucidef_set_led_netdev "wan" "WAN" "$board:white:internet" "eth1"
 	;;
+vr2600v)
+	ucidef_set_led_usbport "usb" "USB" "${board}:white:usb" "usb1-port1" "usb2-port1" "usb3-port1" "usb4-port1"
+	ucidef_set_led_switch "lan" "lan" "${board}:white:lan" "switch0" "0x1e"
+	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${board}:white:wlan2g" "phy0radio"
+	ucidef_set_led_wlan "wlan5g" "WLAN5G" "${board}:white:wlan5g" "phy1radio"
+	ucidef_set_led_switch "wan" "wan" "${board}:white:wan" "switch0" "0x20"
+	;;
 *)
 	;;
 esac

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -18,7 +18,8 @@ c2600 |\
 d7800 |\
 r7500 |\
 r7500v2 |\
-r7800)
+r7800 |\
+vr2600v)
 	ucidef_add_switch "switch0" \
 		"1:lan" "2:lan" "3:lan" "4:lan" "6@eth1" "5:wan" "0@eth0"
 	;;

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -63,6 +63,9 @@ case "$FIRMWARE" in
          r7800)
 		ath10kcal_extract "art" 4096 12064
 		;;
+	vr2600v)
+		ath10kcal_extract "ART" 4096 12064
+		;;
 	esac
 	;;
 "ath10k/cal-pci-0001:01:00.0.bin")
@@ -81,6 +84,9 @@ case "$FIRMWARE" in
         r7500v2 |\
         r7800)
 		ath10kcal_extract "art" 20480 12064
+		;;
+	vr2600v)
+		ath10kcal_extract "ART" 20480 12064
 		;;
 	esac
 	;;

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -21,6 +21,9 @@ case "$board" in
 	r7800)
 		echo $(macaddr_add $(mtd_get_mac_binary art 6)  $(($PHYNBR + 1)) ) > /sys${DEVPATH}/macaddress
 		;;
+	vr2600v)
+		echo $(macaddr_add $(mtd_get_mac_binary default-mac 0)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
+		;;
 	*)
 		;;
 esac

--- a/target/linux/ipq806x/base-files/lib/ipq806x.sh
+++ b/target/linux/ipq806x/base-files/lib/ipq806x.sh
@@ -41,6 +41,9 @@ ipq806x_board_detect() {
 	*"R7800")
 		name="r7800"
 		;;
+	*"VR2600v")
+		name="vr2600v"
+		;;
 	esac
 
 	[ -z "$name" ] && name="unknown"

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -60,6 +60,11 @@ platform_do_upgrade() {
 	ea8500)
 		platform_do_upgrade_linksys "$ARGV"
 		;;
+	vr2600v)
+		PART_NAME="kernel:rootfs"
+		MTD_CONFIG_ARGS="-s 0x200000"
+		default_do_upgrade "$ARGV"
+		;;
 	esac
 }
 

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-vr2600v.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-vr2600v.dts
@@ -1,0 +1,423 @@
+#include "qcom-ipq8064-v1.0.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "TP-Link Archer VR2600v";
+	compatible = "tplink,vr2600v", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		rsvd@41200000 {
+			reg = <0x41200000 0x300000>;
+			no-map;
+		};
+	};
+
+	aliases {
+		serial0 = &uart4;
+		mdio-gpio0 = &mdio0;
+
+		led-boot = &power;
+		led-failsafe = &general;
+		led-running = &power;
+		led-upgrade = &general;
+	};
+
+	chosen {
+		linux,stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		pinmux@800000 {
+			led_pins: led_pins {
+				pins = "gpio7", "gpio8", "gpio9", "gpio16", "gpio17",
+					"gpio26", "gpio53", "gpio56", "gpio66";
+				function = "gpio";
+				drive-strength = <2>;
+				bias-pull-up;
+			};
+
+			i2c4_pins: i2c4_pinmux {
+				mux {
+					pins = "gpio12", "gpio13";
+					function = "gsbi4";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
+			button_pins: button_pins {
+				pins = "gpio54", "gpio64", "gpio65", "gpio67", "gpio68";
+				function = "gpio";
+				drive-strength = <2>;
+				bias-pull-up;
+			};
+
+			spi_pins: spi_pins {
+				mux {
+					pins = "gpio18", "gpio19", "gpio21";
+					function = "gsbi5";
+					bias-pull-down;
+				};
+
+				data {
+					pins = "gpio18", "gpio19";
+					drive-strength = <10>;
+				};
+
+				cs {
+					pins = "gpio20";
+					drive-strength = <10>;
+					bias-pull-up;
+				};
+
+				clk {
+					pins = "gpio21";
+					drive-strength = <12>;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+
+			rgmii2_pins: rgmii2_pins {
+				mux {
+					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
+					       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+					function = "rgmii2";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+
+		};
+
+		gsbi@16300000 {
+			qcom,mode = <GSBI_PROT_I2C_UART>;
+			status = "ok";
+			serial@16340000 {
+				status = "ok";
+			};
+			/*
+			 * The i2c device on gsbi4 should not be enabled.
+			 * On ipq806x designs gsbi4 i2c is meant for exclusive
+			 * RPM usage. Turning this on in kernel manifests as
+			 * i2c failure for the RPM.
+			 */
+		};
+
+		gsbi5: gsbi@1a200000 {
+			qcom,mode = <GSBI_PROT_SPI>;
+			status = "ok";
+
+			spi4: spi@1a280000 {
+				status = "ok";
+				spi-max-frequency = <50000000>;
+
+				pinctrl-0 = <&spi_pins>;
+				pinctrl-names = "default";
+
+				cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+				flash: W25Q128@0 {
+					compatible = "jedec,spi-nor";
+					#address-cells = <1>;
+					#size-cells = <1>;
+					spi-max-frequency = <50000000>;
+					reg = <0>;
+
+					SBL1@0 {
+						label = "SBL1";
+						reg = <0x0 0x20000>;
+						read-only;
+					};
+
+					MIBIB@20000 {
+						label = "MIBIB";
+						reg = <0x20000 0x20000>;
+						read-only;
+					};
+
+					SBL2@40000 {
+						label = "SBL2";
+						reg = <0x40000 0x40000>;
+						read-only;
+					};
+
+					SBL3@80000 {
+						label = "SBL3";
+						reg = <0x80000 0x80000>;
+						read-only;
+					};
+
+					DDRCONFIG@100000 {
+						label = "DDRCONFIG";
+						reg = <0x100000 0x10000>;
+						read-only;
+					};
+
+					SSD@110000 {
+						label = "SSD";
+						reg = <0x110000 0x10000>;
+						read-only;
+					};
+
+					TZ@120000 {
+						label = "TZ";
+						reg = <0x120000 0x80000>;
+						read-only;
+					};
+
+					RPM@1a0000 {
+						label = "RPM";
+						reg = <0x1a0000 0x80000>;
+						read-only;
+					};
+
+					APPSBL@220000 {
+						label = "APPSBL";
+						reg = <0x220000 0x80000>;
+						read-only;
+					};
+
+					APPSBLENV@2a0000 {
+						label = "APPSBLENV";
+						reg = <0x2a0000 0x40000>;
+						read-only;
+					};
+
+					OLDART@2e0000 {
+						label = "OLDART";
+						reg = <0x2e0000 0x40000>;
+						read-only;
+					};
+
+					kernel@320000 {
+						label = "kernel";
+						reg = <0x320000 0x200000>;
+					};
+
+					rootfs@520000 {
+						label = "rootfs";
+						reg = <0x520000 0xa60000>;
+					};
+
+					defaultmac: default-mac@0xfaf100 {
+						label = "default-mac";
+						reg = <0xfaf100 0x00200>;
+						read-only;
+					};
+
+					ART@fc0000 {
+						label = "ART";
+						reg = <0xfc0000 0x40000>;
+						read-only;
+					};
+
+				};
+			};
+		};
+
+		phy@100f8800 {		/* USB3 port 1 HS phy */
+			status = "ok";
+		};
+
+		phy@100f8830 {		/* USB3 port 1 SS phy */
+			status = "ok";
+		};
+
+		phy@110f8800 {		/* USB3 port 0 HS phy */
+			status = "ok";
+		};
+
+		phy@110f8830 {		/* USB3 port 0 SS phy */
+			status = "ok";
+		};
+
+		usb30@0 {
+			status = "ok";
+		};
+
+		usb30@1 {
+			status = "ok";
+		};
+
+		pcie0: pci@1b500000 {
+			status = "ok";
+			phy-tx0-term-offset = <7>;
+		};
+
+		pcie1: pci@1b700000 {
+			status = "ok";
+			phy-tx0-term-offset = <7>;
+		};
+
+		mdio0: mdio {
+			compatible = "virtual,mdio-gpio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH &qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
+			pinctrl-0 = <&mdio0_pins>;
+			pinctrl-names = "default";
+
+			phy0: ethernet-phy@0 {
+				device_type = "ethernet-phy";
+				reg = <0>;
+				qca,ar8327-initvals = <
+					0x00004 0x7600000   /* PAD0_MODE */
+					0x00008 0x1000000   /* PAD5_MODE */
+					0x0000c 0x80        /* PAD6_MODE */
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
+					0x000e0 0xc74164de  /* SGMII_CTRL */
+					0x0007c 0x4e        /* PORT0_STATUS */
+					0x00094 0x4e        /* PORT6_STATUS */
+					>;
+			};
+
+			phy4: ethernet-phy@4 {
+				device_type = "ethernet-phy";
+				reg = <4>;
+			};
+		};
+
+		gmac1: ethernet@37200000 {
+			status = "ok";
+			phy-mode = "rgmii";
+			qcom,id = <1>;
+
+			pinctrl-0 = <&rgmii2_pins>;
+			pinctrl-names = "default";
+
+			mtd-mac-address = <&defaultmac 0>;
+			mtd-mac-address-increment = <1>;
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+
+		gmac2: ethernet@37400000 {
+			status = "ok";
+			phy-mode = "sgmii";
+			qcom,id = <2>;
+
+			mtd-mac-address = <&defaultmac 0>;
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+
+		rpm@108000 {
+			pinctrl-0 = <&i2c4_pins>;
+			pinctrl-names = "default";
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		wifi {
+			label = "wifi";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		dect {
+			label = "dect";
+			gpios = <&qcom_pinmux 67 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_PHONE>;
+		};
+
+		ledswitch {
+			label = "ledswitch";
+			gpios = <&qcom_pinmux 68 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		dsl {
+			label = "vr2600v:white:dsl";
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb {
+			label = "vr2600v:white:usb";
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan {
+			label = "vr2600v:white:lan";
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g {
+			label = "vr2600v:white:wlan2g";
+			gpios = <&qcom_pinmux 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g {
+			label = "vr2600v:white:wlan5g";
+			gpios = <&qcom_pinmux 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		power: power {
+			label = "vr2600v:white:power";
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		phone {
+			label = "vr2600v:white:phone";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan {
+			label = "vr2600v:white:wan";
+			gpios = <&qcom_pinmux 56 GPIO_ACTIVE_HIGH>;
+		};
+
+		general: general {
+			label = "vr2600v:white:general";
+			gpios = <&qcom_pinmux 66 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&adm_dma {
+	status = "ok";
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -224,6 +224,23 @@ define Device/NBG6817
 	$(call Device/ZyXELImage)
 endef
 
-TARGET_DEVICES += AP148 AP148-legacy C2600 D7800 DB149 EA8500 R7500 R7500v2 R7800 NBG6817
+define Device/VR2600v
+	PROFILES += $$(DEVICE_NAME)
+	FILESYSTEMS := squashfs
+	KERNEL_SUFFIX := -uImage
+	KERNEL = kernel-bin | append-dtb | uImage none
+	KERNEL_NAME := zImage
+	KERNEL_SIZE := 2097152
+	DEVICE_DTS := qcom-ipq8064-vr2600v
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	BOARD_NAME := vr2600v
+	DEVICE_TITLE := TP-Link Archer VR2600v
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0
+	IMAGES := sysupgrade.bin
+	IMAGE/sysupgrade.bin := pad-extra 512 | append-kernel | pad-to $$$${KERNEL_SIZE} | append-rootfs | pad-rootfs | append-metadata
+endef
+
+TARGET_DEVICES += AP148 AP148-legacy C2600 D7800 DB149 EA8500 R7500 R7500v2 R7800 NBG6817 VR2600v
 
 $(eval $(call BuildImage))


### PR DESCRIPTION
This pull request will provide initial support for TP-Link Archer VR2600v. It is possible to flash the sysupgrade image via tftp. Afterwards an upgrade via sysupgrade is possible.
Wifi is not working yet, so is the DSL modem.
I also began adding this router to the OpenWRT wiki: https://wiki.openwrt.org/inbox/tp-link/tp-link_archer_vr2600v_v1