### PR TITLE
dnsmasq: add log facility option

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -573,6 +573,7 @@ dnsmasq_start()
 	append_bool "$cfg" allservers "--all-servers"
 	append_bool "$cfg" noping "--no-ping"
 
+	append_parm "$cfg" logfacility "--log-facility"
 	append_parm "$cfg" dhcpscript "--dhcp-script"
 	append_parm "$cfg" cachesize "--cache-size"
 	append_parm "$cfg" dnsforwardmax "--dns-forward-max"


### PR DESCRIPTION
add possibility to set the facility to which dnsmasq will send syslog entries, i.e. set it to '/dev/null' to mute dnsmasq output at all.

Signed-off-by: Dirk Brenken dev@brenken.org