### PR TITLE
linux: backport SPI_NOR_HAS_LOCK for f25l32pa

### DIFF
--- a/target/linux/generic/patches-4.4/048-mtd-spi-nor-backport-SPI_NOR_HAS_LOCK-flag.patch
+++ b/target/linux/generic/patches-4.4/048-mtd-spi-nor-backport-SPI_NOR_HAS_LOCK-flag.patch
@@ -1,0 +1,30 @@
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -68,6 +68,7 @@ struct flash_info {
+ #define	SPI_NOR_DUAL_READ	0x20    /* Flash supports Dual Read */
+ #define	SPI_NOR_QUAD_READ	0x40    /* Flash supports Quad Read */
+ #define	USE_FSR			0x80	/* use flag status register */
++#define	SPI_NOR_HAS_LOCK	0x100	/* Flash supports lock/unlock via SR */
+ };
+ 
+ #define JEDEC_MFR(info)	((info)->id[0])
+@@ -1222,7 +1223,8 @@ int spi_nor_scan(struct spi_nor *nor, co
+
+ 	if (JEDEC_MFR(info) == SNOR_MFR_ATMEL ||
+ 	    JEDEC_MFR(info) == SNOR_MFR_INTEL ||
+-	    JEDEC_MFR(info) == SNOR_MFR_SST) {
++	    JEDEC_MFR(info) == SNOR_MFR_SST ||
++	    info->flags & SPI_NOR_HAS_LOCK) {
+ 		write_enable(nor);
+ 		write_sr(nor, 0);
+ 	}
+@@ -1238,7 +1240,8 @@ int spi_nor_scan(struct spi_nor *nor, co
+ 	mtd->_read = spi_nor_read;
+ 
+ 	/* NOR protection support for STmicro/Micron chips and similar */
+-	if (JEDEC_MFR(info) == SNOR_MFR_MICRON) {
++	if (JEDEC_MFR(info) == SNOR_MFR_MICRON ||
++		info->flags & SPI_NOR_HAS_LOCK) {
+ 		nor->flash_lock = stm_lock;
+ 		nor->flash_unlock = stm_unlock;
+ 		nor->flash_is_locked = stm_is_locked;

--- a/target/linux/generic/patches-4.4/465-m25p80-mx-disable-software-protection.patch
+++ b/target/linux/generic/patches-4.4/465-m25p80-mx-disable-software-protection.patch
@@ -9,6 +9,6 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (JEDEC_MFR(info) == SNOR_MFR_ATMEL ||
  	    JEDEC_MFR(info) == SNOR_MFR_INTEL ||
 +	    JEDEC_MFR(info) == SNOR_MFR_MACRONIX ||
- 	    JEDEC_MFR(info) == SNOR_MFR_SST) {
- 		write_enable(nor);
- 		write_sr(nor, 0);
+	    JEDEC_MFR(info) == SNOR_MFR_SST ||
+		info->flags & SPI_NOR_HAS_LOCK) {
+		write_enable(nor);

--- a/target/linux/generic/patches-4.4/479-enable_mtd_has_lock_for_f25l32pa.patch
+++ b/target/linux/generic/patches-4.4/479-enable_mtd_has_lock_for_f25l32pa.patch
@@ -1,0 +1,10 @@
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -688,7 +689,7 @@ static const struct flash_info spi_nor_i
+ 	{ "en25s64",	INFO(0x1c3817, 0, 64 * 1024,  128, SECT_4K) },
+ 
+ 	/* ESMT */
+-	{ "f25l32pa", INFO(0x8c2016, 0, 64 * 1024, 64, SECT_4K) },
++	{ "f25l32pa", INFO(0x8c2016, 0, 64 * 1024, 64, SECT_4K | SPI_NOR_HAS_LOCK) },
+ 	{ "f25l32qa", INFO(0x8c4116, 0, 64 * 1024, 64, SECT_4K) },
+ 	{ "f25l64qa", INFO(0x8c4117, 0, 64 * 1024, 128, SECT_4K) },


### PR DESCRIPTION
This flag was added on
https://github.com/torvalds/linux/commit/76a4707de5e18dc32d9cb4e990686140c5664a15#diff-4df1cc2eea43805aed92602fb38a0ab7

Current commit backports this one and enables it for f25l32pa, which has
write protection enabled by default.

Signed-off-by: Victor Shyba <victor1984@riseup.net>


### Solves cold boot write issues, as described on this [bugreport](https://bugs.lede-project.org/index.php?do=details&task_id=336)