### PR TITLE
default.nix: build support for nix/nixos

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,54 @@
+# Nix is a powerful package manager for Linux and other Unix systems that makes
+# package management reliable and reproducible: https://nixos.org/nix/.
+# This file is intended to be used with `nix-shell`
+# (https://nixos.org/nix/manual/#sec-nix-shell) to setup a fully-functional
+# LEDE build environment by installing all required dependencies.
+with import <nixpkgs> {};
+stdenv.mkDerivation {
+  name = "openwrt-dev-env";
+  buildInputs = [
+    # This list is more explicit then it have to be: it also includes utils
+    # from stdenv. However including every dependencies
+    # mentioned in include/prereq-build.mk makes future updates easier.
+    gnumake
+    gcc
+    ncurses
+    zlibStatic
+    zlibStatic.static
+    openssl
+    perlPackages.ThreadQueue
+    gnutar
+    findutils
+    bash
+    patchutils
+    diffutils
+    coreutils # captures cp, md5sum, stat
+    gawk
+    gnugrep
+  ] ++ [(if (stdenv.isDarwin) then getopt else utillinux)] ++ [
+    unzip
+    bzip2
+    wget
+    perl
+    python2
+    git
+    file
+    # additional dependencies from https://lede-project.org/docs/guide-developer/install-buildsystem
+    asciidoc
+    bc
+    binutils
+    fastjar
+    flex
+    intltool
+    jikespg
+    cdrkit
+    perlPackages.ExtUtilsMakeMaker
+    rsync
+    ruby
+    sdcc
+    gettext
+    libxslt
+  ];
+  NIX_LDFLAGS="-lncurses";
+  hardeningDisable = "all";
+}


### PR DESCRIPTION
nix is a distribution independent package manager.
By providing this file user of nix get automatically all
required build dependencies by sourcing default.nix via a tool called
`nix-shell`. This should lower the entry barrier when setting up a
build environment