### PR TITLE
dnsmasq: reload config if host name is modified

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -785,7 +785,7 @@ dnsmasq_stop()
 
 service_triggers()
 {
-	procd_add_reload_trigger "dhcp"
+	procd_add_reload_trigger "dhcp" "system"
 	procd_add_raw_trigger "interface.*" 2000 /etc/init.d/dnsmasq reload
 }
 
@@ -825,6 +825,7 @@ start_service() {
 
 reload_service() {
 	rc_procd start_service "$@"
+	killall -HUP dnsmasq
 	return 0
 }
 


### PR DESCRIPTION
If the hostname in /etc/config/system is modified the dnsmasq will not
reread the update host file under /tmp/hosts/dhcp.$cfg.

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>