### PR TITLE
comgt-ncm: fix typo

### DIFF
--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -35,7 +35,7 @@ proto_ncm_setup() {
 	[ -n "$profile" ] || profile=1
 
 	pdptype=`echo "$pdptype" | awk '{print toupper($0)}'`
-	[ "$pdptype" = "IP" -o "$pdptype" = "IPV6" -o "$pdptype" = "IPV4V6" ] || $pdptype="IP"
+	[ "$pdptype" = "IP" -o "$pdptype" = "IPV6" -o "$pdptype" = "IPV4V6" ] || pdptype="IP"
 
 	[ -n "$ctl_device" ] && device=$ctl_device
 


### PR DESCRIPTION
Fix typo in ncm.sh. Resolves:

`Wed Dec 21 09:55:54 2016 daemon.notice netifd: wan (4455): ./ncm.sh: eval: line 1: =IP: not found`

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>