### PR TITLE
base-files: Changed UCI variable name for GPIO value

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -401,7 +401,7 @@ generate_gpioswitch() {
 				set system.$cfg='gpio_switch'
 				set system.$cfg.name='$name'
 				set system.$cfg.gpio_pin='$pin'
-				set system.$cfg.default='$default'
+				set system.$cfg.value='$default'
 			EOF
 		json_select ..
 	json_select ..


### PR DESCRIPTION
This PR changes the UCI variable for the GPIO value from `system.$cfg.default` to `system.$cfg.value` as it was before the change from `uci-defaults` to `board.d`. `/etc/init.d/gpio_switch` still expects the value to be in `system.$cfg.value`.

* [old uci-defaults function](https://github.com/lede-project/source/blob/d65916047b44d6d157d88d15e8e3d92555c5e6f8/package/base-files/files/lib/functions/uci-defaults.sh#L197)
* [current gpio_switch init-script](https://github.com/lede-project/source/blob/master/package/base-files/files/etc/init.d/gpio_switch#L17)