### PR TITLE
    ramips : fix PBR-D1 button definition in dts

### DIFF
--- a/target/linux/ramips/dts/PBR-D1.dts
+++ b/target/linux/ramips/dts/PBR-D1.dts
@@ -43,10 +43,10 @@
 		#size-cells = <0>;
 		poll-interval = <20>;
 
-		wps {
+		reset {
 			label = "reset";
 			gpios = <&gpio1 38 1>;
-			linux,code = <KEY_WPS_BUTTON>;
+			linux,code = <KEY_RESTART>;
 		};
 	};
 


### PR DESCRIPTION
    Due to the product specification,
    the button on PBR-D1 should be reset, not wps.

Signed-off-by: BangLang Huang <banglang.huang@foxmail.com>