### PR TITLE
bcm53xx: Add missing LEDs definition for Buffalo WZR-900DHP

### DIFF
--- a/target/linux/bcm53xx/patches-4.4/047-ARM-BCM5301X-Add-missing-WZR-900DHP-LEDs.patch
+++ b/target/linux/bcm53xx/patches-4.4/047-ARM-BCM5301X-Add-missing-WZR-900DHP-LEDs.patch
@@ -1,0 +1,83 @@
+--- a/arch/arm/boot/dts/bcm47081-buffalo-wzr-900dhp.dts
++++ b/arch/arm/boot/dts/bcm47081-buffalo-wzr-900dhp.dts
+@@ -25,6 +25,80 @@
+ 		       0x88000000 0x08000000>;
+ 	};
+ 
++	spi {
++		compatible = "spi-gpio";
++		num-chipselects = <1>;
++		gpio-sck = <&chipcommon 7 0>;
++		gpio-mosi = <&chipcommon 4 0>;
++		cs-gpios = <&chipcommon 6 0>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		hc595: gpio_spi@0 {
++
++			compatible = "fairchild,74hc595";
++			reg = <0>;
++			registers-number = <1>;
++			spi-max-frequency = <100000>;
++
++			gpio-controller;
++			#gpio-cells = <2>;
++		};
++
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		usb {
++			label = "bcm53xx:green:usb";
++			gpios = <&hc595 0 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-off";
++		};
++
++		power-green {
++			label = "bcm53xx:green:power";
++			gpios = <&hc595 1 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-on";
++		};
++
++		power-red {
++			label = "bcm53xx:red:power";
++			gpios = <&hc595 2 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-off";
++		};
++
++		router-green {
++			label = "bcm53xx:green:router";
++			gpios = <&hc595 3 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-off";
++		};
++
++		router-amber {
++			label = "bcm53xx:amber:router";
++			gpios = <&hc595 4 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-off";
++		};
++
++		wan {
++			label = "bcm53xx:green:wan";
++			gpios = <&hc595 5 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-off";
++		};
++
++		wireless-green {
++			label = "bcm53xx:green:wireless";
++			gpios = <&hc595 6 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-off";
++		};
++
++		wireless-amber {
++			label = "bcm53xx:amber:wireless";
++			gpios = <&hc595 7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-off";
++		};
++	};
++
+ 	gpio-keys {
+ 		compatible = "gpio-keys";
+ 		#address-cells = <1>;


### PR DESCRIPTION
The LEDs of Buffalo WZR-900DHP are not defined in dts and cannot be used,
so I added those definition.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>