### PR TITLE
mikrotik: set kernel rw flag for rootfs

### DIFF
--- a/target/linux/generic/files/fs/yaffs2/yaffs_mtdif.c
+++ b/target/linux/generic/files/fs/yaffs2/yaffs_mtdif.c
@@ -259,7 +259,7 @@ struct mtd_info * yaffs_get_mtd_device(dev_t sdev)
 		return NULL;	/* This isn't an mtd device */
 
 	/* Check it's NAND */
-	if (mtd->type != MTD_NANDFLASH) {
+	if (mtd->type != MTD_NANDFLASH && mtd->type != MTD_MLCNANDFLASH) {
 		yaffs_trace(YAFFS_TRACE_ALWAYS,
 			"yaffs: MTD device is not NAND it's type %d",
 			mtd->type);

--- a/target/linux/generic/files/fs/yaffs2/yaffs_vfs.c
+++ b/target/linux/generic/files/fs/yaffs2/yaffs_vfs.c
@@ -2598,7 +2598,7 @@ static int yaffs_remount_fs(struct super_block *sb, int *flags, char *data)
 	}
 
 	/* Check it's NAND */
-	if (mtd->type != MTD_NANDFLASH) {
+	if (mtd->type != MTD_NANDFLASH && mtd->type != MTD_MLCNANDFLASH) {
 		yaffs_trace(YAFFS_TRACE_ALWAYS,
 			"MTD device is not NAND it's type %d",
 			mtd->type);


### PR DESCRIPTION
Hello,
after I flashed latest pre-built image for Mikrotik and booted it, I noticed the root filesystem was mounted as read-only. All changes made to the device therefore won't last after reboot. I'm using Mikrotik RouterBoard 450G.

Here is output:
root@lede:~# dmesg | grep yaffs
[    2.941747] yaffs: dev is 32505862 name is "mtdblock6" **ro**
[    3.072586] VFS: Mounted **root (yaffs filesystem) readonly** on device 31:6.

I checked arguments passed to the kernel and there was no explicit rw flag set. I know for sure that stable image Chaos Calmer worked without change, so maybe default values changed in newer kernel release.

After I passed the RW flag and built custom image, router works as expected:
[    2.930827] yaffs: dev is 32505862 name is "mtdblock6" **rw**
[    3.064720] VFS: Mounted **root (yaffs filesystem)** on device 31:6.

According to [this thread](https://forum.openwrt.org/viewtopic.php?id=64298) the issue affects only some devices. However I'm not able to verify this, as I have only one affected device.

Changes in my commit affect only mikrotik devices and I assume it is safe to have the flag set. If it's not acceptable for you, please let me know and I'll try to get more info on this issue.

Signed-off-by: Vladimir Zahradnik vladimir.zahradnik@gmail.com