### PR TITLE
gettext-full: enforce only static lib on the host build

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -59,6 +59,8 @@ CONFIGURE_ARGS += \
 	--without-emacs
 
 HOST_CONFIGURE_ARGS += \
+	--disable-shared \
+	--enable-static \
 	--disable-libasprintf \
 	--disable-rpath \
 	--disable-java \


### PR DESCRIPTION
Sometimes I'm getting error on the host-side build:
```
/usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: /home/sandu/work/lede/staging_dir/host/lib/liblzma.a(liblzma_la-common.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/home/sandu/work/lede/staging_dir/host/lib/liblzma.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
Makefile:2847: recipe for target 'libgettextlib.la' failed
make[9]: *** [libgettextlib.la] Error 1
make[9]: Leaving directory '/home/sandu/work/lede/build_dir/target-x86_64_musl-1.1.15/host/gettext-0.19.8.1/gettext-tools/gnulib-lib'
Makefile:2597: recipe for target 'all' failed
```

Disabling the shared-lib build, seems to fix this.

This is when building glib2 on the host-side.
glib2 is required by newer QEMU package [which is in the feeds].

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>