### PR TITLE
ipq806x: clean up dts files

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -16,7 +16,7 @@ c2600)
 	ucidef_set_led_usbport "usb2" "USB 2" "${board}:white:usb_4" "usb3-port1" "usb4-port1"
 	ucidef_set_led_switch "wan" "wan" "${board}:white:wan" "switch0" "0x20"
 	ucidef_set_led_switch "lan" "lan" "${board}:white:lan" "switch0" "0x1e"
-	ucidef_set_led_default "general" "general" "${board}:white:ledgnr" "1"
+	ucidef_set_led_default "general" "general" "${board}:white:general" "1"
 	;;
 d7800 |\
 r7500 |\

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
@@ -1,4 +1,5 @@
 #include "qcom-ipq8064-v1.0.dtsi"
+
 #include <dt-bindings/input/input.h>
 
 / {
@@ -25,9 +26,9 @@
 		mdio-gpio0 = &mdio0;
 
 		led-boot = &power;
-		led-failsafe = &ledgnr;
+		led-failsafe = &general;
 		led-running = &power;
-		led-upgrade = &ledgnr;
+		led-upgrade = &general;
 	};
 
 	chosen {
@@ -36,10 +37,32 @@
 
 	soc {
 		pinmux@800000 {
+			button_pins: button_pins {
+				mux {
+					pins = "gpio16", "gpio54", "gpio65";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
 			i2c4_pins: i2c4_pinmux {
-				pins = "gpio12", "gpio13";
-				function = "gsbi4";
-				bias-disable;
+				mux {
+					pins = "gpio12", "gpio13";
+					function = "gsbi4";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
+			led_pins: led_pins {
+				mux {
+					pins = "gpio6", "gpio7", "gpio8", "gpio9", "gpio26", "gpio33",
+					       "gpio53", "gpio66";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
 			};
 
 			spi_pins: spi_pins {
@@ -56,6 +79,7 @@
 
 				cs {
 					pins = "gpio20";
+					function = "gpio";
 					drive-strength = <10>;
 					bias-pull-up;
 				};
@@ -63,31 +87,6 @@
 				clk {
 					pins = "gpio21";
 					drive-strength = <12>;
-				};
-			};
-
-			nand_pins: nand_pins {
-				mux {
-					pins = "gpio34", "gpio35", "gpio36",
-					       "gpio37", "gpio38", "gpio39",
-					       "gpio40", "gpio41", "gpio42",
-					       "gpio43", "gpio44", "gpio45",
-					       "gpio46", "gpio47";
-					function = "nand";
-					drive-strength = <10>;
-					bias-disable;
-				};
-
-				pullups {
-					pins = "gpio39";
-					bias-pull-up;
-				};
-
-				hold {
-					pins = "gpio40", "gpio41", "gpio42",
-					       "gpio43", "gpio44", "gpio45",
-					       "gpio46", "gpio47";
-					bias-bus-hold;
 				};
 			};
 
@@ -107,6 +106,26 @@
 					function = "rgmii2";
 					drive-strength = <8>;
 					bias-disable;
+				};
+			};
+
+			usb0_pwr_en_pin: usb0_pwr_en_pin {
+				mux {
+					pins = "gpio25";
+					function = "gpio";
+					drive-strength = <10>;
+					bias-pull-up;
+					output-high;
+				};
+			};
+
+			usb1_pwr_en_pin: usb1_pwr_en_pin {
+				mux {
+					pins = "gpio23";
+					function = "gpio";
+					drive-strength = <10>;
+					bias-pull-up;
+					output-high;
 				};
 			};
 		};
@@ -314,10 +333,16 @@
 
 		usb30@0 {
 			status = "ok";
+
+			pinctrl-0 = <&usb0_pwr_en_pin>;
+			pinctrl-names = "default";
 		};
 
 		usb30@1 {
 			status = "ok";
+
+			pinctrl-0 = <&usb1_pwr_en_pin>;
+			pinctrl-names = "default";
 		};
 
 		pcie0: pci@1b500000 {
@@ -387,10 +412,17 @@
 				full-duplex;
 			};
 		};
+
+		rpm@108000 {
+			pinctrl-0 = <&i2c4_pins>;
+			pinctrl-names = "default";
+		};
 	};
 
 	gpio-keys {
 		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
 
 		wifi {
 			label = "wifi";
@@ -410,15 +442,17 @@
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
-                ledgeneral {
-			label = "ledgeneral";
+		ledswitch {
+			label = "ledswitch";
 			gpios = <&qcom_pinmux 16 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_DOLLAR>;
+			linux,code = <KEY_LIGHTS_TOGGLE>;
 		};
 	};
 
 	gpio-leds {
 		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
 
 		lan {
 			label = "c2600:white:lan";
@@ -441,7 +475,7 @@
 		};
 
 		wan_red {
-			label = "c2600:red:wan";
+			label = "c2600:orange:wan";
 			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_LOW>;
 		};
 
@@ -453,27 +487,12 @@
 		power: status {
 			label = "c2600:white:status";
 			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
 		};
 
-		ledgnr: ledgnr {
-			label = "c2600:white:ledgnr";
+		general: general {
+			label = "c2600:white:general";
 			gpios = <&qcom_pinmux 66 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb1_power {
-			gpio-export,name = "usb1_power";
-			gpio-export,output = <1>;
-			gpios = <&qcom_pinmux 25 GPIO_ACTIVE_HIGH>;
-		};
-		usb2_power {
-			gpio-export,name = "usb2_power";
-			gpio-export,output = <1>;
-			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -24,6 +24,11 @@
 	aliases {
 		serial0 = &uart4;
 		mdio-gpio0 = &mdio0;
+
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
 	};
 
 	chosen {
@@ -33,26 +38,39 @@
 
 	soc {
 		pinmux@800000 {
-			i2c4_pins: i2c4_pinmux {
-				pins = "gpio12", "gpio13";
-				function = "gsbi4";
-				bias-disable;
+			button_pins: button_pins {
+				mux {
+					pins = "gpio6", "gpio54", "gpio65";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
 			};
 
-			pcie0_pins: pcie0_pinmux {
+			i2c4_pins: i2c4_pinmux {
 				mux {
-					pins = "gpio3";
-					function = "pcie1_rst";
+					pins = "gpio12", "gpio13";
+					function = "gsbi4";
 					drive-strength = <12>;
 					bias-disable;
 				};
 			};
 
-			pcie1_pins: pcie1_pinmux {
+			led_pins: led_pins {
 				mux {
-					pins = "gpio48";
-					function = "pcie2_rst";
-					drive-strength = <12>;
+					pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
+						"gpio24","gpio26", "gpio53", "gpio64", "gpio67";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
 					bias-disable;
 				};
 			};
@@ -80,15 +98,6 @@
 				};
 			};
 
-			mdio0_pins: mdio0_pins {
-				mux {
-					pins = "gpio0", "gpio1";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-disable;
-				};
-			};
-
 			rgmii2_pins: rgmii2_pins {
 				mux {
 					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
@@ -96,6 +105,26 @@
 					function = "rgmii2";
 					drive-strength = <8>;
 					bias-disable;
+				};
+			};
+
+			usb0_pwr_en_pins: usb0_pwr_en_pins {
+				mux {
+					pins = "gpio15";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-down;
+					output-high;
+				};
+			};
+
+			usb1_pwr_en_pins: usb1_pwr_en_pins {
+				mux {
+					pins = "gpio16", "gpio68";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-down;
+					output-high;
 				};
 			};
 		};
@@ -140,22 +169,28 @@
 
 		usb30@0 {
 			status = "ok";
+
+			pinctrl-0 = <&usb0_pwr_en_pins>;
+			pinctrl-names = "default";
 		};
 
 		usb30@1 {
 			status = "ok";
+
+			pinctrl-0 = <&usb1_pwr_en_pins>;
+			pinctrl-names = "default";
 		};
 
 		pcie0: pci@1b500000 {
 			status = "ok";
-			reset-gpio = <&qcom_pinmux 3 0>;
+			reset-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_HIGH>;
 			pinctrl-0 = <&pcie0_pins>;
 			pinctrl-names = "default";
 		};
 
 		pcie1: pci@1b700000 {
 			status = "ok";
-			reset-gpio = <&qcom_pinmux 48 0>;
+			reset-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_HIGH>;
 			pinctrl-0 = <&pcie1_pins>;
 			pinctrl-names = "default";
 		};
@@ -228,14 +263,13 @@
 				label = "firmware";
 				reg = <0x1480000 0x2000000>;
 			};
-
 		};
 
 		mdio0: mdio {
 			compatible = "virtual,mdio-gpio";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			gpios = <&qcom_pinmux 1 0 &qcom_pinmux 0 0>;
+			gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH &qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
 			pinctrl-0 = <&mdio0_pins>;
 			pinctrl-names = "default";
 
@@ -283,82 +317,91 @@
 				full-duplex;
 			};
 		};
+
+		rpm@108000 {
+			pinctrl-0 = <&i2c4_pins>;
+			pinctrl-names = "default";
+		};
 	};
 
 	gpio-keys {
 		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
 
 		wifi {
 			label = "wifi";
-			gpios = <&qcom_pinmux 6 1>;
-			linux,code = <KEY_WLAN>;
+			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&qcom_pinmux 54 1>;
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&qcom_pinmux 65 1>;
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
 
 	gpio-leds {
 		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
 
 		usb1 {
 			label = "d7800:amber:usb1";
-			gpios = <&qcom_pinmux 7 0>;
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		usb3 {
 			label = "d7800:amber:usb3";
-			gpios = <&qcom_pinmux 8 0>;
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		status {
 			label = "d7800:amber:status";
-			gpios = <&qcom_pinmux 9 0>;
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		internet {
 			label = "d7800:white:internet";
-			gpios = <&qcom_pinmux 22 0>;
+			gpios = <&qcom_pinmux 22 GPIO_ACTIVE_HIGH>;
 		};
 
 		wan {
 			label = "d7800:white:wan";
-			gpios = <&qcom_pinmux 23 0>;
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
 		};
 
 		wps {
 			label = "d7800:white:wps";
-			gpios = <&qcom_pinmux 24 0>;
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
 		};
 
 		esata {
 			label = "d7800:white:esata";
-			gpios = <&qcom_pinmux 26 0>;
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
 		};
 
-		power {
+		power: power {
 			label = "d7800:white:power";
-			gpios = <&qcom_pinmux 53 0>;
-			default-state = "on";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
 		};
 
 		rfkill {
 			label = "d7800:white:rfkill";
-			gpios = <&qcom_pinmux 64 0>;
+			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_HIGH>;
 		};
 
 		wifi5g {
 			label = "d7800:white:wifi5g";
-			gpios = <&qcom_pinmux 67 0>;
+			gpios = <&qcom_pinmux 67 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
@@ -39,20 +39,42 @@
 
 	soc {
 		pinmux@800000 {
-			i2c4_pins: i2c4_pinmux {
-				pins = "gpio12", "gpio13";
-				function = "gsbi4";
-				bias-disable;
-			};
-
-			spi_pins: spi_pins {
+			button_pins: button_pins {
 				mux {
-					pins = "gpio18", "gpio19", "gpio21";
-					function = "gsbi5";
-					drive-strength = <10>;
-					bias-none;
+					pins = "gpio65", "gpio67", "gpio68";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
 				};
 			};
+
+			i2c4_pins: i2c4_pinmux {
+				mux {
+					pins = "gpio12", "gpio13";
+					function = "gsbi4";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
+			led_pins: led_pins {
+				mux {
+					pins = "gpio6", "gpio53", "gpio54";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+
 			nand_pins: nand_pins {
 				mux {
 					pins = "gpio34", "gpio35", "gpio36",
@@ -76,15 +98,6 @@
 				};
 			};
 
-			mdio0_pins: mdio0_pins {
-				mux {
-					pins = "gpio0", "gpio1";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-disable;
-				};
-			};
-
 			rgmii2_pins: rgmii2_pins {
 				mux {
 					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
@@ -94,9 +107,6 @@
 					bias-disable;
 				};
 			};
-			
-			
-			
 		};
 
 		gsbi@16300000 {
@@ -207,7 +217,7 @@
 				reg = <0x0660000 0x0120000>;
 				read-only;
 			};
-			
+
 			TZ@780000 {
 				label = "TZ";
 				reg = <0x0780000 0x0280000>;
@@ -231,54 +241,53 @@
 				reg = <0x0dc0000 0x0100000>;
 				read-only;
 			};
-			
+
 			u_env@ec0000 {
 				label = "u_env";
 				reg = <0x0ec0000 0x0040000>;
 			};
-			
+
 			s_env@f00000 {
 				label = "s_env";
 				reg = <0x0f00000 0x0040000>;
 			};
-			
+
 			devinfo@f40000 {
 				label = "devinfo";
 				reg = <0x0f40000 0x0040000>;
 			};
-			
+
 			linux@f80000 { 
 				label = "kernel1";
 				reg = <0x0f80000 0x2800000>;  /* 3 MB spill to rootfs*/
 			};
-			
+
 			rootfs@1280000 {
 				label = "rootfs1";
 				reg = <0x1280000 0x2500000>;
 			};
-			
+
 			linux2@3780000 {
 				label = "kernel2";
 				reg = <0x3780000 0x2800000>;
 			};
-			
+
 			rootfs2@3a80000 {
 				label = "rootfs2";
 				reg = <0x3a80000 0x2500000>;
 			};
-			
+
 			syscfg@5f80000 {
 				label = "syscfg";
 				reg = <0x5f80000 0x2080000>;
 			};
-
 		};
 
 		mdio0: mdio {
 			compatible = "virtual,mdio-gpio";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			gpios = <&qcom_pinmux 1 0 &qcom_pinmux 0 0>;
+			gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH &qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
 			pinctrl-0 = <&mdio0_pins>;
 			pinctrl-names = "default";
 
@@ -332,17 +341,23 @@
 			};
 		};
 
+		rpm@108000 {
+			pinctrl-0 = <&i2c4_pins>;
+			pinctrl-names = "default";
+		};
+
 		adm_dma: dma@18300000 {
 			status = "ok";
 		};
-
 	};
 
 	gpio-keys {
 		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
 
-		rfkill {
-			label = "rfkill"; /* WIFI on-off*/
+		wifi {
+			label = "wifi";
 			gpios = <&qcom_pinmux 67 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
 		};
@@ -358,29 +373,27 @@
 			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
-
 	};
 
 	gpio-leds {
 		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
 
 		wps {
 			label = "ea8500:green:wps";
-			gpios = <&qcom_pinmux 53 0>;
-			default-state = "off";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
 		};
 
 		power: power {
 			label = "ea8500:white:power";
-			gpios = <&qcom_pinmux 6 1>;
-			default-state = "off";
-			linux,default-trigger = "heartbeat";
+			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
 		};
 
 		wifi {
 			label = "ea8500:green:wifi";
-			gpios = <&qcom_pinmux 54 0>;
-			default-state = "off";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
@@ -24,6 +24,11 @@
 	aliases {
 		serial0 = &uart4;
 		mdio-gpio0 = &mdio0;
+
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
 	};
 
 	chosen {
@@ -33,10 +38,41 @@
 
 	soc {
 		pinmux@800000 {
+			button_pins: button_pins {
+				mux {
+					pins = "gpio6", "gpio54", "gpio65";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
 			i2c4_pins: i2c4_pinmux {
-				pins = "gpio12", "gpio13";
-				function = "gsbi4";
-				bias-disable;
+				mux {
+					pins = "gpio12", "gpio13";
+					function = "gsbi4";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
+			led_pins: led_pins {
+				mux {
+					pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
+						"gpio24","gpio26", "gpio53", "gpio64", "gpio67";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
 			};
 
 			nand_pins: nand_pins {
@@ -59,15 +95,6 @@
 					       "gpio43", "gpio44", "gpio45",
 					       "gpio46", "gpio47";
 					bias-bus-hold;
-				};
-			};
-
-			mdio0_pins: mdio0_pins {
-				mux {
-					pins = "gpio0", "gpio1";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-disable;
 				};
 			};
 
@@ -205,7 +232,7 @@
 			compatible = "virtual,mdio-gpio";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			gpios = <&qcom_pinmux 1 0 &qcom_pinmux 0 0>;
+			gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH &qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
 			pinctrl-0 = <&mdio0_pins>;
 			pinctrl-names = "default";
 
@@ -257,82 +284,91 @@
 				full-duplex;
 			};
 		};
+
+		rpm@108000 {
+			pinctrl-0 = <&i2c4_pins>;
+			pinctrl-names = "default";
+		};
 	};
 
 	gpio-keys {
 		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
 
 		wifi {
 			label = "wifi";
-			gpios = <&qcom_pinmux 6 1>;
-			linux,code = <KEY_WLAN>;
+			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&qcom_pinmux 54 1>;
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&qcom_pinmux 65 1>;
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
 
 	gpio-leds {
 		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
 
 		usb1 {
 			label = "r7500:amber:usb1";
-			gpios = <&qcom_pinmux 7 0>;
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		usb3 {
 			label = "r7500:amber:usb3";
-			gpios = <&qcom_pinmux 8 0>;
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		status {
 			label = "r7500:amber:status";
-			gpios = <&qcom_pinmux 9 0>;
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		internet {
 			label = "r7500:white:internet";
-			gpios = <&qcom_pinmux 22 0>;
+			gpios = <&qcom_pinmux 22 GPIO_ACTIVE_HIGH>;
 		};
 
 		wan {
 			label = "r7500:white:wan";
-			gpios = <&qcom_pinmux 23 0>;
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
 		};
 
 		wps {
 			label = "r7500:white:wps";
-			gpios = <&qcom_pinmux 24 0>;
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
 		};
 
 		esata {
 			label = "r7500:white:esata";
-			gpios = <&qcom_pinmux 26 0>;
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
 		};
 
-		power {
+		power: power {
 			label = "r7500:white:power";
-			gpios = <&qcom_pinmux 53 0>;
-			default-state = "on";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
 		};
 
 		rfkill {
 			label = "r7500:white:rfkill";
-			gpios = <&qcom_pinmux 64 0>;
+			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_HIGH>;
 		};
 
 		wifi5g {
 			label = "r7500:white:wifi5g";
-			gpios = <&qcom_pinmux 67 0>;
+			gpios = <&qcom_pinmux 67 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
@@ -29,6 +29,11 @@
 	aliases {
 		serial0 = &uart4;
 		mdio-gpio0 = &mdio0;
+
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
 	};
 
 	chosen {
@@ -38,10 +43,41 @@
 
 	soc {
 		pinmux@800000 {
+			button_pins: button_pins {
+				mux {
+					pins = "gpio6", "gpio54", "gpio65";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
 			i2c4_pins: i2c4_pinmux {
-				pins = "gpio12", "gpio13";
-				function = "gsbi4";
-				bias-disable;
+				mux {
+					pins = "gpio12", "gpio13";
+					function = "gsbi4";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
+			led_pins: led_pins {
+				mux {
+					pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
+						"gpio24","gpio26", "gpio53", "gpio64";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
 			};
 
 			nand_pins: nand_pins {
@@ -67,15 +103,6 @@
 				};
 			};
 
-			mdio0_pins: mdio0_pins {
-				mux {
-					pins = "gpio0", "gpio1";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-disable;
-				};
-			};
-
 			rgmii2_pins: rgmii2_pins {
 				mux {
 					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
@@ -83,6 +110,26 @@
 					function = "rgmii2";
 					drive-strength = <8>;
 					bias-disable;
+				};
+			};
+
+			usb0_pwr_en_pins: usb0_pwr_en_pins {
+				mux {
+					pins = "gpio15";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-down;
+					output-high;
+				};
+			};
+
+			usb1_pwr_en_pins: usb1_pwr_en_pins {
+				mux {
+					pins = "gpio16", "gpio68";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-down;
+					output-high;
 				};
 			};
 		};
@@ -127,10 +174,16 @@
 
 		usb30@0 {
 			status = "ok";
+
+			pinctrl-0 = <&usb0_pwr_en_pins>;
+			pinctrl-names = "default";
 		};
 
 		usb30@1 {
 			status = "ok";
+
+			pinctrl-0 = <&usb1_pwr_en_pins>;
+			pinctrl-names = "default";
 		};
 
 		pcie0: pci@1b500000 {
@@ -222,7 +275,7 @@
 			compatible = "virtual,mdio-gpio";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			gpios = <&qcom_pinmux 1 0 &qcom_pinmux 0 0>;
+			gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH &qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
 			pinctrl-0 = <&mdio0_pins>;
 			pinctrl-names = "default";
 
@@ -274,79 +327,87 @@
 				full-duplex;
 			};
 		};
+
+		rpm@108000 {
+			pinctrl-0 = <&i2c4_pins>;
+			pinctrl-names = "default";
+		};
 	};
 
 	gpio-keys {
 		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
 
 		wifi {
 			label = "wifi";
-			gpios = <&qcom_pinmux 6 1>;
-			linux,code = <KEY_WLAN>;
+			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&qcom_pinmux 54 1>;
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&qcom_pinmux 65 1>;
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
 
 	gpio-leds {
 		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
 
 		usb1 {
 			label = "r7500v2:amber:usb1";
-			gpios = <&qcom_pinmux 7 0>;
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		usb3 {
 			label = "r7500v2:amber:usb3";
-			gpios = <&qcom_pinmux 8 0>;
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		status {
 			label = "r7500v2:amber:status";
-			gpios = <&qcom_pinmux 9 0>;
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		internet {
 			label = "r7500v2:white:internet";
-			gpios = <&qcom_pinmux 22 0>;
+			gpios = <&qcom_pinmux 22 GPIO_ACTIVE_HIGH>;
 		};
 
 		wan {
 			label = "r7500v2:white:wan";
-			gpios = <&qcom_pinmux 23 0>;
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
 		};
 
 		wps {
 			label = "r7500v2:white:wps";
-			gpios = <&qcom_pinmux 24 0>;
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
 		};
 
 		esata {
 			label = "r7500v2:white:esata";
-			gpios = <&qcom_pinmux 26 0>;
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
 		};
 
-		power {
+		power: power {
 			label = "r7500v2:white:power";
-			gpios = <&qcom_pinmux 53 0>;
-			default-state = "on";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
 		};
 
 		rfkill {
 			label = "r7500v2:white:rfkill";
-			gpios = <&qcom_pinmux 64 0>;
+			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 };
 

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-vr2600v.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-vr2600v.dts
@@ -38,11 +38,13 @@
 	soc {
 		pinmux@800000 {
 			led_pins: led_pins {
-				pins = "gpio7", "gpio8", "gpio9", "gpio16", "gpio17",
-					"gpio26", "gpio53", "gpio56", "gpio66";
-				function = "gpio";
-				drive-strength = <2>;
-				bias-pull-up;
+				mux {
+					pins = "gpio7", "gpio8", "gpio9", "gpio16", "gpio17",
+						"gpio26", "gpio53", "gpio56", "gpio66";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
 			};
 
 			i2c4_pins: i2c4_pinmux {
@@ -55,10 +57,12 @@
 			};
 
 			button_pins: button_pins {
-				pins = "gpio54", "gpio64", "gpio65", "gpio67", "gpio68";
-				function = "gpio";
-				drive-strength = <2>;
-				bias-pull-up;
+				mux {
+					pins = "gpio54", "gpio64", "gpio65", "gpio67", "gpio68";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
 			};
 
 			spi_pins: spi_pins {
@@ -103,7 +107,6 @@
 					bias-disable;
 				};
 			};
-
 		};
 
 		gsbi@16300000 {
@@ -227,7 +230,6 @@
 						reg = <0xfc0000 0x40000>;
 						read-only;
 					};
-
 				};
 			};
 		};

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-nbg6817.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-nbg6817.dts
@@ -25,6 +25,11 @@
 		serial0 = &uart4;
 		mdio-gpio0 = &mdio0;
 		sdcc1 = &sdcc1;
+
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
 	};
 
 	chosen {
@@ -34,8 +39,14 @@
 
 	soc {
 		pinmux@800000 {
-			pinctrl-0 = <&mdio0_pins &rgmii2_pins>;
-			pinctrl-names = "default";
+			button_pins: button_pins {
+				mux {
+					pins = "gpio6", "gpio54", "gpio65";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
 
 			i2c4_pins: i2c4_pinmux {
 				mux {
@@ -43,6 +54,22 @@
 					function = "gsbi4";
 					drive-strength = <12>;
 					bias-disable;
+				};
+			};
+
+			led_pins: led_pins {
+				off {
+					pins = "gpio26", "gpio33", "gpio64";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-down;
+				};
+
+				on {
+					pins = "gpio9";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
 				};
 			};
 
@@ -86,6 +113,42 @@
 				cs {
 					pins = "gpio20";
 					drive-strength = <12>;
+				};
+			};
+
+			usb0_pwr_en_pins: usb0_pwr_en_pins {
+				pwr {
+					pins = "gpio14";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-down;
+					output-high;
+				};
+
+				ovc {
+					pins = "gpio15";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-up;
+					output-high;
+				};
+			};
+
+			usb1_pwr_en_pins: usb1_pwr_en_pins {
+				pwr {
+					pins = "gpio17";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-down;
+					output-high;
+				};
+
+				ovc {
+					pins = "gpio16";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-up;
+					output-high;
 				};
 			};
 		};
@@ -146,10 +209,16 @@
 
 		usb30@0 {
 			status = "ok";
+
+			pinctrl-0 = <&usb0_pwr_en_pins>;
+			pinctrl-names = "default";
 		};
 
 		usb30@1 {
 			status = "ok";
+
+			pinctrl-0 = <&usb1_pwr_en_pins>;
+			pinctrl-names = "default";
 		};
 
 		pcie0: pci@1b500000 {
@@ -170,7 +239,9 @@
 			compatible = "virtual,mdio-gpio";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			gpios = <&qcom_pinmux 1 0 &qcom_pinmux 0 0>;
+			gpios = <&qcom_pinmux 1 GPIO_ACTIVE_LOW &qcom_pinmux 0 GPIO_ACTIVE_LOW>;
+			pinctrl-0 = <&mdio0_pins>;
+			pinctrl-names = "default";
 
 			phy0: ethernet-phy@0 {
 				device_type = "ethernet-phy";
@@ -222,6 +293,9 @@
 			qcom,irq = <255>;
 			mdiobus = <&mdio0>;
 
+			pinctrl-0 = <&rgmii2_pins>;
+			pinctrl-names = "default";
+
 			fixed-link {
 				speed = <1000>;
 				full-duplex;
@@ -253,18 +327,18 @@
 
 		amba {
 			sdcc1: sdcc@12400000 {
-				status          = "okay";
-                                dmas = <&sdcc1bam 2>, <&sdcc1bam 1>;
-                                dma-names = "tx", "rx";
+				status = "okay";
+				dmas = <&sdcc1bam 2>, <&sdcc1bam 1>;
+				dma-names = "tx", "rx";
 			};
 		};
-
-
-
 	};
 
 	gpio-keys {
 		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
 		wifi {
 			label = "wifi";
 			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
@@ -286,15 +360,17 @@
 
 	gpio-leds {
 		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
 		internet {
 			label = "nbg6817:white:internet";
 			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_HIGH>;
 		};
 
-		power {
+		power: power {
 			label = "nbg6817:white:power";
 			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
-			default-state = "on";
 		};
 
 		wifi {
@@ -305,33 +381,6 @@
 		wifi5g {
 			label = "nbg6817:amber:wifi5g";
 			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb0_status {
-			gpio-export,name = "usb0";
-			gpio-export,output = <1>;
-			gpios = <&qcom_pinmux 15 GPIO_ACTIVE_HIGH>;
-		};
-
-		usb1_status {
-			gpio-export,name = "usb1";
-			gpio-export,output = <1>;
-			gpios = <&qcom_pinmux 16 GPIO_ACTIVE_HIGH>;
-		};
-		usb1_power {
-			gpio-export,name = "usb1_power";
-			gpio-export,output = <1>;
-			gpios = <&qcom_pinmux 14 GPIO_ACTIVE_HIGH>;
-		};
-		usb2_power {
-			gpio-export,name = "usb2_power";
-			gpio-export,output = <1>;
-			gpios = <&qcom_pinmux 17 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
@@ -42,8 +42,14 @@
 
 	soc {
 		pinmux@800000 {
-			pinctrl-0 = <&mdio0_pins &rgmii2_pins>;
-			pinctrl-names = "default";
+			button_pins: button_pins {
+				mux {
+					pins = "gpio6", "gpio54", "gpio65";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
 
 			i2c4_pins: i2c4_pinmux {
 				mux {
@@ -52,6 +58,14 @@
 					drive-strength = <12>;
 					bias-disable;
 				};
+			};
+
+			led_pins: led_pins {
+				pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
+					"gpio24","gpio26", "gpio53", "gpio64", "gpio67";
+				function = "gpio";
+				drive-strength = <2>;
+				bias-pull-down;
 			};
 
 			nand_pins: nand_pins {
@@ -165,6 +179,26 @@
 					output-high;
 				};
 			};
+
+			usb0_pwr_en_pins: usb0_pwr_en_pins {
+				mux {
+					pins = "gpio15";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-down;
+					output-high;
+				};
+			};
+
+			usb1_pwr_en_pins: usb1_pwr_en_pins {
+				mux {
+					pins = "gpio16", "gpio68";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-down;
+					output-high;
+				};
+			};
 		};
 
 		gsbi@16300000 {
@@ -191,7 +225,7 @@
 				pinctrl-0 = <&spi_pins>;
 				pinctrl-names = "default";
 
-				cs-gpios = <&qcom_pinmux 20 0>;
+				cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
 
 				flash: m25p80@0 {
 					compatible = "jedec,spi-nor";
@@ -214,7 +248,7 @@
 				pinctrl-0 = <&spi6_pins>;
 				pinctrl-names = "default";
 
-				cs-gpios = <&qcom_pinmux 57 0>;
+				cs-gpios = <&qcom_pinmux 57 GPIO_ACTIVE_HIGH>;
 
 				spi-nor@0 {
 					compatible = "spi-nor";
@@ -251,10 +285,16 @@
 
 		usb30@0 {
 			status = "ok";
+
+			pinctrl-0 = <&usb0_pwr_en_pins>;
+			pinctrl-names = "default";
 		};
 
 		usb30@1 {
 			status = "ok";
+
+			pinctrl-0 = <&usb1_pwr_en_pins>;
+			pinctrl-names = "default";
 		};
 
 		pcie0: pci@1b500000 {
@@ -336,14 +376,16 @@
 				label = "firmware";
 				reg = <0x1480000 0x2000000>;
 			};
-
 		};
 
 		mdio0: mdio {
 			compatible = "virtual,mdio-gpio";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			gpios = <&qcom_pinmux 1 0 &qcom_pinmux 0 0>;
+			gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH &qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
+			pinctrl-0 = <&mdio0_pins>;
+			pinctrl-names = "default";
+
 
 			phy0: ethernet-phy@0 {
 				device_type = "ethernet-phy";
@@ -399,6 +441,9 @@
 			qcom,irq = <255>;
 			mdiobus = <&mdio0>;
 
+			pinctrl-0 = <&rgmii2_pins>;
+			pinctrl-names = "default";
+
 			mtd-mac-address = <&art 6>;
 
 			fixed-link {
@@ -435,10 +480,12 @@
 
 	gpio-keys {
 		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
 
 		wifi {
 			label = "wifi";
-			gpios = <&qcom_pinmux 6 1>;
+			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
 			debounce-interval = <60>;
 			wakeup-source;
@@ -446,7 +493,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&qcom_pinmux 54 1>;
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 			debounce-interval = <60>;
 			wakeup-source;
@@ -454,7 +501,7 @@
 
 		wps {
 			label = "wps";
-			gpios = <&qcom_pinmux 65 1>;
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 			debounce-interval = <60>;
 			wakeup-source;
@@ -463,79 +510,58 @@
 
 	gpio-leds {
 		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
 
 		power_white: power_white {
 			label = "r7800:white:power";
-			gpios = <&qcom_pinmux 53 0>;
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
 			default-state = "on";
 		};
 
 		power_amber: power_amber {
 			label = "r7800:amber:power";
-			gpios = <&qcom_pinmux 9 0>;
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		wan_white {
 			label = "r7800:white:wan";
-			gpios = <&qcom_pinmux 22 0>;
+			gpios = <&qcom_pinmux 22 GPIO_ACTIVE_HIGH>;
 		};
 
 		wan_amber {
 			label = "r7800:amber:wan";
-			gpios = <&qcom_pinmux 23 0>;
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
 		};
 
 		usb1 {
 			label = "r7800:white:usb1";
-			gpios = <&qcom_pinmux 7 0>;
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		usb2 {
 			label = "r7800:white:usb2";
-			gpios = <&qcom_pinmux 8 0>;
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		esata {
 			label = "r7800:white:esata";
-			gpios = <&qcom_pinmux 26 0>;
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
 		};
 
 		rfkill {
 			label = "r7800:white:rfkill";
-			gpios = <&qcom_pinmux 64 0>;
+			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_HIGH>;
 		};
 
 		wps {
 			label = "r7800:white:wps";
-			gpios = <&qcom_pinmux 24 0>;
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
 		};
 
 		wifi {
 			label = "r7800:white:wifi";
-			gpios = <&qcom_pinmux 67 0>;
-		};
-	};
-
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb1-power {
-			gpio-export,name = "usb1";
-			gpio-export,output = <1>;
-			gpios = <&qcom_pinmux 15 0>;
-		};
-
-		usb2-power {
-			gpio-export,name = "usb2";
-			gpio-export,output = <1>;
-			gpios = <&qcom_pinmux 16 0>;
-		};
-
-		usb-power {
-			gpio-export,name = "usb_p";
-			gpio-export,output = <1>;
-			gpios = <&qcom_pinmux 68 0>;
+			gpios = <&qcom_pinmux 67 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };


### PR DESCRIPTION
- Set the pinmux to the values found in the GPL tarballs of the boards.
Remove pinmux which are is not used (like nand pinmux for spi
flash boards).
This allows to use the wan orange led of the C2600 which had a wrong
pinmux before. Might fix buttons or leds of other boards as well.

- Fix the LED color and the ledswitch key code of the C2600. Rename the
ledgnr to ledswitch.

- Add support for indication the boot state using LEDs to the D7800,
R7500 and R7500v2.

- Change GPIO active to readable values in D7800, EA8500, R7500, 
R7500v2 and R7800.

- Add gpio export usb ports on D7800 and R7500v2.

- Add proper "drive strenght" to i2c4_pins and use it for RPM on
C2600, D7800, EA8500, R7500 and R7500v2.

- Remove pcie pinmux from D7800.

- Move pinctrl to correct place in R7800.


Big thanks to @mkresin @dissent1 
Signed-off-by: Henryk Heisig <hyniu@o2.pl>