### PR TITLE
ipq806x: fix pvs1_bin voltage in ipq8065 DT

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
@@ -222,11 +222,11 @@
 			 < 600000000 1000000 >,
 			 < 384000000 975000 >;
 		qcom,speed0-pvs1-bin-v0 =
-			< 1725000000 1262500 >,
-			< 1400000000 1175000 >,
-			< 1000000000 1100000 >,
-			 < 800000000 1050000 >,
-			 < 600000000 1000000 >,
+			< 1725000000 1225000 >,
+			< 1400000000 1150000 >,
+			< 1000000000 1075000 >,
+			 < 800000000 1025000 >,
+			 < 600000000 975000 >,
 			 < 384000000 950000 >;
 		qcom,speed0-pvs2-bin-v0 =
 			< 1725000000 1200000 >,
@@ -340,13 +340,13 @@
 				};
 
 				smb208_s2a: s2a {
-					regulator-min-microvolt = < 800000>;
+					regulator-min-microvolt = <775000>;
 					regulator-max-microvolt = <1275000>;
 					qcom,switch-mode-frequency = <1200000>;
 				};
 
 				smb208_s2b: s2b {
-					regulator-min-microvolt = < 800000>;
+					regulator-min-microvolt = <775000>;
 					regulator-max-microvolt = <1275000>;
 					qcom,switch-mode-frequency = <1200000>;
 				};


### PR DESCRIPTION
Fixing pvs1 bin voltage as found in GPL tarball.

Also adjusting smb208_s2a/b minimum voltage to reflect lowest value in pvs table.

Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>