### PR TITLE
ar71xx: Add ath10k-firmware-qca988x for DomyWifi DW33D

### DIFF
--- a/target/linux/ar71xx/image/nand.mk
+++ b/target/linux/ar71xx/image/nand.mk
@@ -15,7 +15,7 @@ TARGET_DEVICES += c-60
 
 define Device/domywifi-dw33d
   DEVICE_TITLE := DomyWifi DW33D
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-storage kmod-usb-ledtrig-usbport kmod-ath10k
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-storage kmod-usb-ledtrig-usbport kmod-ath10k ath10k-firmware-qca988x
   BOARDNAME = DW33D
   IMAGE_SIZE = 16000k
   CONSOLE = ttyS0,115200


### PR DESCRIPTION
add 5g wireless driver.
Signed-off-by: Jing Lin <mumuqz@163.com>