### PR TITLE
ath10k-ct: Enable DFS when "Enable DFS support" is set for kmod-ath

### DIFF
--- a/package/kernel/ath10k-ct/Makefile
+++ b/package/kernel/ath10k-ct/Makefile
@@ -61,6 +61,10 @@ ifdef CONFIG_PACKAGE_ATH_DEBUG
   NOSTDINC_FLAGS += -DCONFIG_ATH10K_DEBUG
 endif
 
+ifdef CONFIG_PACKAGE_ATH_DFS
+  NOSTDINC_FLAGS += -DCONFIG_ATH10K_DFS_CERTIFIED
+endif
+
 define Build/Configure
 	cp $(STAGING_DIR)/usr/include/mac80211/ath/*.h $(PKG_BUILD_DIR)
 endef


### PR DESCRIPTION
This allows users of this package to configure DFS channels.
It mimics the behaviour of the ath10k module included in
package mac80211

Signed-off-by: Andy Strohman <andrew@andrewstrohman.com>