### PR TITLE
dnsmasq: fix splitting hostid for DHCPv6 static leases

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -35,7 +35,7 @@ hex_to_hostid() {
         export "$var=$(
                 printf "%0x:%0x"  \
                         $(((0x$hex >> 16) % 65536)) \
-                        $(( 0x$hex        % 256))
+                        $(( 0x$hex        % 65536))
         )"
 
         return 0


### PR DESCRIPTION
Correct splitting the 32-bit 'hostid' value to two 16-bit hexadecimal values. Previously, the lower 16-bit value was truncated to an 8-bit value, which would result in hostid values 100 and 200 both to be set to [::0:0] instead of [::0:100] and [::0:200] respectively.

Signed-off-by: Arjen de Korte \<build+lede@de-korte.org\>