### PR TITLE
github: adding a pull request template

### DIFF
--- a/.github/pull_request_template
+++ b/.github/pull_request_template
@@ -1,0 +1,8 @@
+Thanks for your contribution to the LEDE project!
+
+To help keep the codebase consistent and readable,
+and to help people review your contribution,
+we ask you to follow the rules you find in the wiki at this link
+https://lede-project.org/submitting-patches
+
+Please remove this message before posting the pull request.


### PR DESCRIPTION
This text is used by GitHub to remind important things to people posting PRs through the GitHub's web interface. See here for more information https://github.com/blog/2111-issue-and-pull-request-templates

Loosely inspired by OpenWRT package feed's own pull request template
https://github.com/openwrt/packages/blob/master/.github/pull_request_template

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>