### PR TITLE
wwan: adding cdc_ether modem support

### DIFF
--- a/package/network/utils/comgt/files/ncm.json
+++ b/package/network/utils/comgt/files/ncm.json
@@ -63,5 +63,21 @@
 		},
 		"connect": "AT*ENAP=1,1",
 		"disconnect": "AT*ENAP=0"
+	},
+	"mtk2": {
+                "initialize": [
+			"AT+CFUN=1"
+		],
+                "configure": [
+			"AT+CREG?",
+			"AT+CGDCONT=1,\\\"${pdptype}\\\",\\\"${apn}\\\",0,0",
+                        "AT+CGACT=1,1"
+                ],
+                "modes": {
+                        "umts": "AT",
+                        "gsm": "AT"
+                },
+                "connect": "AT+CGDATA=\\\"M-MBIM\\\",1,1",
+                "disconnect": "AT+CGACT=0,1"
 	}
 }

--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -84,7 +84,9 @@ proto_ncm_setup() {
 	[ -n "$delay" ] && sleep "$delay"
 
 	manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk '/Manufacturer/ { print tolower($2) }'`
-	manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | head -2 | tail -1 | tr -d "\r" | tr [A-Z] [a-z]`
+	[ -z $manufacturer ] && {
+		manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | head -2 | tail -1 | tr -d "\r" | tr [A-Z] [a-z]`
+	}
 	[ $? -ne 0 ] && {
 		echo "Failed to get modem information"
 		proto_notify_error "$interface" GETINFO_FAILED
@@ -149,10 +151,10 @@ proto_ncm_setup() {
 	proto_init_update "$ifname" 1
 	proto_send_update "$interface"
 
-	son_load "$(cat /etc/gcom/ncm.json)"
-	son_select "$manufacturer"
-	son_get_vars connect
-	val COMMAND="$connect" gcom -d "$device" -s /etc/gcom/runcommand.gcom || {
+	json_load "$(cat /etc/gcom/ncm.json)"
+	json_select "$manufacturer"
+	json_get_vars connect
+	eval COMMAND="$connect" gcom -d "$device" -s /etc/gcom/runcommand.gcom || {
                echo "Failed to connect"
                proto_notify_error "$interface" CONNECT_FAILED
                return 1
@@ -187,7 +189,9 @@ proto_ncm_teardown() {
 	echo "Stopping network device:$device"
 
 	manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk '/Manufacturer/ { print tolower($2) }'`
-	manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | sed '2q;d' | tr -d "\n\r" | tr [A-Z] [a-z]`
+	[ -z $manufacturer ] && {
+		manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | sed '2q;d' | tr -d "\n\r" | tr [A-Z] [a-z]`
+	}
 	[ $? -ne 0 ] && {
 		echo "Failed to get modem information"
 		proto_notify_error "$interface" GETINFO_FAILED

--- a/package/network/utils/wwan/files/wwan.sh
+++ b/package/network/utils/wwan/files/wwan.sh
@@ -66,15 +66,15 @@ proto_wwan_setup() {
 		}
 	}
 
-	[ -z "$ctl_device" ] && for net in $(ls /sys/class/net/ | grep wwan); do
+	[ -z "$ctl_device" ] && for net in $(ls /sys/class/net/ | grep -e wwan -e usb); do
 		[ -z "$ctl_device" ] || continue
 		driver=$(grep DRIVER /sys/class/net/$net/device/uevent | cut -d= -f2)
 		case "$driver" in
 		qmi_wwan|cdc_mbim)
 			ctl_device=/dev/$(ls /sys/class/net/$net/device/usbmisc)
 			;;
-		sierra_net|*cdc_ncm)
-			ctl_device=/dev/$(cd /sys/class/net/$net/; find ../../../ -name ttyUSB* |xargs basename | head -n1)
+		sierra_net|cdc_ether|*cdc_ncm)
+			ctl_device=/dev/$(cd /sys/class/net/$net/; find ../../../ -name ttyUSB* |xargs -n1 basename | head -n1)
 			;;
 		*) continue;;
 		esac
@@ -97,6 +97,7 @@ proto_wwan_setup() {
 	cdc_mbim)	proto_mbim_setup $@ ;;
 	sierra_net)	proto_directip_setup $@ ;;
 	comgt)		proto_3g_setup $@ ;;
+	cdc_ether)	proto_ncm_setup $@ ;;
 	*cdc_ncm)	proto_ncm_setup $@ ;;
 	esac
 }
@@ -112,6 +113,7 @@ proto_wwan_teardown() {
 	cdc_mbim)	proto_mbim_teardown $@ ;;
 	sierra_net)	proto_mbim_teardown $@ ;;
 	comgt)		proto_3g_teardown $@ ;;
+	cdc_ether)	proto_ncm_teardown $@ ;;
 	*cdc_ncm)	proto_ncm_teardown $@ ;;
 	esac
 }


### PR DESCRIPTION
Some modem use the USB cdc_ether interface to transfer data and the usb_serial to control the modem.
This patch provides support for these modem.

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>