### PR TITLE
wwan: adding wwan support for the dwr-512 3G modem

### DIFF
--- a/package/network/utils/comgt/files/ncm.json
+++ b/package/network/utils/comgt/files/ncm.json
@@ -63,5 +63,16 @@
 		},
 		"connect": "AT*ENAP=1,${profile}",
 		"disconnect": "AT*ENAP=0"
+	},
+	"mtk1": {
+		"initialize": [
+			"AT+CFUN=1"
+		],
+		"configure": [
+			"AT+CGDCONT=${profile},\\\"${pdptype}\\\",\\\"${apn}\\\",0,0"
+		],
+		"connect": "AT+CGACT=1,${profile}",
+		"finalize": "AT+CGDATA=\\\"M-MBIM\\\",${profile},1",
+		"disconnect": "AT+CGACT=0,${profile}"
 	}
 }

--- a/package/network/utils/wwan/files/wwan.sh
+++ b/package/network/utils/wwan/files/wwan.sh
@@ -66,15 +66,15 @@ proto_wwan_setup() {
 		}
 	}
 
-	[ -z "$ctl_device" ] && for net in $(ls /sys/class/net/ | grep wwan); do
+	[ -z "$ctl_device" ] && for net in $(ls /sys/class/net/ | grep -e wwan -e usb); do
 		[ -z "$ctl_device" ] || continue
 		driver=$(grep DRIVER /sys/class/net/$net/device/uevent | cut -d= -f2)
 		case "$driver" in
 		qmi_wwan|cdc_mbim)
 			ctl_device=/dev/$(ls /sys/class/net/$net/device/usbmisc)
 			;;
-		sierra_net|*cdc_ncm)
-			ctl_device=/dev/$(cd /sys/class/net/$net/; find ../../../ -name ttyUSB* |xargs basename | head -n1)
+		sierra_net|cdc_ether|*cdc_ncm)
+			ctl_device=/dev/$(cd /sys/class/net/$net/; find ../../../ -name ttyUSB* |xargs -n1 basename | head -n1)
 			;;
 		*) continue;;
 		esac
@@ -93,11 +93,11 @@ proto_wwan_setup() {
 	uci_set_state network $interface dat_device "$dat_device"
 
 	case $driver in
-	qmi_wwan)	proto_qmi_setup $@ ;;
-	cdc_mbim)	proto_mbim_setup $@ ;;
-	sierra_net)	proto_directip_setup $@ ;;
-	comgt)		proto_3g_setup $@ ;;
-	*cdc_ncm)	proto_ncm_setup $@ ;;
+	qmi_wwan)		proto_qmi_setup $@ ;;
+	cdc_mbim)		proto_mbim_setup $@ ;;
+	sierra_net)		proto_directip_setup $@ ;;
+	comgt)			proto_3g_setup $@ ;;
+	cdc_ether|*cdc_ncm)	proto_ncm_setup $@ ;;
 	esac
 }
 
@@ -108,11 +108,11 @@ proto_wwan_teardown() {
 	dat_device=$(uci_get_state network $interface dat_device)
 
 	case $driver in
-	qmi_wwan)	proto_qmi_teardown $@ ;;
-	cdc_mbim)	proto_mbim_teardown $@ ;;
-	sierra_net)	proto_mbim_teardown $@ ;;
-	comgt)		proto_3g_teardown $@ ;;
-	*cdc_ncm)	proto_ncm_teardown $@ ;;
+	qmi_wwan)		proto_qmi_teardown $@ ;;
+	cdc_mbim)		proto_mbim_teardown $@ ;;
+	sierra_net)		proto_mbim_teardown $@ ;;
+	comgt)			proto_3g_teardown $@ ;;
+	cdc_ether|*cdc_ncm)	proto_ncm_teardown $@ ;;
 	esac
 }
 

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -177,8 +177,8 @@ TARGET_DEVICES += dir-620-d1
 define Device/dwr-512-b
   DTS := DWR-512-B
   DEVICE_TITLE := D-Link DWR-512 B
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-i2c-core kmod-i2c-ralink kmod-spi-dev \
-			kmod-usb-serial kmod-usb-serial-option kmod-usb-serial-wwan comgt
+  DEVICE_PACKAGES := kmod-usb2 kmod-spi-dev kmod-usb-serial kmod-usb-serial-option \
+			kmod-usb-net kmod-usb-net-cdc-ether comgt-ncm
 endef
 TARGET_DEVICES += dwr-512-b
 


### PR DESCRIPTION
This PR allow the 3G modem embedded in the DWR-512 to be managed
by the wwan-ncm scripts. The modem will use the usb-option and
usb-cdc-ether drivers.
The DWR-512 DT is updated accordingly.

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>