### PR TITLE
ramips: SamKnows SK-WB8 DTS cleanup

### DIFF
--- a/target/linux/ramips/dts/SK-WB8.dts
+++ b/target/linux/ramips/dts/SK-WB8.dts
@@ -1,8 +1,8 @@
 /dts-v1/;
 
 #include "mt7621.dtsi"
-
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
 
 / {
 	compatible = "mediatek,mt7621-eval-board", "mediatek,mt7621-soc";
@@ -22,12 +22,12 @@
 
 		wps {
 			label = "sk-wb8:green:wps";
-			gpios = <&gpio1 14 1>;
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
 			label = "sk-wb8:green:usb";
-			gpios = <&gpio1 15 1>;
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -38,12 +38,12 @@
 		poll-interval = <20>;
 		wps {
 			label = "wps";
-			gpios = <&gpio1 11 1>;
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 		reset {
 			label = "reset";
-			gpios = <&gpio1 9 1>;
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};
@@ -79,12 +79,7 @@
 
 		partition@50000 {
 			label = "firmware";
-			reg = <0x50000 0x7b0000>;
-		};
-
-		partition@e30000 {
-			label = "recovery";
-			reg = <0xe30000 0x1d0000>;
+			reg = <0x50000 0xfb0000>;
 		};
 
 	};


### PR DESCRIPTION
Use gpio.h definition of GPIO_ACTIVE_HIGH and GPIO_ACTIVE_LOW.
Remove unused backup partition to increase available JFFS space. As long as U-Boot env variable "bootcount" is < 3 (reset to 0 after boot by init script) SamKnow's U-Boot will not attempt to boot from the backup flash address (0xe30000).

Signed-off-by: Andrew Yong <me@ndoo.sg>