### PR TITLE
uqmi: verify pin only when needed

### DIFF
--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -68,12 +68,14 @@ proto_qmi_setup() {
 	done
 
 	[ -n "$pincode" ] && {
-		uqmi -s -d "$device" --verify-pin1 "$pincode" || {
-			echo "Unable to verify PIN"
-			proto_notify_error "$interface" PIN_FAILED
-			proto_block_restart "$interface"
-			return 1
-		}
+		if uqmi -s -d "$device" --get-pin-status | grep -q '"pin1_status":"not_verified"'; then
+			uqmi -s -d "$device" --verify-pin1 "$pincode" || {
+				echo "Unable to verify PIN"
+				proto_notify_error "$interface" PIN_FAILED
+				proto_block_restart "$interface"
+				return 1
+			}
+		fi
 	}
 
 	[ -n "$apn" ] || {


### PR DESCRIPTION
Pin should be verified only when SIM required this. Now if pin is set in config and SIM not required pin, connection fail.

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>