### PR TITLE
libnl-tiny: define _GNU_SOURCE if not defined

### DIFF
--- a/package/libs/libnl-tiny/src/include/netlink-local.h
+++ b/package/libs/libnl-tiny/src/include/netlink-local.h
@@ -11,7 +11,9 @@
 
 #ifndef NETLINK_LOCAL_H_
 #define NETLINK_LOCAL_H_
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <stdio.h>
 #include <errno.h>


### PR DESCRIPTION
If _GNU_SOURCE was added as part of a package's TARGET_CFLAGS,
then compilation would fail for that module (especially if
warnings get treated as errors).

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>