### PR TITLE
ramips: RB750Gr3: Add pwr LED and buzzer to DTS, use pwr LED in diag.sh

### DIFF
--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -191,7 +191,7 @@ get_status_led() {
 		status_led="$board:green:wps"
 		;;
 	rb750gr3)
-		status_led="$board:green:usr"
+		status_led="$board:blue:pwr"
 		;;
 	sap-g3200u3)
 		status_led="$board:green:usb"

--- a/target/linux/ramips/dts/RB750Gr3.dts
+++ b/target/linux/ramips/dts/RB750Gr3.dts
@@ -20,6 +20,11 @@
 	gpio-leds {
 		compatible = "gpio-leds";
 
+		pwr {
+			label = "rb750gr3:blue:pwr";
+			gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		};
+
 		usr {
 			label = "rb750gr3:green:usr";
 			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
@@ -48,6 +53,12 @@
 	gpio_export {
 		compatible = "gpio-export";
 		#size-cells = <0>;
+
+		buzzer {
+			gpio-export,name = "buzzer";
+			gpio-export,output = <0>;
+			gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+		};
 
 		usb {
 			gpio-export,name = "usb";
@@ -102,7 +113,7 @@
 &pinctrl {
 	state_default: pinctrl0 {
 		gpio {
-			ralink,group = "i2c", "rgmii2", "sdhci";
+			ralink,group = "i2c", "uart2", "uart3", "pcie", "rgmii2", "jtag";
 			ralink,function = "gpio";
 		};
 	};


### PR DESCRIPTION
Expose unused pinmux pins as GPIOs, then export power LED and buzzer pins
Use rb750gr3:blue:pwr LED in diag.sh for boot status instead of rb750gr3:green:usr

Signed-off-by: Andrew Yong <me@ndoo.sg>