### PR TITLE
download.pl: use curl in preference to wget

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -126,18 +126,18 @@ sub download
 			}
 		};
 	} else {
-		open WGET, "command -v curl >/dev/null 2>&1 && curl --connect-timeout 20 --retry 5 --location --insecure $curl_options '$mirror/$url_filename' || wget --tries=5 --timeout=20 --no-check-certificate $wget_options --output-document=- '$mirror/$url_filename' |" or die "Cannot launch curl or wget.\n";
+		open FETCH_FD, "command -v curl >/dev/null 2>&1 && curl --connect-timeout 20 --retry 5 --location --insecure $curl_options '$mirror/$url_filename' || wget --tries=5 --timeout=20 --no-check-certificate $wget_options --output-document=- '$mirror/$url_filename' |" or die "Cannot launch curl or wget.\n";
 		$hash_cmd and do {
 			open MD5SUM, "| $hash_cmd > '$target/$filename.hash'" or die "Cannot launch $hash_cmd.\n";
 		};
 		open OUTPUT, "> $target/$filename.dl" or die "Cannot create file $target/$filename.dl: $!\n";
 		my $buffer;
-		while (read WGET, $buffer, 1048576) {
+		while (read FETCH_FD, $buffer, 1048576) {
 			$hash_cmd and print MD5SUM $buffer;
 			print OUTPUT $buffer;
 		}
 		$hash_cmd and close MD5SUM;
-		close WGET;
+		close FETCH_FD;
 		close OUTPUT;
 
 		if ($? >> 8) {

--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -78,7 +78,8 @@ my $hash_cmd = hash_cmd();
 sub download
 {
 	my $mirror = shift;
-	my $options = $ENV{WGET_OPTIONS} || "";
+	my $wget_options = $ENV{WGET_OPTIONS} || "";
+	my $curl_options = $ENV{CURL_OPTIONS} || "";
 
 	$mirror =~ s!/$!!;
 
@@ -125,7 +126,7 @@ sub download
 			}
 		};
 	} else {
-		open WGET, "wget -t5 --timeout=20 --no-check-certificate $options -O- '$mirror/$url_filename' |" or die "Cannot launch wget.\n";
+		open WGET, "command -v curl >/dev/null 2>&1 && curl --connect-timeout 20 --retry 5 --location --insecure $curl_options '$mirror/$url_filename' || wget --tries=5 --timeout=20 --no-check-certificate $wget_options --output-document=- '$mirror/$url_filename' |" or die "Cannot launch curl or wget.\n";
 		$hash_cmd and do {
 			open MD5SUM, "| $hash_cmd > '$target/$filename.hash'" or die "Cannot launch $hash_cmd.\n";
 		};


### PR DESCRIPTION
Because wget doesn't know how to do Negotiate authentication with a proxy and curl does, use curl if it's present. The user is expected to have a ~/.curlrc that sets the options necessary for any proxy authentication. A ~/.curlrc is completely optional however and curl will work in exactly the same manner as wget without one.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>