### PR TITLE
ath10k-firmware: removed broken submenu

### DIFF
--- a/package/firmware/ath10k-firmware/Makefile
+++ b/package/firmware/ath10k-firmware/Makefile
@@ -25,7 +25,6 @@ include $(INCLUDE_DIR)/package.mk
 define Package/ath10k-firmware-default
   SECTION:=firmware
   CATEGORY:=Firmware
-  SUBMENU:=$(WMENU)
   URL:=$(PKG_SOURCE_URL)
   DEPENDS:=
 endef


### PR DESCRIPTION
this package references an undefined variable for its submenu. 
Remove this NOP variable assignment.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>