### PR TITLE
usb-serial: adding DWM-158 3g Modem

### DIFF
--- a/target/linux/ramips/patches-4.4/102-add-dlink-dwr158-in-usb-serial-option.patch
+++ b/target/linux/ramips/patches-4.4/102-add-dlink-dwr158-in-usb-serial-option.patch
@@ -1,0 +1,14 @@
+Adding registration for 3G modem DWM-158 in usb-serial-option
+
+Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>
+
+--- a/drivers/usb/serial/option.c	2016-12-03 17:51:59.873595002 +0100
++++ b/drivers/usb/serial/option.c	2016-12-05 19:45:19.891240692 +0100
+@@ -1989,6 +1989,7 @@
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x2001, 0x7d02, 0xff, 0x00, 0x00) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x2001, 0x7d03, 0xff, 0x02, 0x01) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x2001, 0x7d03, 0xff, 0x00, 0x00) },
++	{ USB_DEVICE_INTERFACE_CLASS(0x2001, 0x7d04, 0xff) },			/* D-Link DWM-158 */
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x2001, 0x7e19, 0xff),			/* D-Link DWM-221 B1 */
+ 	  .driver_info = (kernel_ulong_t)&net_intf4_blacklist },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x3e01, 0xff, 0xff, 0xff) }, /* D-Link DWM-152/C1 */


### PR DESCRIPTION
This patch add the 3G modem DWM-158 to the usb-serial option driver.
The DWM-158 is a pcie 3G modem. It is embedded in the DWR-512 modem supportet by lede.
The patch has been submitted and merged in the upstream linux-next repository.

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>