### PR TITLE
ramips: specify rom chip modalias for DIR-610 A1

### DIFF
--- a/target/linux/ramips/dts/DIR-610-A1.dts
+++ b/target/linux/ramips/dts/DIR-610-A1.dts
@@ -50,7 +50,7 @@
 		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		linux,modalias = "m25p80";
+		linux,modalias = "m25p80", "f25l32pa";
 		spi-max-frequency = <10000000>;
 
 		partition@0 {


### PR DESCRIPTION
This should make the flash stable.

Signed-off-by: Victor Shyba <victor1984@riseup.net>