### PR TITLE
lantiq-vgv7519: write protect u-boot and u-boot-env partitions

### DIFF
--- a/target/linux/lantiq/dts/VGV7519NOR.dts
+++ b/target/linux/lantiq/dts/VGV7519NOR.dts
@@ -11,10 +11,12 @@
 					partition@0 {
 						label = "uboot";
 						reg = <0x00000 0x40000>;
+						read-only;
 					};
 					partition@60000 {
 						label = "uboot_env";
 						reg = <0x60000 0x10000>;
+						read-only;
 					};
 					partition@80000 {
 						label = "firmware";


### PR DESCRIPTION
Signed-off-by: Eddi De Pieri <eddi@depieri.net>