### PR TITLE
ramips : tweak set_wifi_led and set_usb_led functions

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -4,11 +4,11 @@
 . /lib/ramips.sh
 
 set_usb_led() {
-	ucidef_set_led_usbdev "usb" "USB" "${1}" "${2:-1-1}"
+	ucidef_set_led_usbdev "${1:-usb}" "${1:-USB}" "${2}" "${3:-1-1}"
 }
 
 set_wifi_led() {
-	ucidef_set_led_netdev "wifi_led" "wifi" "${1}" "${2:-wlan0}"
+	ucidef_set_led_netdev "${1:-wifi}" "${1:-WIFI}" "${2}" "${3:-wlan0}"
 }
 
 


### PR DESCRIPTION
    Since many routers may have two or more usb/wifi leds,
    the original set_wifi_led() and set_usb_led() can not meet
    our requirement, the commit can make it easay to define
    usb and wifi leds as below shows:

    set_usb_led "usb1" "$board:color:usb1" "1-1"
    set_usb_led "usb2" "$board:color:usb2" "2-1"

    and

    set_wifi_led "wifi_2ghz" "$board:color:wifi" "wlan0"
    set_wifi_led "wifi_5ghz" "$board:color:wifi5g" "wlan1"

Signed-off-by: BangLang Huang <banglang.huang@foxmail.com>