### PR TITLE
Fixed sysupgrade error on Linksys WRT3200ACM.

### DIFF
--- a/target/linux/mvebu/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/mvebu/base-files/lib/upgrade/linksys.sh
@@ -77,7 +77,7 @@ linksys_preupgrade() {
 	local board=$(mvebu_board_name)
 
 	case "$board" in
-	armada-385-linksys-caiman|armada-385-linksys-cobra|armada-385-linksys-shelby|armada-xp-linksys-mamba)
+	armada-385-linksys-caiman|armada-385-linksys-cobra|armada-385-linksys-shelby|armada-xp-linksys-mamba|armada-385-linksys-rango)
 		export RAMFS_COPY_BIN="${RAMFS_COPY_BIN} /usr/sbin/fw_printenv /usr/sbin/fw_setenv"
 		export RAMFS_COPY_BIN="${RAMFS_COPY_BIN} /bin/mkdir /bin/touch"
 		export RAMFS_COPY_DATA="${RAMFS_COPY_DATA} /etc/fw_env.config /var/lock/fw_printenv.lock"
@@ -90,4 +90,3 @@ linksys_preupgrade() {
 }
 
 append sysupgrade_pre_upgrade linksys_preupgrade
-


### PR DESCRIPTION
Previously, 'sysupgrade' on WRT3200ACM resulted in this error:
`ash: /usr/sbin/fw_printenv: not found
ash: fw_setenv: not found
ash: touch: not found
cannot find target partition`

Now fixed.