### PR TITLE
ramips: fix wrong check for MT7621AT fix in sdhci

### DIFF
--- a/target/linux/ramips/patches-4.4/0046-mmc-MIPS-ralink-add-sdhci-for-mt7620a-SoC.patch
+++ b/target/linux/ramips/patches-4.4/0046-mmc-MIPS-ralink-add-sdhci-for-mt7620a-SoC.patch
@@ -3906,7 +3906,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +    host->mrq = mrq;    
 +
 +    if (msdc_do_request(mmc,mrq)) {  	
-+        if(host->hw->flags & MSDC_REMOVABLE && CONFIG_SOC_MT7621 && mrq->data && mrq->data->error) {
++        if(host->hw->flags & MSDC_REMOVABLE && ralink_soc == MT762X_SOC_MT7621AT && mrq->data && mrq->data->error) {
 +            msdc_tune_request(mmc,mrq);                                    	
 +        }        	
 +    }


### PR DESCRIPTION
Use ralink_soc == MT762X_SOC_MT7621AT instead of CONFIG_SOC_MT7621 which is wrong and breaks builds on mt7620a-similar platforms (MT7621, MT7688)

Signed-off-by: Andrew Yong <me@ndoo.sg>