### PR TITLE
ramips: fix PBR-D1 dts

### DIFF
--- a/target/linux/ramips/dts/PBR-D1.dts
+++ b/target/linux/ramips/dts/PBR-D1.dts
@@ -43,7 +43,7 @@
 		#size-cells = <0>;
 		poll-interval = <20>;
 
-		wps {
+		reset {
 			label = "reset";
 			gpios = <&gpio1 38 1>;
 			linux,code = <KEY_WPS_BUTTON>;


### PR DESCRIPTION
Fix pbr-d1 dts for button definition, it should be reset, not wps.