### PR TITLE
package/Makefile & ipkg-make-index.sh: add full package data list

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -88,7 +88,8 @@ $(curdir)/index: FORCE
 	@for d in $(PACKAGE_SUBDIRS); do ( \
 		mkdir -p $$d; \
 		cd $$d || continue; \
-		$(SCRIPT_DIR)/ipkg-make-index.sh . 2>&1 > Packages && \
+		$(SCRIPT_DIR)/ipkg-make-index.sh . 2>&1 > Packages.manifest; \
+		grep -vE '^(Maintainer|LicenseFiles|Source|Require)' Packages.manifest > Packages && \
 			gzip -9nc Packages > Packages.gz; \
 	); done
 ifdef CONFIG_SIGNED_PACKAGES

--- a/scripts/ipkg-make-index.sh
+++ b/scripts/ipkg-make-index.sh
@@ -24,7 +24,7 @@ for pkg in `find $pkg_dir -name '*.ipk' | sort`; do
 	tar -xzOf $pkg ./control.tar.gz | tar xzOf - ./control | sed -e "s/^Description:/Filename: $sed_safe_pkg\\
 Size: $file_size\\
 SHA256sum: $sha256sum\\
-Description:/" | grep -vE '^(Maintainer|LicenseFiles|Source|Require)'
+Description:/"
 	echo ""
 done
 [ -n "$empty" ] && echo


### PR DESCRIPTION
The external script used to generate the package lists for the
LEDE wiki's table of packages [1] and package indexes [2] requires
a "Source:" field in the package lists to find package makefiles.
The package makefiles are used to read the package's Category and Submenu.

The "Source:" field was removed in commit
b4aa3c899cbf1f81cd8a1ea197481ac84a9d646e
to reduce package list sizes and lessen opkg issues in low ram devices.

Add a separate package list file with full data to be used by the wiki's script.
It's called Packages.manifest and isn't compressed as it's not necessary.

1. https://lede-project.org/packages/start
2. https://lede-project.org/packages/index/start

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>