### PR TITLE
kernel: fix typo in input-gpio-encoder package title

### DIFF
--- a/package/kernel/linux/modules/input.mk
+++ b/package/kernel/linux/modules/input.mk
@@ -112,7 +112,7 @@ $(eval $(call KernelPackage,input-gpio-keys-polled))
 
 define KernelPackage/input-gpio-encoder
   SUBMENU:=$(INPUT_MODULES_MENU)
-  TITLE:=GPIO rotay encoder
+  TITLE:=GPIO rotary encoder
   DEPENDS:=@GPIO_SUPPORT +kmod-input-core
   KCONFIG:=CONFIG_INPUT_GPIO_ROTARY_ENCODER
   FILES:=$(LINUX_DIR)/drivers/input/misc/rotary_encoder.ko


### PR DESCRIPTION
Line 115, 'rotary' was misspelled as 'rotay'
Signed-off by: Avinash Duduskar <strykar@hotmail.com>