### PR TITLE
Add support for different /etc/dnsmasq.conf file for each dnsmasq instance

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -544,7 +544,7 @@ dnsmasq_start()
 	if [ ! -r "$dnsmasqconffile" ]; then
 		dnsmasqconffile=/etc/dnsmasq.conf
 	fi
-	[ -f $dnsmasqconffile ] && {
+	[ -r $dnsmasqconffile ] && {
 		xappend "--conf-file=$dnsmasqconffile"
 	}
 

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -540,8 +540,12 @@ dnsmasq_start()
 	echo "# auto-generated config file from /etc/config/dhcp" > $HOSTFILE
 
 	# if we did this last, we could override auto-generated config
-	[ -f /etc/dnsmasq.conf ] && {
-		xappend "--conf-file=/etc/dnsmasq.conf"
+	local dnsmasqconffile="/etc/dnsmasq.conf.${cfg}"
+	if [ ! -r "$dnsmasqconffile" ]; then
+		dnsmasqconffile=/etc/dnsmasq.conf
+	fi
+	[ -f $dnsmasqconffile ] && {
+		xappend "--conf-file=$dnsmasqconffile"
 	}
 
 	$PROG --version | grep -osqE "^Compile time options:.* DHCPv6( |$)" && DHCPv6CAPABLE=1 || DHCPv6CAPABLE=0
@@ -753,11 +757,6 @@ dnsmasq_start()
 	procd_set_param command $PROG -C $CONFIGFILE -k -x /var/run/dnsmasq/dnsmasq."${cfg}".pid
 	procd_set_param file $CONFIGFILE
 	procd_set_param respawn
-
-	local dnsmasqconffile="/etc/dnsmasq.${cfg}.conf"
-	if [ ! -r "$dnsmasqconffile" ]; then
-		dnsmasqconffile=/etc/dnsmasq.conf
-	fi
 
 	procd_add_jail dnsmasq ubus log
 	procd_add_jail_mount $CONFIGFILE $TRUSTANCHORSFILE $HOSTFILE /etc/passwd /etc/group /etc/TZ /dev/null /dev/urandom $dnsmasqconffile $dnsmasqconfdir $resolvfile $dhcpscript /etc/hosts /etc/ethers $EXTRA_MOUNT


### PR DESCRIPTION
the initial multiple instance support is already there but they all share the same /etc/dnsmasq.conf file which is not ideal. this simple patch would allow having different conf file if /etc/dnsmasq.conf.${cfg} exists. otherwise it falls back to the default file.