### PR TITLE
dnsmasq: use native 'interface-name' option for local host

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.76
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -8,6 +8,7 @@ PROG=/usr/sbin/dnsmasq
 
 ADD_LOCAL_DOMAIN=1
 ADD_LOCAL_HOSTNAME=1
+ADD_WAN_HOSTNAME=0
 
 BASECONFIGFILE="/var/etc/dnsmasq.conf"
 BASEHOSTFILE="/tmp/hosts/dhcp"
@@ -293,6 +294,26 @@ dhcp_host_add() {
 	xappend "--dhcp-host=$macs${duid:+,id:$duid}${networkid:+,net:$networkid}${broadcast:+,set:needs-broadcast}${tag:+,set:$tag}${ip:+,$ip${hostid:+,[::$hostid]}}${name:+,$name}${leasetime:+,$leasetime}"
 }
 
+dhcp_this_host_add() {
+	# TODO: case-in do/not short-host or FQDN; UCI already intended ...
+	local ifname="$1"
+	local do_enable="$2"
+	local routerstub routername ifdashname
+
+
+	if [ "$do_enable" -gt 0 ] ; then
+		# All IP addresses discovered by dnsmasq will be labeled robustly (except fe80::)
+		ifdashname="${ifname//./-}"
+		routerstub="$( md5sum /etc/os-release )"
+		routerstub="router-${routerstub// */}"
+		routername="$( uci_get system @system[0] hostname $routerstub )"
+
+		xappend "--interface-name=$ifdashname.$routername.$DOMAIN,$ifname"
+		xappend "--interface-name=$routername.$DOMAIN,$ifname"
+		xappend "--interface-name=$routername,$ifname"
+	fi
+}
+
 dhcp_tag_add() {
 	local cfg="$1"
 
@@ -363,7 +384,11 @@ dhcp_add() {
 		DNS_SERVERS="$DNS_SERVERS $dnsserver"
 	}
 
-	append_bool "$cfg" ignore "--no-dhcp-interface=$ifname" && return 0
+	append_bool "$cfg" ignore "--no-dhcp-interface=$ifname" && {
+		# Many ISP do not have useful names for DHCP customers (your WAN).
+		dhcp_this_host_add $ifname $ADD_WAN_HOSTNAME
+		return 0
+	}
 
 	# Do not support non-static interfaces for now
 	[ static = "$proto" ] || return 0
@@ -380,6 +405,9 @@ dhcp_add() {
 	config_get leasetime "$cfg" leasetime
 	config_get options "$cfg" options
 	config_get_bool dynamicdhcp "$cfg" dynamicdhcp 1
+
+	# Put the router host name on this DHCP served interface address(es)
+	dhcp_this_host_add $ifname $ADD_LOCAL_HOSTNAME
 
 	leasetime="${leasetime:-12h}"
 	start="$(dhcp_calc "${start:-100}")"
@@ -605,6 +633,7 @@ dnsmasq_start()
 
 	config_get_bool ADD_LOCAL_DOMAIN "$cfg" add_local_domain 1
 	config_get_bool ADD_LOCAL_HOSTNAME "$cfg" add_local_hostname 1
+	config_get_bool ADD_WAN_HOSTNAME "$cfg" add_wan_hostname 0
 
 	config_get_bool readethers "$cfg" readethers
 	[ "$readethers" = "1" -a \! -e "/etc/ethers" ] && touch /etc/ethers
@@ -701,27 +730,6 @@ dnsmasq_start()
 	config_foreach filter_dnsmasq domain dhcp_domain_add "$cfg"
 	config_foreach filter_dnsmasq hostrecord dhcp_hostrecord_add "$cfg"
 	config_foreach filter_dnsmasq relay dhcp_relay_add "$cfg"
-
-	# add own hostname
-	[ $ADD_LOCAL_HOSTNAME -eq 1 ] && {
-		local lanaddr lanaddr6
-		local ulaprefix="$(uci_get network @globals[0] ula_prefix)"
-		local hostname="$(uci_get system @system[0] hostname Lede)"
-
-		network_get_ipaddr lanaddr "lan" && {
-			dhcp_domain_add "" "$hostname" "$lanaddr"
-		}
-
-		[ -n "$ulaprefix" ] && network_get_ipaddrs6 lanaddr6 "lan" && {
-			for lanaddr6 in $lanaddr6; do
-				case "$lanaddr6" in
-					"${ulaprefix%%:/*}"*)
-						dhcp_domain_add "" "$hostname" "$lanaddr6"
-					;;
-				esac
-			done
-		}
-	}
 
 	echo >> $CONFIGFILE_TMP
 	config_foreach filter_dnsmasq srvhost dhcp_srv_add "$cfg"

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -23,22 +23,22 @@ xappend() {
 }
 
 hex_to_hostid() {
-        local var="$1"
-        local hex="${2#0x}"     # strip optional "0x" prefix
+	local var="$1"
+	local hex="${2#0x}" # strip optional "0x" prefix
 
-        if [ -n "${hex//[0-9a-fA-F]/}" ]; then
-                # is invalid hex literal
-                return 1
-        fi
+	if [ -n "${hex//[0-9a-fA-F]/}" ]; then
+		# is invalid hex literal
+		return 1
+	fi
 
-        # convert into host id
-        export "$var=$(
-                printf "%0x:%0x"  \
-                        $(((0x$hex >> 16) % 65536)) \
-                        $(( 0x$hex        % 65536))
-        )"
+	# convert into host id
+	export "$var=$(
+		printf "%0x:%0x" \
+		$(((0x$hex >> 16) % 65536)) \
+		$(( 0x$hex        % 65536))
+		)"
 
-        return 0
+	return 0
 }
 
 dhcp_calc() {


### PR DESCRIPTION
- add_local_host UCI uses dnsmasq instance host file entry
- add_local_host implementation may drop some addresses (i.e. IP6)
- dnsmasq provides this function natively with 'interface-name'
- change add_local_host UCI to act during DHCP assignment
  - use 'interface-name' to assign host to all addresses on interface
  - assign '\<iface\>.\<host\>.\<domain\>' as the true name (PTR)
  - assign '\<host\>.\<domain\>' and '\<host\>' as convinience aliases (not tech. cnames)
- include new UCI add_local_gatename with similar function
  - most ISP don't rDNS (well), so logs/graphs nicer to read
  - default is off for those with dynamic DNS
  - infer WAN as DHCP 'ignore'

Signed-off-by: Eric Luehrsen <ericluehrsen@hotmail.com>