### PR TITLE
ar71xx: move DomyWifi DW33D to nand subtarget

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -562,10 +562,6 @@ config ATH79_MACH_DOMYWIFI_DW33D
 	select ATH79_DEV_NFC
 	select ATH79_DEV_WMAC
 	select ATH79_DEV_USB
-	select MTD_NAND
-	select MTD_NAND_ECC
-	select MTD_NAND_AR934X
-	select MTD_NAND_AR934X_HW_ECC
 
 config ATH79_MACH_DR344
 	bool "Wallys DR344 board support"

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -98,17 +98,6 @@ define Device/cpe870
 endef
 TARGET_DEVICES += cpe870
 
-define Device/domywifi-dw33d
-  DEVICE_TITLE := DomyWifi DW33D
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-storage kmod-ledtrig-usbdev kmod-ath10k
-  BOARDNAME = DW33D
-  IMAGE_SIZE = 16000k
-  CONSOLE = ttyS0,115200
-  MTDPARTS = spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,14528k(rootfs),1472k(kernel),64k(art)ro,16000k@0x50000(firmware);ar934x-nfc:96m(rootfs_data),32m(backup)ro
-  IMAGE/sysupgrade.bin = append-rootfs | pad-rootfs | pad-to 14528k | append-kernel | check-size $$$$(IMAGE_SIZE)
-endef
-TARGET_DEVICES += domywifi-dw33d
-
 define Device/dragino2
   BOARDNAME := DRAGINO2
   CONSOLE := ttyATH0,115200

--- a/target/linux/ar71xx/image/nand.mk
+++ b/target/linux/ar71xx/image/nand.mk
@@ -13,6 +13,17 @@ endef
 
 TARGET_DEVICES += c-60
 
+define Device/domywifi-dw33d
+  DEVICE_TITLE := DomyWifi DW33D
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-storage kmod-usb-ledtrig-usbport kmod-ath10k
+  BOARDNAME = DW33D
+  IMAGE_SIZE = 16000k
+  CONSOLE = ttyS0,115200
+  MTDPARTS = spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,14528k(rootfs),1472k(kernel),64k(art)ro,16000k@0x50000(firmware);ar934x-nfc:96m(rootfs_data),32m(backup)ro
+  IMAGE/sysupgrade.bin = append-rootfs | pad-rootfs | pad-to 14528k | append-kernel | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += domywifi-dw33d
+
 define Build/MerakiNAND
 	-$(STAGING_DIR_HOST)/bin/mkmerakifw \
 		-B $(BOARDNAME) -s \


### PR DESCRIPTION
Support for this device was included in 7ba9a3a504909ccf8f6d1aca9b1160443da7215b, but it should never go to generic target as it uses NAND FLASH and requires related kernel modules.

Plus, small fix: kmod-ledtrig-usbdev -> kmod-usb-ledtrig-usbport.