### PR TITLE
Fix kernel 4.4 issues preventing F5D8235 V1 from booting

### DIFF
--- a/target/linux/generic/patches-4.4/996-mm-fix_alloc_node_mem_map_calculation.patch
+++ b/target/linux/generic/patches-4.4/996-mm-fix_alloc_node_mem_map_calculation.patch
@@ -1,0 +1,11 @@
+--- a/mm/page_alloc.c
++++ b/mm/page_alloc.c
+@@ -5326,7 +5326,7 @@
+ 		mem_map = NODE_DATA(0)->node_mem_map;
+ #if defined(CONFIG_HAVE_MEMBLOCK_NODE_MAP) || defined(CONFIG_FLATMEM)
+ 		if (page_to_pfn(mem_map) != pgdat->node_start_pfn)
+-			mem_map -= offset;
++			mem_map -= offset + (pgdat->node_start_pfn - ARCH_PFN_OFFSET);
+ #endif /* CONFIG_HAVE_MEMBLOCK_NODE_MAP */
+ 	}
+ #endif

--- a/target/linux/generic/patches-4.4/997-of-Add-check-to-of_scan_flat_dt-before-accessing-initial_boot_params.patch
+++ b/target/linux/generic/patches-4.4/997-of-Add-check-to-of_scan_flat_dt-before-accessing-initial_boot_params.patch
@@ -1,0 +1,18 @@
+--- a/drivers/of/fdt.c
++++ b/drivers/of/fdt.c
+@@ -738,9 +738,12 @@
+ 	const char *pathp;
+ 	int offset, rc = 0, depth = -1;
+ 
+-        for (offset = fdt_next_node(blob, -1, &depth);
+-             offset >= 0 && depth >= 0 && !rc;
+-             offset = fdt_next_node(blob, offset, &depth)) {
++	if (!blob)
++		return 0;
++
++	for (offset = fdt_next_node(blob, -1, &depth);
++	     offset >= 0 && depth >= 0 && !rc;
++	     offset = fdt_next_node(blob, offset, &depth)) {
+ 
+ 		pathp = fdt_get_name(blob, offset, NULL);
+ 		if (*pathp == '/')


### PR DESCRIPTION
Trying to get a F5D8235 V1 router into a working condition showed two bugs in kernel 4.4+.

First a hang can be observed if no valid DTB is found and of_scan_flat_dt() is called to find early memory. Reason for that is that initial_boot_params is not checked in this function before trying to read from it.

Additionally the rt288x suffered from a bug introduced during the development of 4.4 (and is present up to 4.9-rc7 and most likely newer versions). As a consequence the kernel basically panics after hitting "BUG: Bad page state in process swapper". This issue is also described in a [LEDE Flyspray issue report](https://bugs.lede-project.org/index.php?do=details&task_id=244).