### PR TITLE
uboot-envtools: uboot-envtools have some stuff related to the cpu,  m…

### DIFF
--- a/package/boot/uboot-envtools/Makefile
+++ b/package/boot/uboot-envtools/Makefile
@@ -24,6 +24,8 @@ PKG_BUILD_DEPENDS:=+fstools
 PKG_LICENSE:=GPL-2.0 GPL-2.0+
 PKG_LICENSE_FILES:=Licenses/README
 
+PKG_FLAGS:=nonshared
+
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
…ake  it not shared

This should fix following error on lantiq soc:

Downloading http://downloads.lede-project.org/snapshots/packages/mips_24kc/base/uboot-envtools_2015.10-1_mips_24kc.ipk.
Configuring uboot-envtools.
//usr/lib/opkg/info/uboot-envtools.postinst: .: line 10: can't open '/lib/ar71xx.sh'

Signed-off-by: Eddi De Pieri <eddi@depieri.net>