### PR TITLE
ipq806x: refactor rpm clock controller patches

### DIFF
--- a/target/linux/ipq806x/patches-4.4/012-1-clk-qcom-Add-support-for-SMD-RPM-Clocks.patch
+++ b/target/linux/ipq806x/patches-4.4/012-1-clk-qcom-Add-support-for-SMD-RPM-Clocks.patch
@@ -117,10 +117,10 @@ More majordomo info at  http://vger.kernel.org/majordomo-info.html
  	select QCOM_GDSC
 --- a/drivers/clk/qcom/Makefile
 +++ b/drivers/clk/qcom/Makefile
-@@ -28,3 +28,4 @@ obj-$(CONFIG_MSM_MMCC_8960) += mmcc-msm8
+@@ -22,3 +22,4 @@ obj-$(CONFIG_MSM_LCC_8960) += lcc-msm896
+ obj-$(CONFIG_MSM_GCC_8974) += gcc-msm8974.o
+ obj-$(CONFIG_MSM_MMCC_8960) += mmcc-msm8960.o
  obj-$(CONFIG_MSM_MMCC_8974) += mmcc-msm8974.o
- obj-$(CONFIG_QCOM_HFPLL) += hfpll.o
- obj-$(CONFIG_KRAITCC) += krait-cc.o
 +obj-$(CONFIG_QCOM_CLK_SMD_RPM) += clk-smd-rpm.o
 --- /dev/null
 +++ b/drivers/clk/qcom/clk-smd-rpm.c

--- a/target/linux/ipq806x/patches-4.4/012-2-clk-qcom-Add-support-for-RPM-Clocks.patch
+++ b/target/linux/ipq806x/patches-4.4/012-2-clk-qcom-Add-support-for-RPM-Clocks.patch
@@ -1,28 +1,16 @@
-!This is the adjusted version of patch that has been submitted to upstream and that, unfortunately, provides support for RPM clocks only for apq8064 board.
-
-!TODO: make a patch that adds support for ipq806x along with apq8064 and not replaces it.
-
-From patchwork Wed Nov  2 15:56:57 2016
-Content-Type: text/plain; charset="utf-8"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-Subject: [v9,2/3] clk: qcom: Add support for RPM Clocks
+From 872f91b5ea720c72f81fb46d353c43ecb3263ffa Mon Sep 17 00:00:00 2001
 From: Georgi Djakov <georgi.djakov@linaro.org>
-X-Patchwork-Id: 9409425
-Message-Id: <20161102155658.32203-3-georgi.djakov@linaro.org>
-To: sboyd@codeaurora.org, mturquette@baylibre.com
-Cc: linux-clk@vger.kernel.org, devicetree@vger.kernel.org,
- robh+dt@kernel.org, mark.rutland@arm.com,
- linux-kernel@vger.kernel.org, linux-arm-msm@vger.kernel.org,
- georgi.djakov@linaro.org
-Date: Wed,  2 Nov 2016 17:56:57 +0200
+Date: Wed, 2 Nov 2016 17:56:57 +0200
+Subject: clk: qcom: Add support for RPM Clocks
 
 This adds initial support for clocks controlled by the Resource
 Power Manager (RPM) processor on some Qualcomm SoCs, which use
 the qcom_rpm driver to communicate with RPM.
-Such platforms are ipq806x and msm8960.
+Such platforms are apq8064 and msm8960.
 
 Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
+Acked-by: Rob Herring <robh@kernel.org>
+Signed-off-by: Stephen Boyd <sboyd@codeaurora.org>
 ---
  .../devicetree/bindings/clock/qcom,rpmcc.txt       |   1 +
  drivers/clk/qcom/Kconfig                           |  13 +
@@ -32,18 +20,13 @@ Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
  5 files changed, 528 insertions(+)
  create mode 100644 drivers/clk/qcom/clk-rpm.c
 
---
-To unsubscribe from this list: send the line "unsubscribe linux-arm-msm" in
-the body of a message to majordomo@vger.kernel.org
-More majordomo info at  http://vger.kernel.org/majordomo-info.html
-
 --- a/Documentation/devicetree/bindings/clock/qcom,rpmcc.txt
 +++ b/Documentation/devicetree/bindings/clock/qcom,rpmcc.txt
 @@ -11,6 +11,7 @@ Required properties :
                 compatible "qcom,rpmcc" should be also included.
  
  			"qcom,rpmcc-msm8916", "qcom,rpmcc"
-+			"qcom,rpmcc-ipq806x", "qcom,rpmcc"
++			"qcom,rpmcc-apq8064", "qcom,rpmcc"
  
  - #clock-cells : shall contain 1
  
@@ -71,14 +54,14 @@ More majordomo info at  http://vger.kernel.org/majordomo-info.html
  	depends on COMMON_CLK_QCOM && QCOM_SMD_RPM
 --- a/drivers/clk/qcom/Makefile
 +++ b/drivers/clk/qcom/Makefile
-@@ -29,3 +29,4 @@ obj-$(CONFIG_MSM_MMCC_8974) += mmcc-msm8
- obj-$(CONFIG_QCOM_HFPLL) += hfpll.o
- obj-$(CONFIG_KRAITCC) += krait-cc.o
+@@ -23,3 +23,4 @@ obj-$(CONFIG_MSM_GCC_8974) += gcc-msm897
+ obj-$(CONFIG_MSM_MMCC_8960) += mmcc-msm8960.o
+ obj-$(CONFIG_MSM_MMCC_8974) += mmcc-msm8974.o
  obj-$(CONFIG_QCOM_CLK_SMD_RPM) += clk-smd-rpm.o
 +obj-$(CONFIG_QCOM_CLK_RPM) += clk-rpm.o
 --- /dev/null
 +++ b/drivers/clk/qcom/clk-rpm.c
-@@ -0,0 +1,486 @@
+@@ -0,0 +1,489 @@
 +/*
 + * Copyright (c) 2016, Linaro Limited
 + * Copyright (c) 2014, The Linux Foundation. All rights reserved.
@@ -429,42 +412,45 @@ More majordomo info at  http://vger.kernel.org/majordomo-info.html
 +	.recalc_rate	= clk_rpm_recalc_rate,
 +};
 +
-+/* ipq806x */
-+DEFINE_CLK_RPM(ipq806x, afab_clk, afab_a_clk, QCOM_RPM_APPS_FABRIC_CLK);
-+DEFINE_CLK_RPM(ipq806x, cfpb_clk, cfpb_a_clk, QCOM_RPM_CFPB_CLK);
-+DEFINE_CLK_RPM(ipq806x, daytona_clk, daytona_a_clk, QCOM_RPM_DAYTONA_FABRIC_CLK);
-+DEFINE_CLK_RPM(ipq806x, ebi1_clk, ebi1_a_clk, QCOM_RPM_EBI1_CLK);
-+DEFINE_CLK_RPM(ipq806x, nss_fabric_0_clk, nss_fabric_0_a_clk, QCOM_RPM_NSS_FABRIC_0_CLK);
-+DEFINE_CLK_RPM(ipq806x, nss_fabric_1_clk, nss_fabric_1_a_clk, QCOM_RPM_NSS_FABRIC_1_CLK);
-+DEFINE_CLK_RPM(ipq806x, sfab_clk, sfab_a_clk, QCOM_RPM_SYS_FABRIC_CLK);
-+DEFINE_CLK_RPM(ipq806x, sfpb_clk, sfpb_a_clk, QCOM_RPM_SFPB_CLK);
++/* apq8064 */
++DEFINE_CLK_RPM(apq8064, afab_clk, afab_a_clk, QCOM_RPM_APPS_FABRIC_CLK);
++DEFINE_CLK_RPM(apq8064, cfpb_clk, cfpb_a_clk, QCOM_RPM_CFPB_CLK);
++DEFINE_CLK_RPM(apq8064, daytona_clk, daytona_a_clk, QCOM_RPM_DAYTONA_FABRIC_CLK);
++DEFINE_CLK_RPM(apq8064, ebi1_clk, ebi1_a_clk, QCOM_RPM_EBI1_CLK);
++DEFINE_CLK_RPM(apq8064, mmfab_clk, mmfab_a_clk, QCOM_RPM_MM_FABRIC_CLK);
++DEFINE_CLK_RPM(apq8064, mmfpb_clk, mmfpb_a_clk, QCOM_RPM_MMFPB_CLK);
++DEFINE_CLK_RPM(apq8064, sfab_clk, sfab_a_clk, QCOM_RPM_SYS_FABRIC_CLK);
++DEFINE_CLK_RPM(apq8064, sfpb_clk, sfpb_a_clk, QCOM_RPM_SFPB_CLK);
++DEFINE_CLK_RPM(apq8064, qdss_clk, qdss_a_clk, QCOM_RPM_QDSS_CLK);
 +
-+static struct clk_rpm *ipq806x_clks[] = {
-+	[RPM_APPS_FABRIC_CLK] = &ipq806x_afab_clk,
-+	[RPM_APPS_FABRIC_A_CLK] = &ipq806x_afab_a_clk,
-+	[RPM_CFPB_CLK] = &ipq806x_cfpb_clk,
-+	[RPM_CFPB_A_CLK] = &ipq806x_cfpb_a_clk,
-+	[RPM_DAYTONA_FABRIC_CLK] = &ipq806x_daytona_clk,
-+	[RPM_DAYTONA_FABRIC_A_CLK] = &ipq806x_daytona_a_clk,
-+	[RPM_EBI1_CLK] = &ipq806x_ebi1_clk,
-+	[RPM_EBI1_A_CLK] = &ipq806x_ebi1_a_clk,
-+	[RPM_NSS_FABRIC_0_CLK] = &ipq806x_nss_fabric_0_clk,
-+	[RPM_NSS_FABRIC_0_A_CLK] = &ipq806x_nss_fabric_0_a_clk,
-+	[RPM_NSS_FABRIC_1_CLK] = &ipq806x_nss_fabric_1_clk,
-+	[RPM_NSS_FABRIC_1_A_CLK] = &ipq806x_nss_fabric_1_a_clk,
-+	[RPM_SYS_FABRIC_CLK] = &ipq806x_sfab_clk,
-+	[RPM_SYS_FABRIC_A_CLK] = &ipq806x_sfab_a_clk,
-+	[RPM_SFPB_CLK] = &ipq806x_sfpb_clk,
-+	[RPM_SFPB_A_CLK] = &ipq806x_sfpb_a_clk,
++static struct clk_rpm *apq8064_clks[] = {
++	[RPM_APPS_FABRIC_CLK] = &apq8064_afab_clk,
++	[RPM_APPS_FABRIC_A_CLK] = &apq8064_afab_a_clk,
++	[RPM_CFPB_CLK] = &apq8064_cfpb_clk,
++	[RPM_CFPB_A_CLK] = &apq8064_cfpb_a_clk,
++	[RPM_DAYTONA_FABRIC_CLK] = &apq8064_daytona_clk,
++	[RPM_DAYTONA_FABRIC_A_CLK] = &apq8064_daytona_a_clk,
++	[RPM_EBI1_CLK] = &apq8064_ebi1_clk,
++	[RPM_EBI1_A_CLK] = &apq8064_ebi1_a_clk,
++	[RPM_MM_FABRIC_CLK] = &apq8064_mmfab_clk,
++	[RPM_MM_FABRIC_A_CLK] = &apq8064_mmfab_a_clk,
++	[RPM_MMFPB_CLK] = &apq8064_mmfpb_clk,
++	[RPM_MMFPB_A_CLK] = &apq8064_mmfpb_a_clk,
++	[RPM_SYS_FABRIC_CLK] = &apq8064_sfab_clk,
++	[RPM_SYS_FABRIC_A_CLK] = &apq8064_sfab_a_clk,
++	[RPM_SFPB_CLK] = &apq8064_sfpb_clk,
++	[RPM_SFPB_A_CLK] = &apq8064_sfpb_a_clk,
++	[RPM_QDSS_CLK] = &apq8064_qdss_clk,
++	[RPM_QDSS_A_CLK] = &apq8064_qdss_a_clk,
 +};
 +
-+static const struct rpm_clk_desc rpm_clk_ipq806x = {
-+	.clks = ipq806x_clks,
-+	.num_clks = ARRAY_SIZE(ipq806x_clks),
++static const struct rpm_clk_desc rpm_clk_apq8064 = {
++	.clks = apq8064_clks,
++	.num_clks = ARRAY_SIZE(apq8064_clks),
 +};
 +
 +static const struct of_device_id rpm_clk_match_table[] = {
-+	{ .compatible = "qcom,rpmcc-ipq806x", .data = &rpm_clk_ipq806x },
++	{ .compatible = "qcom,rpmcc-apq8064", .data = &rpm_clk_apq8064 },
 +	{ }
 +};
 +MODULE_DEVICE_TABLE(of, rpm_clk_match_table);
@@ -522,7 +508,7 @@ More majordomo info at  http://vger.kernel.org/majordomo-info.html
 +		ret = devm_clk_hw_register(&pdev->dev, &rpm_clks[i]->hw);
 +		if (ret)
 +			goto err;
-+		}
++	}
 +
 +	ret = of_clk_add_hw_provider(pdev->dev.of_node, of_clk_hw_onecell_get,
 +				     data);
@@ -567,11 +553,11 @@ More majordomo info at  http://vger.kernel.org/majordomo-info.html
 +MODULE_ALIAS("platform:qcom-clk-rpm");
 --- a/include/dt-bindings/clock/qcom,rpmcc.h
 +++ b/include/dt-bindings/clock/qcom,rpmcc.h
-@@ -14,6 +14,28 @@
+@@ -14,6 +14,30 @@
  #ifndef _DT_BINDINGS_CLK_MSM_RPMCC_H
  #define _DT_BINDINGS_CLK_MSM_RPMCC_H
  
-+/* ipq806x */
++/* apq8064 */
 +#define RPM_PXO_CLK				0
 +#define RPM_PXO_A_CLK				1
 +#define RPM_CXO_CLK				2
@@ -580,18 +566,20 @@ More majordomo info at  http://vger.kernel.org/majordomo-info.html
 +#define RPM_APPS_FABRIC_A_CLK			5
 +#define RPM_CFPB_CLK				6
 +#define RPM_CFPB_A_CLK				7
-+#define RPM_DAYTONA_FABRIC_CLK			8
-+#define RPM_DAYTONA_FABRIC_A_CLK		9
-+#define RPM_EBI1_CLK				10
-+#define RPM_EBI1_A_CLK				11
-+#define RPM_NSS_FABRIC_0_CLK			12
-+#define RPM_NSS_FABRIC_0_A_CLK			13
-+#define RPM_NSS_FABRIC_1_CLK			14
-+#define RPM_NSS_FABRIC_1_A_CLK			15
-+#define RPM_SYS_FABRIC_CLK			16
-+#define RPM_SYS_FABRIC_A_CLK			17
-+#define RPM_SFPB_CLK				18
-+#define RPM_SFPB_A_CLK				19
++#define RPM_QDSS_CLK				8
++#define RPM_QDSS_A_CLK				9
++#define RPM_DAYTONA_FABRIC_CLK			10
++#define RPM_DAYTONA_FABRIC_A_CLK		11
++#define RPM_EBI1_CLK				12
++#define RPM_EBI1_A_CLK				13
++#define RPM_MM_FABRIC_CLK			14
++#define RPM_MM_FABRIC_A_CLK			15
++#define RPM_MMFPB_CLK				16
++#define RPM_MMFPB_A_CLK				17
++#define RPM_SYS_FABRIC_CLK			18
++#define RPM_SYS_FABRIC_A_CLK			19
++#define RPM_SFPB_CLK				20
++#define RPM_SFPB_A_CLK				21
 +
  /* msm8916 */
  #define RPM_SMD_XO_CLK_SRC				0

--- a/target/linux/ipq806x/patches-4.4/012-3-clk-qcom-clk-rpm-Fix-clk_hw-references.patch
+++ b/target/linux/ipq806x/patches-4.4/012-3-clk-qcom-clk-rpm-Fix-clk_hw-references.patch
@@ -1,0 +1,94 @@
+From c260524aba53b57f72b5446ed553080df30b4d09 Mon Sep 17 00:00:00 2001
+From: Georgi Djakov <georgi.djakov@linaro.org>
+Date: Wed, 23 Nov 2016 16:52:49 +0200
+Subject: clk: qcom: clk-rpm: Fix clk_hw references
+
+Fix the clk_hw references to the actual clocks and add a xlate function
+to return the hw pointers from the already existing static array.
+
+Reported-by: Michael Scott <michael.scott@linaro.org>
+Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
+Signed-off-by: Stephen Boyd <sboyd@codeaurora.org>
+---
+ drivers/clk/qcom/clk-rpm.c | 36 ++++++++++++++++++++++--------------
+ 1 file changed, 22 insertions(+), 14 deletions(-)
+
+--- a/drivers/clk/qcom/clk-rpm.c
++++ b/drivers/clk/qcom/clk-rpm.c
+@@ -127,8 +127,8 @@ struct clk_rpm {
+ 
+ struct rpm_cc {
+ 	struct qcom_rpm *rpm;
+-	struct clk_hw_onecell_data data;
+-	struct clk_hw *hws[];
++	struct clk_rpm **clks;
++	size_t num_clks;
+ };
+ 
+ struct rpm_clk_desc {
+@@ -391,11 +391,23 @@ static const struct of_device_id rpm_clk
+ };
+ MODULE_DEVICE_TABLE(of, rpm_clk_match_table);
+ 
++static struct clk_hw *qcom_rpm_clk_hw_get(struct of_phandle_args *clkspec,
++					  void *data)
++{
++	struct rpm_cc *rcc = data;
++	unsigned int idx = clkspec->args[0];
++
++	if (idx >= rcc->num_clks) {
++		pr_err("%s: invalid index %u\n", __func__, idx);
++		return ERR_PTR(-EINVAL);
++	}
++
++	return rcc->clks[idx] ? &rcc->clks[idx]->hw : ERR_PTR(-ENOENT);
++}
++
+ static int rpm_clk_probe(struct platform_device *pdev)
+ {
+-	struct clk_hw **hws;
+ 	struct rpm_cc *rcc;
+-	struct clk_hw_onecell_data *data;
+ 	int ret;
+ 	size_t num_clks, i;
+ 	struct qcom_rpm *rpm;
+@@ -415,14 +427,12 @@ static int rpm_clk_probe(struct platform
+ 	rpm_clks = desc->clks;
+ 	num_clks = desc->num_clks;
+ 
+-	rcc = devm_kzalloc(&pdev->dev, sizeof(*rcc) + sizeof(*hws) * num_clks,
+-			   GFP_KERNEL);
++	rcc = devm_kzalloc(&pdev->dev, sizeof(*rcc), GFP_KERNEL);
+ 	if (!rcc)
+ 		return -ENOMEM;
+ 
+-	hws = rcc->hws;
+-	data = &rcc->data;
+-	data->num = num_clks;
++	rcc->clks = rpm_clks;
++	rcc->num_clks = num_clks;
+ 
+ 	for (i = 0; i < num_clks; i++) {
+ 		if (!rpm_clks[i])
+@@ -436,18 +446,16 @@ static int rpm_clk_probe(struct platform
+ 	}
+ 
+ 	for (i = 0; i < num_clks; i++) {
+-		if (!rpm_clks[i]) {
+-			data->hws[i] = ERR_PTR(-ENOENT);
++		if (!rpm_clks[i])
+ 			continue;
+-		}
+ 
+ 		ret = devm_clk_hw_register(&pdev->dev, &rpm_clks[i]->hw);
+ 		if (ret)
+ 			goto err;
+ 	}
+ 
+-	ret = of_clk_add_hw_provider(pdev->dev.of_node, of_clk_hw_onecell_get,
+-				     data);
++	ret = of_clk_add_hw_provider(pdev->dev.of_node, qcom_rpm_clk_hw_get,
++				     rcc);
+ 	if (ret)
+ 		goto err;
+ 

--- a/target/linux/ipq806x/patches-4.4/138-clk-qcom-Add-HFPLL-driver.patch
+++ b/target/linux/ipq806x/patches-4.4/138-clk-qcom-Add-HFPLL-driver.patch
@@ -73,7 +73,7 @@ Signed-off-by: Stephen Boyd <sboyd@codeaurora.org>
 +	};
 --- a/drivers/clk/qcom/Kconfig
 +++ b/drivers/clk/qcom/Kconfig
-@@ -106,3 +106,11 @@ config MSM_MMCC_8974
+@@ -135,3 +135,11 @@ config MSM_MMCC_8974
  	  Support for the multimedia clock controller on msm8974 devices.
  	  Say Y if you want to support multimedia devices such as display,
  	  graphics, video encode/decode, camera, etc.
@@ -87,10 +87,10 @@ Signed-off-by: Stephen Boyd <sboyd@codeaurora.org>
 +	  such as MSM8974, APQ8084, etc.
 --- a/drivers/clk/qcom/Makefile
 +++ b/drivers/clk/qcom/Makefile
-@@ -23,3 +23,4 @@ obj-$(CONFIG_MSM_LCC_8960) += lcc-msm896
- obj-$(CONFIG_MSM_GCC_8974) += gcc-msm8974.o
- obj-$(CONFIG_MSM_MMCC_8960) += mmcc-msm8960.o
+@@ -25,3 +25,4 @@ obj-$(CONFIG_MSM_MMCC_8960) += mmcc-msm8
  obj-$(CONFIG_MSM_MMCC_8974) += mmcc-msm8974.o
+ obj-$(CONFIG_QCOM_CLK_SMD_RPM) += clk-smd-rpm.o
+ obj-$(CONFIG_QCOM_CLK_RPM) += clk-rpm.o
 +obj-$(CONFIG_QCOM_HFPLL) += hfpll.o
 --- /dev/null
 +++ b/drivers/clk/qcom/hfpll.c

--- a/target/linux/ipq806x/patches-4.4/140-clk-qcom-Add-support-for-Krait-clocks.patch
+++ b/target/linux/ipq806x/patches-4.4/140-clk-qcom-Add-support-for-Krait-clocks.patch
@@ -30,7 +30,7 @@ drivers/clk/qcom/Kconfig     |   4 ++
 
 --- a/drivers/clk/qcom/Kconfig
 +++ b/drivers/clk/qcom/Kconfig
-@@ -114,3 +114,7 @@ config QCOM_HFPLL
+@@ -143,3 +143,7 @@ config QCOM_HFPLL
  	  Support for the high-frequency PLLs present on Qualcomm devices.
  	  Say Y if you want to support CPU frequency scaling on devices
  	  such as MSM8974, APQ8084, etc.

--- a/target/linux/ipq806x/patches-4.4/141-clk-qcom-Add-KPSS-ACC-GCC-driver.patch
+++ b/target/linux/ipq806x/patches-4.4/141-clk-qcom-Add-KPSS-ACC-GCC-driver.patch
@@ -82,7 +82,7 @@ Signed-off-by: Stephen Boyd <sboyd@codeaurora.org>
 +	};
 --- a/drivers/clk/qcom/Kconfig
 +++ b/drivers/clk/qcom/Kconfig
-@@ -115,6 +115,14 @@ config QCOM_HFPLL
+@@ -144,6 +144,14 @@ config QCOM_HFPLL
  	  Say Y if you want to support CPU frequency scaling on devices
  	  such as MSM8974, APQ8084, etc.
  

--- a/target/linux/ipq806x/patches-4.4/142-clk-qcom-Add-Krait-clock-controller-driver.patch
+++ b/target/linux/ipq806x/patches-4.4/142-clk-qcom-Add-Krait-clock-controller-driver.patch
@@ -56,7 +56,7 @@ Signed-off-by: Stephen Boyd <sboyd@codeaurora.org>
 +	};
 --- a/drivers/clk/qcom/Kconfig
 +++ b/drivers/clk/qcom/Kconfig
-@@ -123,6 +123,14 @@ config KPSS_XCC
+@@ -152,6 +152,14 @@ config KPSS_XCC
  	  if you want to support CPU frequency scaling on devices such
  	  as MSM8960, APQ8064, etc.
  
@@ -73,9 +73,9 @@ Signed-off-by: Stephen Boyd <sboyd@codeaurora.org>
  	select KRAIT_L2_ACCESSORS
 --- a/drivers/clk/qcom/Makefile
 +++ b/drivers/clk/qcom/Makefile
-@@ -26,3 +26,4 @@ obj-$(CONFIG_MSM_GCC_8974) += gcc-msm897
- obj-$(CONFIG_MSM_MMCC_8960) += mmcc-msm8960.o
- obj-$(CONFIG_MSM_MMCC_8974) += mmcc-msm8974.o
+@@ -28,3 +28,4 @@ obj-$(CONFIG_MSM_MMCC_8974) += mmcc-msm8
+ obj-$(CONFIG_QCOM_CLK_SMD_RPM) += clk-smd-rpm.o
+ obj-$(CONFIG_QCOM_CLK_RPM) += clk-rpm.o
  obj-$(CONFIG_QCOM_HFPLL) += hfpll.o
 +obj-$(CONFIG_KRAITCC) += krait-cc.o
 --- /dev/null

--- a/target/linux/ipq806x/patches-4.4/311-add-rpmcc-for-ipq806x.patch
+++ b/target/linux/ipq806x/patches-4.4/311-add-rpmcc-for-ipq806x.patch
@@ -1,0 +1,81 @@
+--- a/Documentation/devicetree/bindings/clock/qcom,rpmcc.txt
++++ b/Documentation/devicetree/bindings/clock/qcom,rpmcc.txt
+@@ -12,6 +12,7 @@ Required properties :
+ 
+ 			"qcom,rpmcc-msm8916", "qcom,rpmcc"
+ 			"qcom,rpmcc-apq8064", "qcom,rpmcc"
++			"qcom,rpmcc-ipq806x", "qcom,rpmcc"
+ 
+ - #clock-cells : shall contain 1
+ 
+--- a/drivers/clk/qcom/clk-rpm.c
++++ b/drivers/clk/qcom/clk-rpm.c
+@@ -359,6 +359,16 @@ DEFINE_CLK_RPM(apq8064, sfab_clk, sfab_a
+ DEFINE_CLK_RPM(apq8064, sfpb_clk, sfpb_a_clk, QCOM_RPM_SFPB_CLK);
+ DEFINE_CLK_RPM(apq8064, qdss_clk, qdss_a_clk, QCOM_RPM_QDSS_CLK);
+ 
++/* ipq806x */
++DEFINE_CLK_RPM(ipq806x, afab_clk, afab_a_clk, QCOM_RPM_APPS_FABRIC_CLK);
++DEFINE_CLK_RPM(ipq806x, cfpb_clk, cfpb_a_clk, QCOM_RPM_CFPB_CLK);
++DEFINE_CLK_RPM(ipq806x, daytona_clk, daytona_a_clk, QCOM_RPM_DAYTONA_FABRIC_CLK);
++DEFINE_CLK_RPM(ipq806x, ebi1_clk, ebi1_a_clk, QCOM_RPM_EBI1_CLK);
++DEFINE_CLK_RPM(ipq806x, sfab_clk, sfab_a_clk, QCOM_RPM_SYS_FABRIC_CLK);
++DEFINE_CLK_RPM(ipq806x, sfpb_clk, sfpb_a_clk, QCOM_RPM_SFPB_CLK);
++DEFINE_CLK_RPM(ipq806x, nss_fabric_0_clk, nss_fabric_0_a_clk, QCOM_RPM_NSS_FABRIC_0_CLK);
++DEFINE_CLK_RPM(ipq806x, nss_fabric_1_clk, nss_fabric_1_a_clk, QCOM_RPM_NSS_FABRIC_1_CLK);
++
+ static struct clk_rpm *apq8064_clks[] = {
+ 	[RPM_APPS_FABRIC_CLK] = &apq8064_afab_clk,
+ 	[RPM_APPS_FABRIC_A_CLK] = &apq8064_afab_a_clk,
+@@ -380,13 +390,38 @@ static struct clk_rpm *apq8064_clks[] =
+ 	[RPM_QDSS_A_CLK] = &apq8064_qdss_a_clk,
+ };
+ 
++static struct clk_rpm *ipq806x_clks[] = {
++	[RPM_APPS_FABRIC_CLK] = &ipq806x_afab_clk,
++	[RPM_APPS_FABRIC_A_CLK] = &ipq806x_afab_a_clk,
++	[RPM_CFPB_CLK] = &ipq806x_cfpb_clk,
++	[RPM_CFPB_A_CLK] = &ipq806x_cfpb_a_clk,
++	[RPM_DAYTONA_FABRIC_CLK] = &ipq806x_daytona_clk,
++	[RPM_DAYTONA_FABRIC_A_CLK] = &ipq806x_daytona_a_clk,
++	[RPM_EBI1_CLK] = &ipq806x_ebi1_clk,
++	[RPM_EBI1_A_CLK] = &ipq806x_ebi1_a_clk,
++	[RPM_SYS_FABRIC_CLK] = &ipq806x_sfab_clk,
++	[RPM_SYS_FABRIC_A_CLK] = &ipq806x_sfab_a_clk,
++	[RPM_SFPB_CLK] = &ipq806x_sfpb_clk,
++	[RPM_SFPB_A_CLK] = &ipq806x_sfpb_a_clk,
++	[RPM_NSS_FABRIC_0_CLK] = &ipq806x_nss_fabric_0_clk,
++	[RPM_NSS_FABRIC_0_A_CLK] = &ipq806x_nss_fabric_0_a_clk,
++	[RPM_NSS_FABRIC_1_CLK] = &ipq806x_nss_fabric_1_clk,
++	[RPM_NSS_FABRIC_1_A_CLK] = &ipq806x_nss_fabric_1_a_clk,
++};
++
+ static const struct rpm_clk_desc rpm_clk_apq8064 = {
+ 	.clks = apq8064_clks,
+ 	.num_clks = ARRAY_SIZE(apq8064_clks),
+ };
+ 
++static const struct rpm_clk_desc rpm_clk_ipq806x = {
++	.clks = ipq806x_clks,
++	.num_clks = ARRAY_SIZE(ipq806x_clks),
++};
++
+ static const struct of_device_id rpm_clk_match_table[] = {
+ 	{ .compatible = "qcom,rpmcc-apq8064", .data = &rpm_clk_apq8064 },
++	{ .compatible = "qcom,rpmcc-ipq806x", .data = &rpm_clk_ipq806x },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(of, rpm_clk_match_table);
+--- a/include/dt-bindings/clock/qcom,rpmcc.h
++++ b/include/dt-bindings/clock/qcom,rpmcc.h
+@@ -37,6 +37,10 @@
+ #define RPM_SYS_FABRIC_A_CLK			19
+ #define RPM_SFPB_CLK				20
+ #define RPM_SFPB_A_CLK				21
++#define RPM_NSS_FABRIC_0_CLK				22
++#define RPM_NSS_FABRIC_0_A_CLK				23
++#define RPM_NSS_FABRIC_1_CLK				24
++#define RPM_NSS_FABRIC_1_A_CLK				25
+ 
+ /* msm8916 */
+ #define RPM_SMD_XO_CLK_SRC				0


### PR DESCRIPTION
RPM clock controller driver had made its way upstream and previous
approach of directly redoing a driver to support ipq806x is a no go anymore.

Thus reverting mentioned patches to upstream state and renaming
in correct patch numbering accordance.

To make the driver work on ipq806x boards we introduce a custom patch.

Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>