### PR TITLE
net/utils/tcpdump: update to 4.8.1

### DIFF
--- a/package/network/utils/tcpdump/Makefile
+++ b/package/network/utils/tcpdump/Makefile
@@ -8,15 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcpdump
-PKG_VERSION:=4.5.1
-PKG_RELEASE:=4
+PKG_VERSION:=4.8.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.tcpdump.org/release/ \
-	http://ftp.gwdg.de/pub/misc/tcpdump/ \
-	http://www.at.tcpdump.org/ \
-	http://www.br.tcpdump.org/
-PKG_MD5SUM:=973a2513d0076e34aa9da7e15ed98e1b
+	http://www.at.tcpdump.org/
+PKG_MD5SUM:=32f57943649f276e09236ba66622bb0c
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_BUILD_PARALLEL:=1

--- a/package/network/utils/tcpdump/patches/001-remove_pcap_debug.patch
+++ b/package/network/utils/tcpdump/patches/001-remove_pcap_debug.patch
@@ -1,23 +1,100 @@
---- a/tcpdump.c
-+++ b/tcpdump.c
-@@ -1095,20 +1095,6 @@ main(int argc, char **argv)
- 				error("invalid data link type %s", gndo->ndo_dltname);
- 			break;
+--- a/configure
++++ b/configure
+@@ -6260,97 +6260,6 @@ $as_echo "no" >&6; }
+     fi
+ fi
  
--#if defined(HAVE_PCAP_DEBUG) || defined(HAVE_YYDEBUG)
--		case 'Y':
--			{
--			/* Undocumented flag */
--#ifdef HAVE_PCAP_DEBUG
--			extern int pcap_debug;
--			pcap_debug = 1;
--#else
+-#
+-# Check for special debugging functions
+-#
+-for ac_func in pcap_set_parser_debug
+-do :
+-  ac_fn_c_check_func "$LINENO" "pcap_set_parser_debug" "ac_cv_func_pcap_set_parser_debug"
+-if test "x$ac_cv_func_pcap_set_parser_debug" = xyes; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define HAVE_PCAP_SET_PARSER_DEBUG 1
+-_ACEOF
+-
+-fi
+-done
+-
+-if test "$ac_cv_func_pcap_set_parser_debug" = "no" ; then
+-	#
+-	# OK, we don't have pcap_set_parser_debug() to set the libpcap
+-	# filter expression parser debug flag; can we directly set the
+-	# flag?
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether pcap_debug is defined by libpcap" >&5
+-$as_echo_n "checking whether pcap_debug is defined by libpcap... " >&6; }
+-	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-
+-		extern int pcap_debug;
+-
+-		return pcap_debug;
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_c_try_link "$LINENO"; then :
+-  ac_lbl_cv_pcap_debug_defined=yes
+-else
+-  ac_lbl_cv_pcap_debug_defined=no
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext conftest.$ac_ext
+-	if test "$ac_lbl_cv_pcap_debug_defined" = yes ; then
+-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
+-
+-$as_echo "#define HAVE_PCAP_DEBUG 1" >>confdefs.h
+-
+-	else
+-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-		#
+-		# OK, what about "yydebug"?
+-		#
+-		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether yydebug is defined by libpcap" >&5
+-$as_echo_n "checking whether yydebug is defined by libpcap... " >&6; }
+-		cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-
 -			extern int yydebug;
--			yydebug = 1;
--#endif
--			}
--			break;
--#endif
- 		case 'z':
- 			if (optarg) {
- 				zflag = strdup(optarg);
+-
+-			return yydebug;
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_c_try_link "$LINENO"; then :
+-  ac_lbl_cv_yydebug_defined=yes
+-else
+-  ac_lbl_cv_yydebug_defined=no
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext conftest.$ac_ext
+-		if test "$ac_lbl_cv_yydebug_defined" = yes ; then
+-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
+-
+-$as_echo "#define HAVE_YYDEBUG 1" >>confdefs.h
+-
+-		else
+-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-		fi
+-	fi
+-fi
+ for ac_func in pcap_set_optimizer_debug
+ do :
+   ac_fn_c_check_func "$LINENO" "pcap_set_optimizer_debug" "ac_cv_func_pcap_set_optimizer_debug"

--- a/package/network/utils/tcpdump/patches/002-remove_static_libpcap_check.patch
+++ b/package/network/utils/tcpdump/patches/002-remove_static_libpcap_check.patch
@@ -1,35 +1,44 @@
 --- a/configure
 +++ b/configure
-@@ -5813,28 +5813,6 @@ $as_echo "Using $pfopen" >&6; }
+@@ -5472,37 +5472,6 @@ $as_echo "Using $pfopen" >&6; }
  		    LIBS="$LIBS $pfopen"
  	    fi
      fi
--    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for local pcap library" >&5
+-	libpcap=FAIL
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for local pcap library" >&5
 -$as_echo_n "checking for local pcap library... " >&6; }
--    libpcap=FAIL
--    lastdir=FAIL
--    places=`ls $srcdir/.. | sed -e 's,/$,,' -e "s,^,$srcdir/../," | \
--	egrep '/libpcap-[0-9]+\.[0-9]+(\.[0-9]*)?([ab][0-9]*|-PRE-GIT)?$'`
--    for dir in $places $srcdir/../libpcap $srcdir/libpcap ; do
--	    basedir=`echo $dir | sed -e 's/[ab][0-9]*$//' | \
--	        sed -e 's/-PRE-GIT$//' `
--	    if test $lastdir = $basedir ; then
--		    		    continue;
--	    fi
--	    lastdir=$dir
--	    if test -r $dir/libpcap.a ; then
--		    libpcap=$dir/libpcap.a
--		    d=$dir
--		    	    fi
--    done
+-
+-# Check whether --with-system-libpcap was given.
+-if test "${with_system_libpcap+set}" = set; then :
+-  withval=$with_system_libpcap;
+-fi
+-
+-	if test "x$with_system_libpcap" != xyes ; then
+-		lastdir=FAIL
+-    	places=`ls $srcdir/.. | sed -e 's,/$,,' -e "s,^,$srcdir/../," | \
+-		egrep '/libpcap-[0-9]+\.[0-9]+(\.[0-9]*)?([ab][0-9]*|-PRE-GIT)?$'`
+-    	places2=`ls .. | sed -e 's,/$,,' -e "s,^,../," | \
+-		egrep '/libpcap-[0-9]+\.[0-9]+(\.[0-9]*)?([ab][0-9]*|-PRE-GIT)?$'`
+-    	for dir in $places $srcdir/../libpcap ../libpcap $srcdir/libpcap $places2 ; do
+-	    	basedir=`echo $dir | sed -e 's/[ab][0-9]*$//' | \
+-	        	sed -e 's/-PRE-GIT$//' `
+-	    	if test $lastdir = $basedir ; then
+-		    			    	continue;
+-	    	fi
+-	    	lastdir=$dir
+-	    	if test -r $dir/libpcap.a ; then
+-		    	libpcap=$dir/libpcap.a
+-		    	d=$dir
+-		    		    	fi
+-		done
+-	fi
 -    if test $libpcap = FAIL ; then
 -	    { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
 -$as_echo "not found" >&6; }
--
+ 
  	    #
  	    # Look for pcap-config.
- 	    #
-@@ -5989,41 +5967,6 @@ if test "x$ac_cv_lib_pcap_main" = xyes;
+@@ -5658,51 +5627,6 @@ if test "x$ac_cv_lib_pcap_main" = xyes;
    libpcap="-lpcap"
  fi
  
@@ -59,13 +68,23 @@
 -	    V_PCAPDEP=$libpcap
 -	    places=`ls $srcdir/.. | sed -e 's,/$,,' -e "s,^,$srcdir/../," | \
 -    	 		egrep '/libpcap-[0-9]*.[0-9]*(.[0-9]*)?([ab][0-9]*)?$'`
+-	    places2=`ls .. | sed -e 's,/$,,' -e "s,^,../," | \
+-    	 		egrep '/libpcap-[0-9]*.[0-9]*(.[0-9]*)?([ab][0-9]*)?$'`
+-            pcapH=FAIL
 -	    if test -r $d/pcap.h; then
--		    V_INCLS="-I$d $V_INCLS"
--	    elif test -r $places/pcap.h; then
--		    V_INCLS="-I$places $V_INCLS"
+-                    pcapH=$d
 -	    else
--                    as_fn_error see INSTALL "cannot find pcap.h" "$LINENO" 5
+-                for dir in $places $srcdir/../libpcap ../libpcap $srcdir/libpcap $places2 ; do
+-                   if test -r $dir/pcap.h ; then
+-                       pcapH=$dir
+-                   fi
+-                done
+-            fi
+-
+-            if test $pcapH = FAIL ; then
+-                    as_fn_error $? "cannot find pcap.h: see INSTALL" "$LINENO" 5
 - 	    fi
+-            V_INCLS="-I$pcapH $V_INCLS"
 -	    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $libpcap" >&5
 -$as_echo "$libpcap" >&6; }
  	    # Extract the first word of "pcap-config", so it can be a program name with args.

--- a/package/network/utils/tcpdump/patches/100-tcpdump_mini.patch
+++ b/package/network/utils/tcpdump/patches/100-tcpdump_mini.patch
@@ -1,45 +1,118 @@
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -71,6 +71,22 @@ DEPENDENCY_CFLAG = @DEPENDENCY_CFLAG@
+@@ -70,6 +70,87 @@ DEPENDENCY_CFLAG = @DEPENDENCY_CFLAG@
  	@rm -f $@
  	$(CC) $(FULL_CFLAGS) -c $(srcdir)/$*.c
  
 +ifdef TCPDUMP_MINI
 +
-+CSRC =	addrtoname.c af.c checksum.c cpack.c gmpls.c oui.c gmt2local.c ipproto.c \
-+        nlpid.c l2vpn.c machdep.c parsenfsfh.c in_cksum.c \
-+	print-802_11.c print-aodv.c print-arp.c print-ascii.c \
-+	print-bgp.c print-bootp.c print-cdp.c print-domain.c print-eap.c print-ether.c \
-+	print-gre.c print-icmp.c print-igmp.c print-ip.c \
-+	print-l2tp.c print-lldp.c print-llc.c \
-+ 	print-nfs.c print-ntp.c print-null.c print-olsr.c print-ospf.c \
-+	print-ppp.c print-pppoe.c print-pptp.c print-radius.c print-raw.c print-rsvp.c \
-+	print-sctp.c print-sip.c print-sll.c print-snmp.c print-stp.c print-sunrpc.c \
-+	print-syslog.c print-tcp.c print-telnet.c print-tftp.c print-udp.c \
-+	setsignal.c tcpdump.c util.c signature.c print-ipnet.c print-forces.c
++CSRC=\
++	tcpdump.c \
++	util.c \
++	setsignal.c \
++	addrtoname.c \
++	addrtostr.c \
++	af.c \
++	ascii_strcasecmp.c \
++	checksum.c \
++	cpack.c \
++	gmpls.c \
++	gmt2local.c \
++	in_cksum.c \
++	ipproto.c \
++	l2vpn.c \
++	machdep.c \
++	nlpid.c \
++	oui.c \
++	parsenfsfh.c \
++	print.c \
++	print-802_11.c \
++	print-aodv.c \
++	print-arp.c \
++	print-ascii.c \
++	print-bgp.c \
++	print-bootp.c \
++	print-cdp.c \
++	print-dhcp6.c \
++	print-domain.c \
++	print-eap.c \
++	print-ether.c \
++	print-ftp.c \
++	print-forces.c \
++	print-gre.c \
++	print-http.c \
++	print-icmp.c \
++	print-icmp6.c \
++	print-igmp.c \
++	print-ip.c \
++	print-ip6.c \
++	print-ip6opts.c \
++	print-ipnet.c \
++	print-l2tp.c \
++	print-llc.c \
++	print-lldp.c \
++	print-loopback.c \
++	print-m3ua.c \
++	print-nfs.c \
++	print-ntp.c \
++	print-null.c \
++	print-olsr.c \
++	print-ospf.c \
++	print-ospf6.c \
++	print-ppp.c \
++	print-pppoe.c \
++	print-pptp.c \
++	print-radius.c \
++	print-raw.c \
++	print-rsvp.c \
++	print-rt6.c \
++	print-rtsp.c \
++	print-sctp.c \
++	print-sip.c \
++	print-sll.c \
++	print-smtp.c \
++	print-snmp.c \
++	print-stp.c \
++	print-sunrpc.c \
++	print-syslog.c \
++	print-tcp.c \
++	print-telnet.c \
++	print-tftp.c \
++	print-udp.c \
++	signature.c \
++	strtoaddr.c \
++	util-print.c
 +
 +else
 +
- CSRC =	addrtoname.c af.c checksum.c cpack.c gmpls.c oui.c gmt2local.c ipproto.c \
-         nlpid.c l2vpn.c machdep.c parsenfsfh.c in_cksum.c \
- 	print-802_11.c print-802_15_4.c print-ap1394.c print-ah.c \
-@@ -103,6 +119,8 @@ LIBNETDISSECT_SRC=print-isakmp.c
- LIBNETDISSECT_OBJ=$(LIBNETDISSECT_SRC:.c=.o)
- LIBNETDISSECT=libnetdissect.a
+ CSRC =	setsignal.c tcpdump.c util.c
+ 
+ LIBNETDISSECT_SRC=\
+@@ -236,12 +317,16 @@ LIBNETDISSECT_SRC=\
+ 	strtoaddr.c \
+ 	util-print.c
  
 +endif
 +
  LOCALSRC = @LOCALSRC@
  GENSRC = version.c
  LIBOBJS = @LIBOBJS@
-@@ -286,10 +304,12 @@ $(PROG): $(OBJ) @V_PCAPDEP@
+ 
++ifndef TCPDUMP_MINI
+ LIBNETDISSECT_OBJ=$(LIBNETDISSECT_SRC:.c=.o) ${LOCALSRC:.c=.o} ${LIBOBJS}
+ LIBNETDISSECT=libnetdissect.a
++endif
+ 
+ 
+ SRC =	$(CSRC) $(GENSRC) $(LOCALSRC) $(LIBNETDISSECT_SRC)
+@@ -367,10 +452,12 @@ $(PROG): $(OBJ) @V_PCAPDEP@
  	@rm -f $@
  	$(CC) $(FULL_CFLAGS) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
  
 +ifndef TCPDUMP_MINI
  $(LIBNETDISSECT): $(LIBNETDISSECT_OBJ)
  	@rm -f $@
- 	$(AR) cr $@ $(LIBNETDISSECT_OBJ) 
+ 	$(AR) cr $@ $(LIBNETDISSECT_OBJ)
  	$(RANLIB) $@
 +endif
  
@@ -47,28 +120,26 @@
  	$(CC) $(FULL_CFLAGS) -o $@ -c $(srcdir)/missing/datalinks.c
 --- a/addrtoname.c
 +++ b/addrtoname.c
-@@ -556,10 +556,10 @@ linkaddr_string(const u_char *ep, const
- 
+@@ -564,8 +564,10 @@ linkaddr_string(netdissect_options *ndo,
  	if (type == LINKADDR_ETHER && len == ETHER_ADDR_LEN)
- 		return (etheraddr_string(ep));
--
+ 		return (etheraddr_string(ndo, ep));
+ 
 +#ifndef TCPDUMP_MINI
  	if (type == LINKADDR_FRELAY)
- 		return (q922_string(ep));
--
+ 		return (q922_string(ndo, ep, len));
 +#endif
- 	tp = lookup_bytestring(ep, len);
+ 
+ 	tp = lookup_bytestring(ndo, ep, len);
  	if (tp->e_name)
- 		return (tp->e_name);
-@@ -1159,6 +1159,7 @@ init_addrtoname(u_int32_t localnet, u_in
- 	init_ipxsaparray();
+@@ -1200,6 +1202,7 @@ init_addrtoname(netdissect_options *ndo,
+ 	init_ipxsaparray(ndo);
  }
  
 +#ifndef TCPDUMP_MINI
  const char *
- dnaddr_string(u_short dnaddr)
+ dnaddr_string(netdissect_options *ndo, u_short dnaddr)
  {
-@@ -1178,6 +1179,7 @@ dnaddr_string(u_short dnaddr)
+@@ -1219,6 +1222,7 @@ dnaddr_string(netdissect_options *ndo, u
  
  	return(tp->name);
  }
@@ -76,727 +147,9 @@
  
  /* Return a zero'ed hnamemem struct and cuts down on calloc() overhead */
  struct hnamemem *
---- a/print-ether.c
-+++ b/print-ether.c
-@@ -342,6 +342,7 @@ ethertype_print(netdissect_options *ndo,
-   	        arp_print(ndo, p, length, caplen);
- 		return (1);
- 
-+#ifndef TCPDUMP_MINI
- 	case ETHERTYPE_DN:
- 		decnet_print(/*ndo,*/p, length, caplen);
- 		return (1);
-@@ -360,10 +361,13 @@ ethertype_print(netdissect_options *ndo,
- 		ND_PRINT((ndo, "(NOV-ETHII) "));
- 		ipx_print(/*ndo,*/p, length);
- 		return (1);
-+#endif
- 
-+#ifndef TCPDUMP_MINI
-         case ETHERTYPE_ISO:
-                 isoclns_print(/*ndo,*/p+1, length-1, length-1);
-                 return(1);
-+#endif
- 
- 	case ETHERTYPE_PPPOED:
- 	case ETHERTYPE_PPPOES:
-@@ -376,9 +380,11 @@ ethertype_print(netdissect_options *ndo,
- 	        eap_print(ndo, p, length);
- 		return (1);
- 
-+#ifndef TCPDUMP_MINI
- 	case ETHERTYPE_RRCP:
- 	        rrcp_print(ndo, p - 14 , length + 14);
- 		return (1);
-+#endif
- 
- 	case ETHERTYPE_PPP:
- 		if (length) {
-@@ -387,6 +393,7 @@ ethertype_print(netdissect_options *ndo,
- 		}
- 		return (1);
- 
-+#ifndef TCPDUMP_MINI
- 	case ETHERTYPE_MPCP:
- 	        mpcp_print(/*ndo,*/p, length);
- 		return (1);
-@@ -399,7 +406,7 @@ ethertype_print(netdissect_options *ndo,
- 	case ETHERTYPE_CFM_OLD:
- 	        cfm_print(/*ndo,*/p, length);
- 		return (1);
--
-+#endif
- 	case ETHERTYPE_LLDP:
- 	        lldp_print(/*ndo,*/p, length);
- 		return (1);
-@@ -407,6 +414,7 @@ ethertype_print(netdissect_options *ndo,
-         case ETHERTYPE_LOOPBACK:
-                 return (1);
- 
-+#ifndef TCPDUMP_MINI
- 	case ETHERTYPE_MPLS:
- 	case ETHERTYPE_MPLS_MULTI:
- 		mpls_print(/*ndo,*/p, length);
-@@ -428,6 +436,7 @@ ethertype_print(netdissect_options *ndo,
-         case ETHERTYPE_CALM_FAST:
-                 calm_fast_print(ndo, p-14, p, length);
-                 return (1);
-+#endif
- 
- 	case ETHERTYPE_LAT:
- 	case ETHERTYPE_SCA:
---- a/print-gre.c
-+++ b/print-gre.c
-@@ -213,6 +213,7 @@ gre_print_0(const u_char *bp, u_int leng
- 		ip6_print(gndo, bp, len);
- 		break;
- #endif
-+#ifndef TCPDUMP_MINI
- 	case ETHERTYPE_MPLS:
- 		mpls_print(bp, len);
- 		break;
-@@ -228,6 +229,7 @@ gre_print_0(const u_char *bp, u_int leng
- 	case ETHERTYPE_TEB:
- 		ether_print(gndo, bp, len, len, NULL, NULL);
- 		break;
-+#endif
- 	default:
- 		printf("gre-proto-0x%x", prot);
- 	}
---- a/print-igmp.c
-+++ b/print-igmp.c
-@@ -309,6 +309,7 @@ igmp_print(register const u_char *bp, re
-         TCHECK2(bp[4], 4);
-         (void)printf("igmp leave %s", ipaddr_string(&bp[4]));
-         break;
-+#ifndef TCPDUMP_MINI
-     case 0x13:
-         (void)printf("igmp dvmrp");
-         if (len < 8)
-@@ -320,6 +321,7 @@ igmp_print(register const u_char *bp, re
-         (void)printf("igmp pimv1");
-         pimv1_print(bp, len);
-         break;
-+#endif
-     case 0x1e:
-         print_mresp(bp, len);
-         break;
---- a/print-ip.c
-+++ b/print-ip.c
-@@ -328,6 +328,7 @@ ip_print_demux(netdissect_options *ndo,
- again:
- 	switch (ipds->nh) {
- 
-+#ifndef TCPDUMP_MINI
- 	case IPPROTO_AH:
- 		ipds->nh = *ipds->cp;
- 		ipds->advance = ah_print(ipds->cp);
-@@ -362,15 +363,15 @@ again:
- 		ipds->nh = enh & 0xff;
- 		goto again;
- 	}
--
-+#endif
- 	case IPPROTO_SCTP:
- 		sctp_print(ipds->cp, (const u_char *)ipds->ip, ipds->len);
- 		break;
--
-+#ifndef TCPDUMP_MINI
- 	case IPPROTO_DCCP:
- 		dccp_print(ipds->cp, (const u_char *)ipds->ip, ipds->len);
- 		break;
--
-+#endif
- 	case IPPROTO_TCP:
- 		/* pass on the MF bit plus the offset to detect fragments */
- 		tcp_print(ipds->cp, ipds->len, (const u_char *)ipds->ip,
-@@ -388,7 +389,7 @@ again:
- 		icmp_print(ipds->cp, ipds->len, (const u_char *)ipds->ip,
- 			   ipds->off & (IP_MF|IP_OFFMASK));
- 		break;
--
-+#ifndef TCPDUMP_MINI
- 	case IPPROTO_PIGP:
- 		/*
- 		 * XXX - the current IANA protocol number assignments
-@@ -409,15 +410,15 @@ again:
- 	case IPPROTO_EIGRP:
- 		eigrp_print(ipds->cp, ipds->len);
- 		break;
--
-+#endif
- 	case IPPROTO_ND:
- 		ND_PRINT((ndo, " nd %d", ipds->len));
- 		break;
--
-+#ifndef TCPDUMP_MINI
- 	case IPPROTO_EGP:
- 		egp_print(ipds->cp, ipds->len);
- 		break;
--
-+#endif
- 	case IPPROTO_OSPF:
- 		ospf_print(ipds->cp, ipds->len, (const u_char *)ipds->ip);
- 		break;
-@@ -451,10 +452,10 @@ again:
- 		gre_print(ipds->cp, ipds->len);
- 		break;
- 
-+#ifndef TCPDUMP_MINI
- 	case IPPROTO_MOBILE:
- 		mobile_print(ipds->cp, ipds->len);
- 		break;
--
- 	case IPPROTO_PIM:
- 		vec[0].ptr = ipds->cp;
- 		vec[0].len = ipds->len;
-@@ -480,7 +481,7 @@ again:
- 	case IPPROTO_PGM:
- 		pgm_print(ipds->cp, ipds->len, (const u_char *)ipds->ip);
- 		break;
--
-+#endif
- 	default:
- 		if (ndo->ndo_nflag==0 && (proto = getprotobynumber(ipds->nh)) != NULL)
- 			ND_PRINT((ndo, " %s", proto->p_name));
---- a/print-ip6.c
-+++ b/print-ip6.c
-@@ -192,9 +192,11 @@ ip6_print(netdissect_options *ndo, const
- 		case IPPROTO_SCTP:
- 			sctp_print(cp, (const u_char *)ip6, len);
- 			return;
-+#ifndef TCPDUMP_MINI
- 		case IPPROTO_DCCP:
- 			dccp_print(cp, (const u_char *)ip6, len);
- 			return;
-+#endif
- 		case IPPROTO_TCP:
- 			tcp_print(cp, len, (const u_char *)ip6, fragmented);
- 			return;
-@@ -204,6 +206,7 @@ ip6_print(netdissect_options *ndo, const
- 		case IPPROTO_ICMPV6:
- 			icmp6_print(ndo, cp, len, (const u_char *)ip6, fragmented);
- 			return;
-+#ifndef TCPDUMP_MINI
- 		case IPPROTO_AH:
- 			advance = ah_print(cp);
- 			nh = *cp;
-@@ -228,7 +231,7 @@ ip6_print(netdissect_options *ndo, const
- 			pim_print(cp, len, nextproto6_cksum(ip6, cp, len,
- 							    IPPROTO_PIM));
- 			return;
--
-+#endif
- 		case IPPROTO_OSPF:
- 			ospf6_print(cp, len);
- 			return;
-@@ -240,11 +243,11 @@ ip6_print(netdissect_options *ndo, const
- 		case IPPROTO_IPV4:
- 		        ip_print(ndo, cp, len);
- 			return;
--
-+#ifndef TCPDUMP_MINI
-                 case IPPROTO_PGM:
-                         pgm_print(cp, len, (const u_char *)ip6);
-                         return;
--
-+#endif
- 		case IPPROTO_GRE:
- 			gre_print(cp, len);
- 			return;
---- a/print-llc.c
-+++ b/print-llc.c
-@@ -196,7 +196,7 @@ llc_print(const u_char *p, u_int length,
- 		control = EXTRACT_LE_16BITS(p + 2);
- 		is_u = 0;
- 	}
--
-+#ifndef TCPDUMP_MINI
- 	if (ssap_field == LLCSAP_GLOBAL && dsap_field == LLCSAP_GLOBAL) {
- 		/*
- 		 * This is an Ethernet_802.3 IPX frame; it has an
-@@ -219,6 +219,7 @@ llc_print(const u_char *p, u_int length,
-             ipx_print(p, length);
-             return (1);
- 	}
-+#endif
- 
- 	dsap = dsap_field & ~LLC_IG;
- 	ssap = ssap_field & ~LLC_GSAP;
-@@ -251,6 +252,7 @@ llc_print(const u_char *p, u_int length,
- 		return (1);
- 	}
- 
-+#ifndef TCPDUMP_MINI
- 	if (ssap == LLCSAP_IPX && dsap == LLCSAP_IPX &&
- 	    control == LLC_UI) {
- 		/*
-@@ -266,6 +268,7 @@ llc_print(const u_char *p, u_int length,
- 		ipx_print(p+3, length-3);
- 		return (1);
- 	}
-+#endif
- 
- #ifdef TCPDUMP_DO_SMB
- 	if (ssap == LLCSAP_NETBEUI && dsap == LLCSAP_NETBEUI
-@@ -297,11 +300,13 @@ llc_print(const u_char *p, u_int length,
- 		return (1);
- 	}
- #endif
-+#ifndef TCPDUMP_MINI
- 	if (ssap == LLCSAP_ISONS && dsap == LLCSAP_ISONS
- 	    && control == LLC_UI) {
- 		isoclns_print(p + 3, length - 3, caplen - 3);
- 		return (1);
- 	}
-+#endif
- 
- 	if (ssap == LLCSAP_SNAP && dsap == LLCSAP_SNAP
- 	    && control == LLC_UI) {
-@@ -444,6 +449,7 @@ snap_print(const u_char *p, u_int length
-                 case PID_CISCO_CDP:
-                         cdp_print(p, length, caplen);
-                         return (1);
-+#ifndef TCPDUMP_MINI
-                 case PID_CISCO_DTP:
-                         dtp_print(p, length); 
-                         return (1);
-@@ -453,6 +459,7 @@ snap_print(const u_char *p, u_int length
-                 case PID_CISCO_VTP:
-                         vtp_print(p, length);
-                         return (1);
-+#endif
-                 case PID_CISCO_PVST:
-                 case PID_CISCO_VLANBRIDGE:
-                         stp_print(p, length);
-@@ -484,6 +491,7 @@ snap_print(const u_char *p, u_int length
- 			ether_print(gndo, p, length, caplen, NULL, NULL);
- 			return (1);
- 
-+#ifndef TCPDUMP_MINI
- 		case PID_RFC2684_802_5_FCS:
- 		case PID_RFC2684_802_5_NOFCS:
- 			/*
-@@ -525,6 +533,7 @@ snap_print(const u_char *p, u_int length
- 			 */
- 			fddi_print(p, length, caplen);
- 			return (1);
-+#endif
- 
- 		case PID_RFC2684_BPDU:
- 			stp_print(p, length);
---- a/print-null.c
-+++ b/print-null.c
-@@ -128,7 +128,7 @@ null_if_print(const struct pcap_pkthdr *
- 		ip6_print(gndo, p, length);
- 		break;
- #endif
--
-+#ifndef TCPDUMP_MINI
- 	case BSD_AFNUM_ISO:
- 		isoclns_print(p, length, caplen);
- 		break;
-@@ -140,7 +140,7 @@ null_if_print(const struct pcap_pkthdr *
- 	case BSD_AFNUM_IPX:
- 		ipx_print(p, length);
- 		break;
--
-+#endif
- 	default:
- 		/* unknown AF_ value */
- 		if (!eflag)
---- a/print-ppp.c
-+++ b/print-ppp.c
-@@ -1262,7 +1262,7 @@ trunc:
- 	return 0;
- }
- 
--
-+#ifndef TCPDUMP_MINI
- static void
- ppp_hdlc(const u_char *p, int length)
- {
-@@ -1327,17 +1327,19 @@ cleanup:
- 	free(b);
-         return;
- }
-+#endif
- 
- 
- /* PPP */
- static void
- handle_ppp(u_int proto, const u_char *p, int length)
- {
-+#ifndef TCPDUMP_MINI
-         if ((proto & 0xff00) == 0x7e00) {/* is this an escape code ? */
-             ppp_hdlc(p-1, length);
-             return;
-         }
--
-+#endif
- 	switch (proto) {
- 	case PPP_LCP: /* fall through */
- 	case PPP_IPCP:
-@@ -1371,6 +1373,7 @@ handle_ppp(u_int proto, const u_char *p,
- 		ip6_print(gndo, p, length);
- 		break;
- #endif
-+#ifndef TCPDUMP_MINI
- 	case ETHERTYPE_IPX:	/*XXX*/
- 	case PPP_IPX:
- 		ipx_print(p, length);
-@@ -1382,6 +1385,7 @@ handle_ppp(u_int proto, const u_char *p,
- 	case PPP_MPLS_MCAST:
- 		mpls_print(p, length);
- 		break;
-+#endif
- 	case PPP_COMP:
- 		printf("compressed PPP data");
- 		break;
-@@ -1520,6 +1524,7 @@ ppp_if_print(const struct pcap_pkthdr *h
- 	return (0);
- }
- 
-+#ifndef TCPDUMP_MINI
- /*
-  * PPP I/F printer to use if we know that RFC 1662-style PPP in HDLC-like
-  * framing, or Cisco PPP with HDLC framing as per section 4.3.1 of RFC 1547,
-@@ -1747,7 +1752,7 @@ printx:
- #endif /* __bsdi__ */
- 	return (hdrlength);
- }
--
-+#endif
- 
- /*
-  * Local Variables:
---- a/print-tcp.c
-+++ b/print-tcp.c
-@@ -573,14 +573,14 @@ tcp_print(register const u_char *bp, reg
-                                         utoval >>= 1;
-                                 (void)printf(" %u", utoval);
-                                 break;
--
-+#ifndef TCPDUMP_MINI
-                         case TCPOPT_MPTCP:
-                                 datalen = len - 2;
-                                 LENCHECK(datalen);
-                                 if (!mptcp_print(cp-2, len, flags))
-                                         goto bad;
-                                 break;
--
-+#endif
-                         case TCPOPT_EXPERIMENT2:
-                                 datalen = len - 2;
-                                 LENCHECK(datalen);
-@@ -659,8 +659,8 @@ tcp_print(register const u_char *bp, reg
-         if ((flags & TH_RST) && vflag) {
-                 print_tcp_rst_data(bp, length);
-                 return;
--        } 
--
-+        }
-+#ifndef TCPDUMP_MINI
-         if (packettype) {
-                 switch (packettype) {
-                 case PT_ZMTP1:
-@@ -669,7 +669,7 @@ tcp_print(register const u_char *bp, reg
-                 }
-                 return;
-         }
--
-+#endif
-         if (sport == TELNET_PORT || dport == TELNET_PORT) {
-                 if (!qflag && vflag)
-                         telnet_print(bp, length);
-@@ -683,10 +683,12 @@ tcp_print(register const u_char *bp, reg
- 	else if (sport == SMB_PORT || dport == SMB_PORT)
- 		smb_tcp_print(bp, length);
- #endif
-+#ifndef TCPDUMP_MINI
-         else if (sport == BEEP_PORT || dport == BEEP_PORT)
-                 beep_print(bp, length);
-         else if (sport == OPENFLOW_PORT || dport == OPENFLOW_PORT)
-                 openflow_print(bp, length);
-+#endif
-         else if (length > 2 &&
-                  (sport == NAMESERVER_PORT || dport == NAMESERVER_PORT ||
-                   sport == MULTICASTDNS_PORT || dport == MULTICASTDNS_PORT)) {
-@@ -695,6 +697,7 @@ tcp_print(register const u_char *bp, reg
-                  * XXX packet could be unaligned, it can go strange
-                  */
-                 ns_print(bp + 2, length - 2, 0);
-+#ifndef TCPDUMP_MINI
-         } else if (sport == MSDP_PORT || dport == MSDP_PORT) {
-                 msdp_print(bp, length);
-         } else if (sport == RPKI_RTR_PORT || dport == RPKI_RTR_PORT) {
-@@ -702,6 +705,7 @@ tcp_print(register const u_char *bp, reg
-         }
-         else if (length > 0 && (sport == LDP_PORT || dport == LDP_PORT)) {
-                 ldp_print(bp, length);
-+#endif
-         }
-         else if ((sport == NFS_PORT || dport == NFS_PORT) &&
-                  length >= 4 && TTEST2(*bp, 4)) {
---- a/print-udp.c
-+++ b/print-udp.c
-@@ -418,11 +418,12 @@ udp_print(register const u_char *bp, u_i
- 			vat_print((void *)(up + 1), up);
- 			break;
- 
-+#ifndef TCPDUMP_MINI
- 		case PT_WB:
- 			udpipaddr_print(ip, sport, dport);
- 			wb_print((void *)(up + 1), length);
- 			break;
--
-+#endif
- 		case PT_RPC:
- 			rp = (struct sunrpc_msg *)(up + 1);
- 			direction = (enum sunrpc_msg_type)EXTRACT_32BITS(&rp->rm_direction);
-@@ -450,11 +451,12 @@ udp_print(register const u_char *bp, u_i
- 			snmp_print((const u_char *)(up + 1), length);
- 			break;
- 
-+#ifndef TCPDUMP_MINI
- 		case PT_CNFP:
- 			udpipaddr_print(ip, sport, dport);
- 			cnfp_print(cp, (const u_char *)ip);
- 			break;
--
-+#endif
- 		case PT_TFTP:
- 			udpipaddr_print(ip, sport, dport);
- 			tftp_print(cp, length);
-@@ -475,6 +477,7 @@ udp_print(register const u_char *bp, u_i
- 			radius_print(cp, length);
- 			break;
- 
-+#ifndef TCPDUMP_MINI
- 		case PT_VXLAN:
- 			udpipaddr_print(ip, sport, dport);
- 			vxlan_print((const u_char *)(up + 1), length);
-@@ -489,6 +492,7 @@ udp_print(register const u_char *bp, u_i
- 			udpipaddr_print(ip, sport, dport);
- 			lmp_print(cp, length);
- 			break;
-+#endif
- 		}
- 		return;
- 	}
-@@ -517,6 +521,7 @@ udp_print(register const u_char *bp, u_i
- 			}
- #endif
- 		}
-+#ifndef TCPDUMP_MINI
- 		if (TTEST(((struct LAP *)cp)->type) &&
- 		    ((struct LAP *)cp)->type == lapDDP &&
- 		    (atalk_port(sport) || atalk_port(dport))) {
-@@ -525,6 +530,7 @@ udp_print(register const u_char *bp, u_i
- 			llap_print(cp, length);
- 			return;
- 		}
-+#endif
- 	}
- 	udpipaddr_print(ip, sport, dport);
- 
-@@ -575,14 +581,18 @@ udp_print(register const u_char *bp, u_i
- 			ns_print((const u_char *)(up + 1), length, 0);
- 		else if (ISPORT(MULTICASTDNS_PORT))
- 			ns_print((const u_char *)(up + 1), length, 1);
-+#ifndef TCPDUMP_MINI
- 		else if (ISPORT(TIMED_PORT))
- 			timed_print((const u_char *)(up + 1));
-+#endif
- 		else if (ISPORT(TFTP_PORT))
- 			tftp_print((const u_char *)(up + 1), length);
- 		else if (ISPORT(IPPORT_BOOTPC) || ISPORT(IPPORT_BOOTPS))
- 			bootp_print((const u_char *)(up + 1), length);
-+#ifndef TCPDUMP_MINI
- 		else if (ISPORT(RIP_PORT))
- 			rip_print((const u_char *)(up + 1), length);
-+#endif
- 		else if (ISPORT(AODV_PORT))
- 			aodv_print((const u_char *)(up + 1), length,
- #ifdef INET6
-@@ -590,6 +600,7 @@ udp_print(register const u_char *bp, u_i
- #else
- 			    0);
- #endif
-+#ifndef TCPDUMP_MINI
- 	        else if (ISPORT(ISAKMP_PORT))
- 			 isakmp_print(gndo, (const u_char *)(up + 1), length, bp2);
-   	        else if (ISPORT(ISAKMP_PORT_NATT))
-@@ -598,12 +609,15 @@ udp_print(register const u_char *bp, u_i
-    	        else if (ISPORT(ISAKMP_PORT_USER1) || ISPORT(ISAKMP_PORT_USER2))
- 			isakmp_print(gndo, (const u_char *)(up + 1), length, bp2);
- #endif
-+#endif
- 		else if (ISPORT(SNMP_PORT) || ISPORT(SNMPTRAP_PORT))
- 			snmp_print((const u_char *)(up + 1), length);
- 		else if (ISPORT(NTP_PORT))
- 			ntp_print((const u_char *)(up + 1), length);
-+#ifndef TCPDUMP_MINI
- 		else if (ISPORT(KERBEROS_PORT) || ISPORT(KERBEROS_SEC_PORT))
- 			krb_print((const void *)(up + 1));
-+#endif
- 		else if (ISPORT(L2TP_PORT))
- 			l2tp_print((const u_char *)(up + 1), length);
- #ifdef TCPDUMP_DO_SMB
-@@ -614,6 +628,7 @@ udp_print(register const u_char *bp, u_i
- #endif
- 		else if (dport == VAT_PORT)
- 			vat_print((const void *)(up + 1), up);
-+#ifndef TCPDUMP_MINI
- 		else if (ISPORT(ZEPHYR_SRV_PORT) || ISPORT(ZEPHYR_CLT_PORT))
- 			zephyr_print((const void *)(up + 1), length);
- 		/*
-@@ -624,6 +639,7 @@ udp_print(register const u_char *bp, u_i
- 			 (dport >= RX_PORT_LOW && dport <= RX_PORT_HIGH))
- 			rx_print((const void *)(up + 1), length, sport, dport,
- 				 (u_char *) ip);
-+#endif
- #ifdef INET6
- 		else if (ISPORT(RIPNG_PORT))
- 			ripng_print((const u_char *)(up + 1), length);
-@@ -635,21 +651,25 @@ udp_print(register const u_char *bp, u_i
- 		/*
- 		 * Kludge in test for whiteboard packets.
- 		 */
-+#ifndef TCPDUMP_MINI
- 		else if (dport == WB_PORT)
- 			wb_print((const void *)(up + 1), length);
- 		else if (ISPORT(CISCO_AUTORP_PORT))
- 			cisco_autorp_print((const void *)(up + 1), length);
-+#endif
- 		else if (ISPORT(RADIUS_PORT) ||
- 			 ISPORT(RADIUS_NEW_PORT) ||
- 			 ISPORT(RADIUS_ACCOUNTING_PORT) ||
- 			 ISPORT(RADIUS_NEW_ACCOUNTING_PORT) )
- 			radius_print((const u_char *)(up+1), length);
-+#ifndef TCPDUMP_MINI
- 		else if (dport == HSRP_PORT)
- 			hsrp_print((const u_char *)(up + 1), length);
- 		else if (ISPORT(LWRES_PORT))
- 			lwres_print((const u_char *)(up + 1), length);
- 		else if (ISPORT(LDP_PORT))
- 			ldp_print((const u_char *)(up + 1), length);
-+#endif
- 		else if (ISPORT(OLSR_PORT))
- 			olsr_print((const u_char *)(up + 1), length,
- #if INET6
-@@ -657,6 +677,7 @@ udp_print(register const u_char *bp, u_i
- #else
- 					0);
- #endif
-+#ifndef TCPDUMP_MINI
- 		else if (ISPORT(MPLS_LSP_PING_PORT))
- 			lspping_print((const u_char *)(up + 1), length);
- 		else if (dport == BFD_CONTROL_PORT ||
-@@ -674,14 +695,17 @@ udp_print(register const u_char *bp, u_i
-                         lwapp_control_print((const u_char *)(up + 1), length, 0);
-                 else if (ISPORT(LWAPP_DATA_PORT))
-                         lwapp_data_print((const u_char *)(up + 1), length);
-+#endif
-                 else if (ISPORT(SIP_PORT))
- 			sip_print((const u_char *)(up + 1), length);
-                 else if (ISPORT(SYSLOG_PORT))
- 			syslog_print((const u_char *)(up + 1), length);
-+#ifndef TCPDUMP_MINI
-                 else if (ISPORT(OTV_PORT))
- 			otv_print((const u_char *)(up + 1), length);
-                 else if (ISPORT(VXLAN_PORT))
- 			vxlan_print((const u_char *)(up + 1), length);
-+#endif
- 		else
- 			(void)printf("UDP, length %u",
- 			    (u_int32_t)(ulen - sizeof(*up)));
---- a/tcpdump.c
-+++ b/tcpdump.c
-@@ -161,6 +161,7 @@ struct ndo_printer {
- 
- 
- static struct printer printers[] = {
-+#ifndef TCPDUMP_MINI
- 	{ arcnet_if_print,	DLT_ARCNET },
- #ifdef DLT_ARCNET_LINUX
- 	{ arcnet_linux_if_print, DLT_ARCNET_LINUX },
-@@ -179,19 +180,23 @@ static struct printer printers[] = {
- #ifdef DLT_SLIP_BSDOS
- 	{ sl_bsdos_if_print,	DLT_SLIP_BSDOS },
- #endif
-+#endif
- 	{ ppp_if_print,		DLT_PPP },
- #ifdef DLT_PPP_WITHDIRECTION
- 	{ ppp_if_print,		DLT_PPP_WITHDIRECTION },
- #endif
-+#ifndef TCPDUMP_MINI
- #ifdef DLT_PPP_BSDOS
- 	{ ppp_bsdos_if_print,	DLT_PPP_BSDOS },
- #endif
- 	{ fddi_if_print,	DLT_FDDI },
-+#endif
- 	{ null_if_print,	DLT_NULL },
- #ifdef DLT_LOOP
- 	{ null_if_print,	DLT_LOOP },
- #endif
- 	{ raw_if_print,		DLT_RAW },
-+#ifndef TCPDUMP_MINI
- 	{ atm_if_print,		DLT_ATM_RFC1483 },
- #ifdef DLT_C_HDLC
- 	{ chdlc_if_print,	DLT_C_HDLC },
-@@ -202,6 +207,7 @@ static struct printer printers[] = {
- #ifdef DLT_PPP_SERIAL
- 	{ ppp_hdlc_if_print,	DLT_PPP_SERIAL },
- #endif
-+#endif
- #ifdef DLT_PPP_ETHER
- 	{ pppoe_if_print,	DLT_PPP_ETHER },
- #endif
-@@ -211,6 +217,7 @@ static struct printer printers[] = {
- #ifdef DLT_IEEE802_11
- 	{ ieee802_11_if_print,	DLT_IEEE802_11},
- #endif
-+#ifndef TCPDUMP_MINI
- #ifdef DLT_LTALK
- 	{ ltalk_if_print,	DLT_LTALK },
- #endif
-@@ -229,12 +236,14 @@ static struct printer printers[] = {
- #ifdef DLT_IP_OVER_FC
- 	{ ipfc_if_print,	DLT_IP_OVER_FC },
- #endif
-+#endif
- #ifdef DLT_PRISM_HEADER
- 	{ prism_if_print,	DLT_PRISM_HEADER },
- #endif
- #ifdef DLT_IEEE802_11_RADIO
- 	{ ieee802_11_radio_if_print,	DLT_IEEE802_11_RADIO },
- #endif
-+#ifndef TCPDUMP_MINI
- #ifdef DLT_ENC
- 	{ enc_if_print,		DLT_ENC },
- #endif
-@@ -244,9 +253,11 @@ static struct printer printers[] = {
- #ifdef DLT_APPLE_IP_OVER_IEEE1394
- 	{ ap1394_if_print,	DLT_APPLE_IP_OVER_IEEE1394 },
- #endif
-+#endif
- #ifdef DLT_IEEE802_11_RADIO_AVS
- 	{ ieee802_11_radio_avs_if_print,	DLT_IEEE802_11_RADIO_AVS },
- #endif
-+#ifndef TCPDUMP_MINI
- #ifdef DLT_JUNIPER_ATM1
- 	{ juniper_atm1_print,	DLT_JUNIPER_ATM1 },
- #endif
-@@ -312,6 +323,7 @@ static struct printer printers[] = {
- #ifdef DLT_IPV6
- 	{ raw_if_print,		DLT_IPV6 },
- #endif
-+#endif
- 	{ NULL,			0 },
- };
- 
-@@ -320,6 +332,7 @@ static struct ndo_printer ndo_printers[]
+--- a/print.c
++++ b/print.c
+@@ -48,6 +48,7 @@ static const struct printer printers[] =
  #ifdef DLT_IPNET
  	{ ipnet_if_print,	DLT_IPNET },
  #endif
@@ -804,7 +157,7 @@
  #ifdef DLT_IEEE802_15_4
  	{ ieee802_15_4_if_print, DLT_IEEE802_15_4 },
  #endif
-@@ -329,15 +342,18 @@ static struct ndo_printer ndo_printers[]
+@@ -57,12 +58,14 @@ static const struct printer printers[] =
  #ifdef DLT_PPI
  	{ ppi_if_print,		DLT_PPI },
  #endif
@@ -816,29 +169,706 @@
  	{ netanalyzer_transparent_if_print, DLT_NETANALYZER_TRANSPARENT },
  #endif
 +#ifndef TCPDUMP_MINI
- #ifdef DLT_NFLOG
+ #if defined(DLT_NFLOG) && defined(HAVE_PCAP_NFLOG_H)
  	{ nflog_if_print,	DLT_NFLOG},
+ #endif
+@@ -75,10 +78,12 @@ static const struct printer printers[] =
+ #ifdef DLT_IP_OVER_FC
+ 	{ ipfc_if_print,	DLT_IP_OVER_FC },
+ #endif
++#endif
+ 	{ null_if_print,	DLT_NULL },
+ #ifdef DLT_LOOP
+ 	{ null_if_print,	DLT_LOOP },
+ #endif
++#ifndef TCPDUMP_MINI
+ #ifdef DLT_APPLE_IP_OVER_IEEE1394
+ 	{ ap1394_if_print,	DLT_APPLE_IP_OVER_IEEE1394 },
+ #endif
+@@ -92,7 +97,9 @@ static const struct printer printers[] =
+ #ifdef DLT_ARCNET_LINUX
+ 	{ arcnet_linux_if_print, DLT_ARCNET_LINUX },
+ #endif
++#endif
+ 	{ raw_if_print,		DLT_RAW },
++#ifndef TCPDUMP_MINI
+ #ifdef DLT_IPV4
+ 	{ raw_if_print,		DLT_IPV4 },
+ #endif
+@@ -116,17 +123,21 @@ static const struct printer printers[] =
+ #ifdef DLT_HDLC
+ 	{ chdlc_if_print,	DLT_HDLC },
+ #endif
++#endif
+ #ifdef DLT_PPP_ETHER
+ 	{ pppoe_if_print,	DLT_PPP_ETHER },
+ #endif
++#ifndef TCPDUMP_MINI
+ #if defined(DLT_PFLOG) && defined(HAVE_NET_IF_PFLOG_H)
+ 	{ pflog_if_print,	DLT_PFLOG },
+ #endif
+ 	{ token_if_print,	DLT_IEEE802 },
+ 	{ fddi_if_print,	DLT_FDDI },
++#endif
+ #ifdef DLT_LINUX_SLL
+ 	{ sll_if_print,		DLT_LINUX_SLL },
+ #endif
++#ifndef TCPDUMP_MINI
+ #ifdef DLT_FR
+ 	{ fr_if_print,		DLT_FR },
+ #endif
+@@ -198,6 +209,7 @@ static const struct printer printers[] =
+ #ifdef DLT_PKTAP
+ 	{ pktap_if_print,	DLT_PKTAP },
+ #endif
++#endif
+ #ifdef DLT_IEEE802_11_RADIO
+ 	{ ieee802_11_radio_if_print,	DLT_IEEE802_11_RADIO },
+ #endif
+@@ -214,12 +226,14 @@ static const struct printer printers[] =
+ #ifdef DLT_PPP_WITHDIRECTION
+ 	{ ppp_if_print,		DLT_PPP_WITHDIRECTION },
+ #endif
++#ifndef TCPDUMP_MINI
+ #ifdef DLT_PPP_BSDOS
+ 	{ ppp_bsdos_if_print,	DLT_PPP_BSDOS },
+ #endif
+ #ifdef DLT_PPP_SERIAL
+ 	{ ppp_hdlc_if_print,	DLT_PPP_SERIAL },
  #endif
 +#endif
  	{ NULL,			0 },
  };
  
+--- a/print-ether.c
++++ b/print-ether.c
+@@ -332,6 +332,7 @@ ethertype_print(netdissect_options *ndo,
+ 	        arp_print(ndo, p, length, caplen);
+ 		return (1);
+ 
++#ifndef TCPDUMP_MINI
+ 	case ETHERTYPE_DN:
+ 		decnet_print(ndo, p, length, caplen);
+ 		return (1);
+@@ -354,6 +355,7 @@ ethertype_print(netdissect_options *ndo,
+ 	case ETHERTYPE_ISO:
+ 		isoclns_print(ndo, p + 1, length - 1, length - 1);
+ 		return(1);
++#endif
+ 
+ 	case ETHERTYPE_PPPOED:
+ 	case ETHERTYPE_PPPOES:
+@@ -366,9 +368,11 @@ ethertype_print(netdissect_options *ndo,
+ 	        eap_print(ndo, p, length);
+ 		return (1);
+ 
++#ifndef TCPDUMP_MINI
+ 	case ETHERTYPE_RRCP:
+ 	        rrcp_print(ndo, p - 14 , length + 14);
+ 		return (1);
++#endif
+ 
+ 	case ETHERTYPE_PPP:
+ 		if (length) {
+@@ -377,6 +381,7 @@ ethertype_print(netdissect_options *ndo,
+ 		}
+ 		return (1);
+ 
++#ifndef TCPDUMP_MINI
+ 	case ETHERTYPE_MPCP:
+ 	        mpcp_print(ndo, p, length);
+ 		return (1);
+@@ -389,6 +394,7 @@ ethertype_print(netdissect_options *ndo,
+ 	case ETHERTYPE_CFM_OLD:
+ 		cfm_print(ndo, p, length);
+ 		return (1);
++#endif
+ 
+ 	case ETHERTYPE_LLDP:
+ 		lldp_print(ndo, p, length);
+@@ -398,6 +404,7 @@ ethertype_print(netdissect_options *ndo,
+ 		loopback_print(ndo, p, length);
+                 return (1);
+ 
++#ifndef TCPDUMP_MINI
+ 	case ETHERTYPE_MPLS:
+ 	case ETHERTYPE_MPLS_MULTI:
+ 		mpls_print(ndo, p, length);
+@@ -427,6 +434,7 @@ ethertype_print(netdissect_options *ndo,
+ 	case ETHERTYPE_MEDSA:
+ 		medsa_print(ndo, p, length, caplen);
+ 		return (1);
++#endif
+ 
+ 	case ETHERTYPE_LAT:
+ 	case ETHERTYPE_SCA:
+--- a/print-gre.c
++++ b/print-gre.c
+@@ -203,6 +203,7 @@ gre_print_0(netdissect_options *ndo, con
+ 	case ETHERTYPE_IPV6:
+ 		ip6_print(ndo, bp, len);
+ 		break;
++#ifndef TCPDUMP_MINI
+ 	case ETHERTYPE_MPLS:
+ 		mpls_print(ndo, bp, len);
+ 		break;
+@@ -218,6 +219,7 @@ gre_print_0(netdissect_options *ndo, con
+ 	case ETHERTYPE_TEB:
+ 		ether_print(ndo, bp, len, len, NULL, NULL);
+ 		break;
++#endif
+ 	default:
+ 		ND_PRINT((ndo, "gre-proto-0x%x", prot));
+ 	}
+--- a/print-igmp.c
++++ b/print-igmp.c
+@@ -304,6 +304,7 @@ igmp_print(netdissect_options *ndo,
+         ND_TCHECK2(bp[4], 4);
+         ND_PRINT((ndo, "igmp leave %s", ipaddr_string(ndo, &bp[4])));
+         break;
++#ifndef TCPDUMP_MINI
+     case 0x13:
+         ND_PRINT((ndo, "igmp dvmrp"));
+         if (len < 8)
+@@ -315,6 +316,7 @@ igmp_print(netdissect_options *ndo,
+         ND_PRINT((ndo, "igmp pimv1"));
+         pimv1_print(ndo, bp, len);
+         break;
++#endif
+     case 0x1e:
+         print_mresp(ndo, bp, len);
+         break;
+--- a/print-ip6.c
++++ b/print-ip6.c
+@@ -297,6 +297,7 @@ ip6_print(netdissect_options *ndo, const
+ 			advance = dstopt_print(ndo, cp);
+ 			nh = *cp;
+ 			break;
++#ifndef TCPDUMP_MINI
+ 		case IPPROTO_FRAGMENT:
+ 			advance = frag6_print(ndo, cp, (const u_char *)ip6);
+ 			if (ndo->ndo_snapend <= cp + advance)
+@@ -318,6 +319,7 @@ ip6_print(netdissect_options *ndo, const
+ 			advance = mobility_print(ndo, cp, (const u_char *)ip6);
+ 			nh = *cp;
+ 			return;
++#endif
+ 		case IPPROTO_ROUTING:
+ 			advance = rt6_print(ndo, cp, (const u_char *)ip6);
+ 			nh = *cp;
+@@ -325,9 +327,11 @@ ip6_print(netdissect_options *ndo, const
+ 		case IPPROTO_SCTP:
+ 			sctp_print(ndo, cp, (const u_char *)ip6, len);
+ 			return;
++#ifndef TCPDUMP_MINI
+ 		case IPPROTO_DCCP:
+ 			dccp_print(ndo, cp, (const u_char *)ip6, len);
+ 			return;
++#endif
+ 		case IPPROTO_TCP:
+ 			tcp_print(ndo, cp, len, (const u_char *)ip6, fragmented);
+ 			return;
+@@ -337,6 +341,7 @@ ip6_print(netdissect_options *ndo, const
+ 		case IPPROTO_ICMPV6:
+ 			icmp6_print(ndo, cp, len, (const u_char *)ip6, fragmented);
+ 			return;
++#ifndef TCPDUMP_MINI
+ 		case IPPROTO_AH:
+ 			advance = ah_print(ndo, cp);
+ 			nh = *cp;
+@@ -360,6 +365,7 @@ ip6_print(netdissect_options *ndo, const
+ 		case IPPROTO_PIM:
+ 			pim_print(ndo, cp, len, (const u_char *)ip6);
+ 			return;
++#endif
+ 
+ 		case IPPROTO_OSPF:
+ 			ospf6_print(ndo, cp, len);
+@@ -373,9 +379,11 @@ ip6_print(netdissect_options *ndo, const
+ 		        ip_print(ndo, cp, len);
+ 			return;
+ 
++#ifndef TCPDUMP_MINI
+                 case IPPROTO_PGM:
+                         pgm_print(ndo, cp, len, (const u_char *)ip6);
+                         return;
++#endif
+ 
+ 		case IPPROTO_GRE:
+ 			gre_print(ndo, cp, len);
+--- a/print-ip.c
++++ b/print-ip.c
+@@ -327,6 +327,7 @@ ip_print_demux(netdissect_options *ndo,
+ again:
+ 	switch (ipds->nh) {
+ 
++#ifndef TCPDUMP_MINI
+ 	case IPPROTO_AH:
+ 		ipds->nh = *ipds->cp;
+ 		ipds->advance = ah_print(ndo, ipds->cp);
+@@ -361,14 +362,17 @@ again:
+ 		ipds->nh = enh & 0xff;
+ 		goto again;
+ 	}
++#endif
+ 
+ 	case IPPROTO_SCTP:
+ 		sctp_print(ndo, ipds->cp, (const u_char *)ipds->ip, ipds->len);
+ 		break;
+ 
++#ifndef TCPDUMP_MINI
+ 	case IPPROTO_DCCP:
+ 		dccp_print(ndo, ipds->cp, (const u_char *)ipds->ip, ipds->len);
+ 		break;
++#endif
+ 
+ 	case IPPROTO_TCP:
+ 		/* pass on the MF bit plus the offset to detect fragments */
+@@ -388,6 +392,7 @@ again:
+ 			   ipds->off & (IP_MF|IP_OFFMASK));
+ 		break;
+ 
++#ifndef TCPDUMP_MINI
+ 	case IPPROTO_PIGP:
+ 		/*
+ 		 * XXX - the current IANA protocol number assignments
+@@ -408,14 +413,17 @@ again:
+ 	case IPPROTO_EIGRP:
+ 		eigrp_print(ndo, ipds->cp, ipds->len);
+ 		break;
++#endif
+ 
+ 	case IPPROTO_ND:
+ 		ND_PRINT((ndo, " nd %d", ipds->len));
+ 		break;
+ 
++#ifndef TCPDUMP_MINI
+ 	case IPPROTO_EGP:
+ 		egp_print(ndo, ipds->cp, ipds->len);
+ 		break;
++#endif
+ 
+ 	case IPPROTO_OSPF:
+ 		ospf_print(ndo, ipds->cp, ipds->len, (const u_char *)ipds->ip);
+@@ -448,6 +456,7 @@ again:
+ 		gre_print(ndo, ipds->cp, ipds->len);
+ 		break;
+ 
++#ifndef TCPDUMP_MINI
+ 	case IPPROTO_MOBILE:
+ 		mobile_print(ndo, ipds->cp, ipds->len);
+ 		break;
+@@ -476,6 +485,7 @@ again:
+ 	case IPPROTO_PGM:
+ 		pgm_print(ndo, ipds->cp, ipds->len, (const u_char *)ipds->ip);
+ 		break;
++#endif
+ 
+ 	default:
+ 		if (ndo->ndo_nflag==0 && (proto = getprotobynumber(ipds->nh)) != NULL)
+--- a/print-llc.c
++++ b/print-llc.c
+@@ -204,6 +204,7 @@ llc_print(netdissect_options *ndo, const
+ 		hdrlen = 4;	/* DSAP, SSAP, 2-byte control field */
+ 	}
+ 
++#ifndef TCPDUMP_MINI
+ 	if (ssap_field == LLCSAP_GLOBAL && dsap_field == LLCSAP_GLOBAL) {
+ 		/*
+ 		 * This is an Ethernet_802.3 IPX frame; it has an
+@@ -226,6 +227,7 @@ llc_print(netdissect_options *ndo, const
+             ipx_print(ndo, p, length);
+             return (0);		/* no LLC header */
+ 	}
++#endif
+ 
+ 	dsap = dsap_field & ~LLC_IG;
+ 	ssap = ssap_field & ~LLC_GSAP;
+@@ -289,6 +291,7 @@ llc_print(netdissect_options *ndo, const
+ 		return (hdrlen);
+ 	}
+ 
++#ifndef TCPDUMP_MINI
+ 	if (ssap == LLCSAP_IPX && dsap == LLCSAP_IPX &&
+ 	    control == LLC_UI) {
+ 		/*
+@@ -302,6 +305,7 @@ llc_print(netdissect_options *ndo, const
+ 		ipx_print(ndo, p, length);
+ 		return (hdrlen);
+ 	}
++#endif
+ 
+ #ifdef ENABLE_SMB
+ 	if (ssap == LLCSAP_NETBEUI && dsap == LLCSAP_NETBEUI
+@@ -320,11 +324,13 @@ llc_print(netdissect_options *ndo, const
+ 		return (hdrlen);
+ 	}
+ #endif
++#ifndef TCPDUMP_MINI
+ 	if (ssap == LLCSAP_ISONS && dsap == LLCSAP_ISONS
+ 	    && control == LLC_UI) {
+ 		isoclns_print(ndo, p, length, caplen);
+ 		return (hdrlen);
+ 	}
++#endif
+ 
+ 	if (!ndo->ndo_eflag) {
+ 		if (ssap == dsap) {
+@@ -461,6 +467,7 @@ snap_print(netdissect_options *ndo, cons
+                 case PID_CISCO_CDP:
+                         cdp_print(ndo, p, length, caplen);
+                         return (1);
++#ifndef TCPDUMP_MINI
+                 case PID_CISCO_DTP:
+                         dtp_print(ndo, p, length);
+                         return (1);
+@@ -470,6 +477,7 @@ snap_print(netdissect_options *ndo, cons
+                 case PID_CISCO_VTP:
+                         vtp_print(ndo, p, length);
+                         return (1);
++#endif
+                 case PID_CISCO_PVST:
+                 case PID_CISCO_VLANBRIDGE:
+                         stp_print(ndo, p, length);
+@@ -482,6 +490,7 @@ snap_print(netdissect_options *ndo, cons
+ 	case OUI_RFC2684:
+ 		switch (et) {
+ 
++#ifndef TCPDUMP_MINI
+ 		case PID_RFC2684_ETH_FCS:
+ 		case PID_RFC2684_ETH_NOFCS:
+ 			/*
+@@ -543,6 +552,7 @@ snap_print(netdissect_options *ndo, cons
+ 			 */
+ 			fddi_print(ndo, p, length, caplen);
+ 			return (1);
++#endif
+ 
+ 		case PID_RFC2684_BPDU:
+ 			stp_print(ndo, p, length);
+--- a/print-null.c
++++ b/print-null.c
+@@ -114,6 +114,7 @@ null_if_print(netdissect_options *ndo, c
+ 		ip6_print(ndo, p, length);
+ 		break;
+ 
++#ifndef TCPDUMP_MINI
+ 	case BSD_AFNUM_ISO:
+ 		isoclns_print(ndo, p, length, caplen);
+ 		break;
+@@ -125,6 +126,7 @@ null_if_print(netdissect_options *ndo, c
+ 	case BSD_AFNUM_IPX:
+ 		ipx_print(ndo, p, length);
+ 		break;
++#endif
+ 
+ 	default:
+ 		/* unknown AF_ value */
+--- a/print-ppp.c
++++ b/print-ppp.c
+@@ -1346,6 +1346,7 @@ trunc:
+ 	return 0;
+ }
+ 
++#ifndef TCPDUMP_MINI
+ static void
+ ppp_hdlc(netdissect_options *ndo,
+          const u_char *p, int length)
+@@ -1424,6 +1425,7 @@ trunc:
+ 	free(b);
+ 	ND_PRINT((ndo, "[|ppp]"));
+ }
++#endif
+ 
+ 
+ /* PPP */
+@@ -1431,10 +1433,12 @@ static void
+ handle_ppp(netdissect_options *ndo,
+            u_int proto, const u_char *p, int length)
+ {
++#ifndef TCPDUMP_MINI
+ 	if ((proto & 0xff00) == 0x7e00) { /* is this an escape code ? */
+ 		ppp_hdlc(ndo, p - 1, length);
+ 		return;
+ 	}
++#endif
+ 
+ 	switch (proto) {
+ 	case PPP_LCP: /* fall through */
+@@ -1467,6 +1471,7 @@ handle_ppp(netdissect_options *ndo,
+ 	case PPP_IPV6:
+ 		ip6_print(ndo, p, length);
+ 		break;
++#ifndef TCPDUMP_MINI
+ 	case ETHERTYPE_IPX:	/*XXX*/
+ 	case PPP_IPX:
+ 		ipx_print(ndo, p, length);
+@@ -1478,6 +1483,7 @@ handle_ppp(netdissect_options *ndo,
+ 	case PPP_MPLS_MCAST:
+ 		mpls_print(ndo, p, length);
+ 		break;
++#endif
+ 	case PPP_COMP:
+ 		ND_PRINT((ndo, "compressed PPP data"));
+ 		break;
+@@ -1618,6 +1624,7 @@ ppp_if_print(netdissect_options *ndo,
+ 	return (0);
+ }
+ 
++#ifndef TCPDUMP_MINI
+ /*
+  * PPP I/F printer to use if we know that RFC 1662-style PPP in HDLC-like
+  * framing, or Cisco PPP with HDLC framing as per section 4.3.1 of RFC 1547,
+@@ -1840,6 +1847,7 @@ printx:
+ #endif /* __bsdi__ */
+ 	return (hdrlength);
+ }
++#endif
+ 
+ 
+ /*
 --- a/print-sll.c
 +++ b/print-sll.c
-@@ -154,14 +154,14 @@ recurse:
- 		 * Yes - what type is it?
+@@ -236,12 +236,14 @@ recurse:
  		 */
  		switch (ether_type) {
--
+ 
 +#ifndef TCPDUMP_MINI
  		case LINUX_SLL_P_802_3:
  			/*
  			 * Ethernet_802.3 IPX frame.
  			 */
- 			ipx_print(p, length);
+ 			ipx_print(ndo, p, length);
  			break;
--
 +#endif
+ 
  		case LINUX_SLL_P_802_2:
  			/*
- 			 * 802.2.
+--- a/print-tcp.c
++++ b/print-tcp.c
+@@ -565,12 +565,14 @@ tcp_print(netdissect_options *ndo,
+                                 ND_PRINT((ndo, " %u", utoval));
+                                 break;
+ 
++#ifndef TCPDUMP_MINI
+                         case TCPOPT_MPTCP:
+                                 datalen = len - 2;
+                                 LENCHECK(datalen);
+                                 if (!mptcp_print(ndo, cp-2, len, flags))
+                                         goto bad;
+                                 break;
++#endif
+ 
+                         case TCPOPT_FASTOPEN:
+                                 datalen = len - 2;
+@@ -645,6 +647,7 @@ tcp_print(netdissect_options *ndo,
+                 return;
+         }
+ 
++#ifndef TCPDUMP_MINI
+         if (ndo->ndo_packettype) {
+                 switch (ndo->ndo_packettype) {
+                 case PT_ZMTP1:
+@@ -656,6 +659,7 @@ tcp_print(netdissect_options *ndo,
+                 }
+                 return;
+         }
++#endif
+ 
+         if (IS_SRC_OR_DST_PORT(TELNET_PORT)) {
+                 telnet_print(ndo, bp, length);
+@@ -666,18 +670,22 @@ tcp_print(netdissect_options *ndo,
+                 bgp_print(ndo, bp, length);
+         else if (IS_SRC_OR_DST_PORT(PPTP_PORT))
+                 pptp_print(ndo, bp);
++#ifndef TCPDUMP_MINI
+         else if (IS_SRC_OR_DST_PORT(REDIS_PORT))
+                 resp_print(ndo, bp, length);
++#endif
+ #ifdef ENABLE_SMB
+         else if (IS_SRC_OR_DST_PORT(NETBIOS_SSN_PORT))
+                 nbt_tcp_print(ndo, bp, length);
+ 	else if (IS_SRC_OR_DST_PORT(SMB_PORT))
+ 		smb_tcp_print(ndo, bp, length);
+ #endif
++#ifndef TCPDUMP_MINI
+         else if (IS_SRC_OR_DST_PORT(BEEP_PORT))
+                 beep_print(ndo, bp, length);
+         else if (IS_SRC_OR_DST_PORT(OPENFLOW_PORT_OLD) || IS_SRC_OR_DST_PORT(OPENFLOW_PORT_IANA))
+                 openflow_print(ndo, bp, length);
++#endif
+         else if (IS_SRC_OR_DST_PORT(FTP_PORT)) {
+                 ND_PRINT((ndo, ": "));
+                 ftp_print(ndo, bp, length);
+@@ -694,6 +702,7 @@ tcp_print(netdissect_options *ndo,
+                  * XXX packet could be unaligned, it can go strange
+                  */
+                 ns_print(ndo, bp + 2, length - 2, 0);
++#ifndef TCPDUMP_MINI
+         } else if (IS_SRC_OR_DST_PORT(MSDP_PORT)) {
+                 msdp_print(ndo, bp, length);
+         } else if (IS_SRC_OR_DST_PORT(RPKI_RTR_PORT)) {
+@@ -701,6 +710,7 @@ tcp_print(netdissect_options *ndo,
+         }
+         else if (length > 0 && (IS_SRC_OR_DST_PORT(LDP_PORT))) {
+                 ldp_print(ndo, bp, length);
++#endif
+         }
+         else if ((IS_SRC_OR_DST_PORT(NFS_PORT)) &&
+                  length >= 4 && ND_TTEST2(*bp, 4)) {
+--- a/print-udp.c
++++ b/print-udp.c
+@@ -397,10 +397,12 @@ udp_print(netdissect_options *ndo, regis
+ 			vat_print(ndo, (const void *)(up + 1), up);
+ 			break;
+ 
++#ifndef TCPDUMP_MINI
+ 		case PT_WB:
+ 			udpipaddr_print(ndo, ip, sport, dport);
+ 			wb_print(ndo, (const void *)(up + 1), length);
+ 			break;
++#endif
+ 
+ 		case PT_RPC:
+ 			rp = (const struct sunrpc_msg *)(up + 1);
+@@ -429,10 +431,12 @@ udp_print(netdissect_options *ndo, regis
+ 			snmp_print(ndo, (const u_char *)(up + 1), length);
+ 			break;
+ 
++#ifndef TCPDUMP_MINI
+ 		case PT_CNFP:
+ 			udpipaddr_print(ndo, ip, sport, dport);
+ 			cnfp_print(ndo, cp);
+ 			break;
++#endif
+ 
+ 		case PT_TFTP:
+ 			udpipaddr_print(ndo, ip, sport, dport);
+@@ -450,6 +454,7 @@ udp_print(netdissect_options *ndo, regis
+ 			radius_print(ndo, cp, length);
+ 			break;
+ 
++#ifndef TCPDUMP_MINI
+ 		case PT_VXLAN:
+ 			udpipaddr_print(ndo, ip, sport, dport);
+ 			vxlan_print(ndo, (const u_char *)(up + 1), length);
+@@ -464,6 +469,7 @@ udp_print(netdissect_options *ndo, regis
+ 			udpipaddr_print(ndo, ip, sport, dport);
+ 			lmp_print(ndo, cp, length);
+ 			break;
++#endif
+ 		}
+ 		return;
+ 	}
+@@ -541,31 +547,40 @@ udp_print(netdissect_options *ndo, regis
+ 			ns_print(ndo, (const u_char *)(up + 1), length, 0);
+ 		else if (IS_SRC_OR_DST_PORT(MULTICASTDNS_PORT))
+ 			ns_print(ndo, (const u_char *)(up + 1), length, 1);
++#ifndef TCPDUMP_MINI
+ 		else if (IS_SRC_OR_DST_PORT(TIMED_PORT))
+ 			timed_print(ndo, (const u_char *)(up + 1));
++#endif
+ 		else if (IS_SRC_OR_DST_PORT(TFTP_PORT))
+ 			tftp_print(ndo, (const u_char *)(up + 1), length);
+ 		else if (IS_SRC_OR_DST_PORT(BOOTPC_PORT) || IS_SRC_OR_DST_PORT(BOOTPS_PORT))
+ 			bootp_print(ndo, (const u_char *)(up + 1), length);
++#ifndef TCPDUMP_MINI
+ 		else if (IS_SRC_OR_DST_PORT(RIP_PORT))
+ 			rip_print(ndo, (const u_char *)(up + 1), length);
++#endif
+ 		else if (IS_SRC_OR_DST_PORT(AODV_PORT))
+ 			aodv_print(ndo, (const u_char *)(up + 1), length,
+ 			    ip6 != NULL);
++#ifndef TCPDUMP_MINI
+ 	        else if (IS_SRC_OR_DST_PORT(ISAKMP_PORT))
+ 			 isakmp_print(ndo, (const u_char *)(up + 1), length, bp2);
++
+ 	        else if (IS_SRC_OR_DST_PORT(ISAKMP_PORT_NATT))
+ 			 isakmp_rfc3948_print(ndo, (const u_char *)(up + 1), length, bp2);
+ #if 1 /*???*/
+ 	        else if (IS_SRC_OR_DST_PORT(ISAKMP_PORT_USER1) || IS_SRC_OR_DST_PORT(ISAKMP_PORT_USER2))
+ 			isakmp_print(ndo, (const u_char *)(up + 1), length, bp2);
+ #endif
++#endif
+ 		else if (IS_SRC_OR_DST_PORT(SNMP_PORT) || IS_SRC_OR_DST_PORT(SNMPTRAP_PORT))
+ 			snmp_print(ndo, (const u_char *)(up + 1), length);
+ 		else if (IS_SRC_OR_DST_PORT(NTP_PORT))
+ 			ntp_print(ndo, (const u_char *)(up + 1), length);
++#ifndef TCPDUMP_MINI
+ 		else if (IS_SRC_OR_DST_PORT(KERBEROS_PORT) || IS_SRC_OR_DST_PORT(KERBEROS_SEC_PORT))
+ 			krb_print(ndo, (const void *)(up + 1));
++#endif
+ 		else if (IS_SRC_OR_DST_PORT(L2TP_PORT))
+ 			l2tp_print(ndo, (const u_char *)(up + 1), length);
+ #ifdef ENABLE_SMB
+@@ -576,6 +591,7 @@ udp_print(netdissect_options *ndo, regis
+ #endif
+ 		else if (dport == VAT_PORT)
+ 			vat_print(ndo, (const void *)(up + 1), up);
++#ifndef TCPDUMP_MINI
+ 		else if (IS_SRC_OR_DST_PORT(ZEPHYR_SRV_PORT) || IS_SRC_OR_DST_PORT(ZEPHYR_CLT_PORT))
+ 			zephyr_print(ndo, (const void *)(up + 1), length);
+ 		/*
+@@ -588,8 +604,11 @@ udp_print(netdissect_options *ndo, regis
+ 				 (const u_char *) ip);
+ 		else if (IS_SRC_OR_DST_PORT(RIPNG_PORT))
+ 			ripng_print(ndo, (const u_char *)(up + 1), length);
++#endif
++
+ 		else if (IS_SRC_OR_DST_PORT(DHCP6_SERV_PORT) || IS_SRC_OR_DST_PORT(DHCP6_CLI_PORT))
+ 			dhcp6_print(ndo, (const u_char *)(up + 1), length);
++#ifndef TCPDUMP_MINI
+ 		else if (IS_SRC_OR_DST_PORT(AHCP_PORT))
+ 			ahcp_print(ndo, (const u_char *)(up + 1), length);
+ 		else if (IS_SRC_OR_DST_PORT(BABEL_PORT) || IS_SRC_OR_DST_PORT(BABEL_PORT_OLD))
+@@ -603,6 +622,7 @@ udp_print(netdissect_options *ndo, regis
+ 			wb_print(ndo, (const void *)(up + 1), length);
+ 		else if (IS_SRC_OR_DST_PORT(CISCO_AUTORP_PORT))
+ 			cisco_autorp_print(ndo, (const void *)(up + 1), length);
++#endif
+ 		else if (IS_SRC_OR_DST_PORT(RADIUS_PORT) ||
+ 			 IS_SRC_OR_DST_PORT(RADIUS_NEW_PORT) ||
+ 			 IS_SRC_OR_DST_PORT(RADIUS_ACCOUNTING_PORT) ||
+@@ -610,15 +630,18 @@ udp_print(netdissect_options *ndo, regis
+ 			 IS_SRC_OR_DST_PORT(RADIUS_CISCO_COA_PORT) ||
+ 			 IS_SRC_OR_DST_PORT(RADIUS_COA_PORT) )
+ 			radius_print(ndo, (const u_char *)(up+1), length);
++#ifndef TCPDUMP_MINI
+ 		else if (dport == HSRP_PORT)
+ 			hsrp_print(ndo, (const u_char *)(up + 1), length);
+ 		else if (IS_SRC_OR_DST_PORT(LWRES_PORT))
+ 			lwres_print(ndo, (const u_char *)(up + 1), length);
+ 		else if (IS_SRC_OR_DST_PORT(LDP_PORT))
+ 			ldp_print(ndo, (const u_char *)(up + 1), length);
++#endif
+ 		else if (IS_SRC_OR_DST_PORT(OLSR_PORT))
+ 			olsr_print(ndo, (const u_char *)(up + 1), length,
+ 					(IP_V(ip) == 6) ? 1 : 0);
++#ifndef TCPDUMP_MINI
+ 		else if (IS_SRC_OR_DST_PORT(MPLS_LSP_PING_PORT))
+ 			lspping_print(ndo, (const u_char *)(up + 1), length);
+ 		else if (dport == BFD_CONTROL_PORT ||
+@@ -636,10 +659,12 @@ udp_print(netdissect_options *ndo, regis
+                         lwapp_control_print(ndo, (const u_char *)(up + 1), length, 0);
+                 else if (IS_SRC_OR_DST_PORT(LWAPP_DATA_PORT))
+                         lwapp_data_print(ndo, (const u_char *)(up + 1), length);
++#endif
+                 else if (IS_SRC_OR_DST_PORT(SIP_PORT))
+ 			sip_print(ndo, (const u_char *)(up + 1), length);
+                 else if (IS_SRC_OR_DST_PORT(SYSLOG_PORT))
+ 			syslog_print(ndo, (const u_char *)(up + 1), length);
++#ifndef TCPDUMP_MINI
+                 else if (IS_SRC_OR_DST_PORT(OTV_PORT))
+ 			otv_print(ndo, (const u_char *)(up + 1), length);
+                 else if (IS_SRC_OR_DST_PORT(VXLAN_PORT))
+@@ -656,7 +681,9 @@ udp_print(netdissect_options *ndo, regis
+ 			if (ndo->ndo_vflag)
+ 				ND_PRINT((ndo, "kip "));
+ 			llap_print(ndo, cp, length);
+-		} else {
++		}
++#endif
++		else {
+ 			if (ulen > length)
+ 				ND_PRINT((ndo, "UDP, bad length %u > %u",
+ 				    ulen, length));


### PR DESCRIPTION
Maintainer: @nbd168 
Compile tested (full and mini): kirkwood, brcm47xx, ar71xx
Run tested (full and mini): kirkwood, brcm47xx

Description:
Update tcpdump to upstream release 4.8.1
To note:
-) Mirrors:
    ftp.gwdg.de brings a 404, therefore removed from the list
    www.br.tcpdump.org is NXDOMAIN, therefore removed from the list
-) Removing parser debug functions (patch 001):
    Parts of the debugging stuff were rewritten upstream, instead of removing
    the debug things in the source, this patch now removes these from
    the configure script, i.e. HAVE_xxx_DEBUG is not written to the confdefs.h
-) tcpdump mini (patch 100):
    Code has been re-organized, therefore additional C files are built for tcpdump mini.
    IPv6 related stuff is now also part of -mini
    -mini is about half the size of -full (48.7% - 49.7% depending on platform)