### PR TITLE
ramips: add support for ZyXEL Keenetic Omni

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -210,7 +210,7 @@ ramips_setup_interfaces()
 		;;
 	kn_rc|\
 	kn_rf)
-		ucidef_add_switch "switch" \
+		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6@eth0"
 		;;
 	kng_rc)

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -339,8 +339,10 @@ ramips_setup_macs()
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
+	kn_rc|\
+	kn_rf|\
 	kng_rc)
-		wan_mac=$(mtd_get_mac_binary factory 28)
+		wan_mac=$(mtd_get_mac_binary factory 40)
 		;;
 	linkits7688 | \
 	linkits7688d)

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -439,7 +439,7 @@ define Device/kn_rc
   DEVICE_TITLE := ZyXEL Keenetic Omni
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | pad-to 64k | check-size $$$$(IMAGE_SIZE) | \
 	zyimage -d 4882 -v "ZyXEL Keenetic Omni"
 endef
 TARGET_DEVICES += kn_rc
@@ -449,7 +449,7 @@ define Device/kn_rf
   DEVICE_TITLE := ZyXEL Keenetic Omni II
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | pad-to 64k | check-size $$$$(IMAGE_SIZE) | \
 	zyimage -d 2102034 -v "ZyXEL Keenetic Omni II"
 endef
 TARGET_DEVICES += kn_rf


### PR DESCRIPTION
Zyxel Keenetic Omni CPU: MT7620N MIPS24Kc @580MHz Flash: 8MB RAM: DDR1 64MB
WLAN: Built in SoC 2T2R/300Mbps (2.4GHz) 2x3 dBi Fixed ext, Switch: 5x100MbE, USB: 1x2.0

Factory image can be installed via Zyxel WebUI.

Signed-off-by: Vitaly Chekryzhev <13hakta@gmail.com>