### PR TITLE
base-files: add a wrapper for init scripts in profile 

### DIFF
--- a/package/base-files/files/etc/profile
+++ b/package/base-files/files/etc/profile
@@ -41,3 +41,14 @@ in order to prevent unauthorized SSH logins.
 --------------------------------------------------
 EOF
 fi
+
+service() {
+if [ -f "/etc/init.d/$1" ]; then
+        "/etc/init.d/$@"
+else
+	printf '%s\n%s\n' "unknown service" "list of available services :"
+	ls "/etc/init.d"
+	return 1
+fi
+}
+


### PR DESCRIPTION
"service" is a simple wrapper that will allow to call init scripts in /etc/init.d by writing "service" (the wrapper's name) followed by the init script's name and then by the command. Here an example.

current method:     #  /etc/init.d/network reload
with the wrapper:   #  service network reload

If the wrapper is called without arguments or with a wrong init script name, it will list the content of etc/init.d/ folder, showing what initscripts can be called.

This wrapper mimicks the main function "service" utility found in linux distros, see manual here https://linux.die.net/man/8/service that was born as a wrapper for initscripts and is now a wrapper for some systemctl (systemd) functions.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>