### PR TITLE
dma-buf: add missing submenu

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -131,6 +131,7 @@ $(eval $(call KernelPackage,bluetooth-hci-h4p))
 
 
 define KernelPackage/dma-buf
+  SUBMENU:=$(OTHER_MENU)
   TITLE:=DMA shared buffer support
   HIDDEN:=1
   KCONFIG:=CONFIG_DMA_SHARED_BUFFER


### PR DESCRIPTION
this kernel module currently has not set submenu. 
Fix this by adding it to the "Others" submenu

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>