### PR TITLE
libs: libnetfilter-queue: update to a newer version in git repo

### DIFF
--- a/package/libs/libnetfilter-queue/Makefile
+++ b/package/libs/libnetfilter-queue/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetfilter_queue
-PKG_VERSION:=1.0.2
+PKG_VERSION:=2016-07-03
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:= \
-	http://www.netfilter.org/projects/libnetfilter_queue/files/ \
-	ftp://ftp.netfilter.org/pub/libnetfilter_queue/
-PKG_MD5SUM:=df09befac35cb215865b39a36c96a3fa
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=http://git.netfilter.org/libnetfilter_queue
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=981025e103d887fb6a9c9bb49c74ec323108d098
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
 
 PKG_FIXUP:=autoreconf
 PKG_LICENSE:=GPL-2.0+

--- a/package/libs/libnetfilter-queue/patches/100-checksum_computation.patch
+++ b/package/libs/libnetfilter-queue/patches/100-checksum_computation.patch
@@ -8,7 +8,7 @@
  #include <arpa/inet.h>
  #include <netinet/ip.h>
  #include <netinet/ip6.h>
-@@ -26,8 +27,13 @@ uint16_t checksum(uint32_t sum, uint16_t
+@@ -26,8 +27,13 @@ uint16_t nfq_checksum(uint32_t sum, uint16_t *buf, int size)
  		sum += *buf++;
  		size -= sizeof(uint16_t);
  	}
@@ -24,16 +24,16 @@
  
  	sum = (sum >> 16) + (sum & 0xffff);
  	sum += (sum >>16);
-@@ -35,7 +41,7 @@ uint16_t checksum(uint32_t sum, uint16_t
+@@ -35,7 +41,7 @@ uint16_t nfq_checksum(uint32_t sum, uint16_t *buf, int size)
  	return (uint16_t)(~sum);
  }
  
--uint16_t checksum_tcpudp_ipv4(struct iphdr *iph)
-+uint16_t checksum_tcpudp_ipv4(struct iphdr *iph, uint16_t protocol_id)
+-uint16_t nfq_checksum_tcpudp_ipv4(struct iphdr *iph)
++uint16_t nfq_checksum_tcpudp_ipv4(struct iphdr *iph, uint16_t protocol_id)
  {
  	uint32_t sum = 0;
  	uint32_t iph_len = iph->ihl*4;
-@@ -46,13 +52,13 @@ uint16_t checksum_tcpudp_ipv4(struct iph
+@@ -46,13 +52,13 @@ uint16_t nfq_checksum_tcpudp_ipv4(struct iphdr *iph)
  	sum += (iph->saddr) & 0xFFFF;
  	sum += (iph->daddr >> 16) & 0xFFFF;
  	sum += (iph->daddr) & 0xFFFF;
@@ -41,15 +41,15 @@
 +	sum += htons(protocol_id);
  	sum += htons(len);
  
- 	return checksum(sum, (uint16_t *)payload, len);
+ 	return nfq_checksum(sum, (uint16_t *)payload, len);
  }
  
--uint16_t checksum_tcpudp_ipv6(struct ip6_hdr *ip6h, void *transport_hdr)
-+uint16_t checksum_tcpudp_ipv6(struct ip6_hdr *ip6h, void *transport_hdr, uint16_t protocol_id)
+-uint16_t nfq_checksum_tcpudp_ipv6(struct ip6_hdr *ip6h, void *transport_hdr)
++uint16_t nfq_checksum_tcpudp_ipv6(struct ip6_hdr *ip6h, void *transport_hdr, uint16_t protocol_id)
  {
  	uint32_t sum = 0;
  	uint32_t hdr_len = (uint32_t *)transport_hdr - (uint32_t *)ip6h;
-@@ -68,7 +74,7 @@ uint16_t checksum_tcpudp_ipv6(struct ip6
+@@ -68,7 +74,7 @@ uint16_t nfq_checksum_tcpudp_ipv6(struct ip6_hdr *ip6h, void *transport_hdr)
  		sum += (ip6h->ip6_dst.s6_addr16[i] >> 16) & 0xFFFF;
  		sum += (ip6h->ip6_dst.s6_addr16[i]) & 0xFFFF;
  	}
@@ -57,57 +57,59 @@
 +	sum += htons(protocol_id);
  	sum += htons(ip6h->ip6_plen);
  
- 	return checksum(sum, (uint16_t *)payload, len);
+ 	return nfq_checksum(sum, (uint16_t *)payload, len);
+diff --git a/src/extra/tcp.c b/src/extra/tcp.c
+index d1cd79d..a66f392 100644
 --- a/src/extra/tcp.c
 +++ b/src/extra/tcp.c
-@@ -91,7 +91,7 @@ nfq_tcp_compute_checksum_ipv4(struct tcp
+@@ -96,7 +96,7 @@ nfq_tcp_compute_checksum_ipv4(struct tcphdr *tcph, struct iphdr *iph)
  {
  	/* checksum field in header needs to be zero for calculation. */
  	tcph->check = 0;
--	tcph->check = checksum_tcpudp_ipv4(iph);
-+	tcph->check = checksum_tcpudp_ipv4(iph, IPPROTO_TCP);
+-	tcph->check = nfq_checksum_tcpudp_ipv4(iph);
++	tcph->check = nfq_checksum_tcpudp_ipv4(iph, IPPROTO_TCP);
  }
  EXPORT_SYMBOL(nfq_tcp_compute_checksum_ipv4);
  
-@@ -105,7 +105,7 @@ nfq_tcp_compute_checksum_ipv6(struct tcp
+@@ -110,7 +110,7 @@ nfq_tcp_compute_checksum_ipv6(struct tcphdr *tcph, struct ip6_hdr *ip6h)
  {
  	/* checksum field in header needs to be zero for calculation. */
  	tcph->check = 0;
--	tcph->check = checksum_tcpudp_ipv6(ip6h, tcph);
-+	tcph->check = checksum_tcpudp_ipv6(ip6h, tcph, IPPROTO_TCP);
+-	tcph->check = nfq_checksum_tcpudp_ipv6(ip6h, tcph);
++	tcph->check = nfq_checksum_tcpudp_ipv6(ip6h, tcph, IPPROTO_TCP);
  }
  EXPORT_SYMBOL(nfq_tcp_compute_checksum_ipv6);
  
 --- a/src/extra/udp.c
 +++ b/src/extra/udp.c
-@@ -91,7 +91,7 @@ nfq_udp_compute_checksum_ipv4(struct udp
+@@ -96,7 +96,7 @@ nfq_udp_compute_checksum_ipv4(struct udphdr *udph, struct iphdr *iph)
  {
  	/* checksum field in header needs to be zero for calculation. */
  	udph->check = 0;
--	udph->check = checksum_tcpudp_ipv4(iph);
-+	udph->check = checksum_tcpudp_ipv4(iph, IPPROTO_UDP);
+-	udph->check = nfq_checksum_tcpudp_ipv4(iph);
++	udph->check = nfq_checksum_tcpudp_ipv4(iph, IPPROTO_UDP);
  }
  EXPORT_SYMBOL(nfq_udp_compute_checksum_ipv4);
  
-@@ -110,7 +110,7 @@ nfq_udp_compute_checksum_ipv6(struct udp
+@@ -115,7 +115,7 @@ nfq_udp_compute_checksum_ipv6(struct udphdr *udph, struct ip6_hdr *ip6h)
  {
  	/* checksum field in header needs to be zero for calculation. */
  	udph->check = 0;
--	udph->check = checksum_tcpudp_ipv6(ip6h, udph);
-+	udph->check = checksum_tcpudp_ipv6(ip6h, udph, IPPROTO_UDP);
+-	udph->check = nfq_checksum_tcpudp_ipv6(ip6h, udph);
++	udph->check = nfq_checksum_tcpudp_ipv6(ip6h, udph, IPPROTO_UDP);
  }
  EXPORT_SYMBOL(nfq_udp_compute_checksum_ipv6);
  
 --- a/src/internal.h
 +++ b/src/internal.h
-@@ -13,8 +13,8 @@ struct iphdr;
+@@ -15,8 +15,8 @@ struct iphdr;
  struct ip6_hdr;
  
- uint16_t checksum(uint32_t sum, uint16_t *buf, int size);
--uint16_t checksum_tcpudp_ipv4(struct iphdr *iph);
--uint16_t checksum_tcpudp_ipv6(struct ip6_hdr *ip6h, void *transport_hdr);
-+uint16_t checksum_tcpudp_ipv4(struct iphdr *iph, uint16_t protocol_id);
-+uint16_t checksum_tcpudp_ipv6(struct ip6_hdr *ip6h, void *transport_hdr, uint16_t protocol_id);
+ uint16_t nfq_checksum(uint32_t sum, uint16_t *buf, int size);
+-uint16_t nfq_checksum_tcpudp_ipv4(struct iphdr *iph);
+-uint16_t nfq_checksum_tcpudp_ipv6(struct ip6_hdr *ip6h, void *transport_hdr);
++uint16_t nfq_checksum_tcpudp_ipv4(struct iphdr *iph, uint16_t protocol_id);
++uint16_t nfq_checksum_tcpudp_ipv6(struct ip6_hdr *ip6h, void *transport_hdr, uint16_t protocol_id);
  
  struct pkt_buff {
  	uint8_t *mac_header;


### PR DESCRIPTION
Last release of libnetfilter-queue was in 2012.
There don't seem to be any release tarballs since then.

This updates it to a more recent version, pointing to the git repo.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>