### PR TITLE
ramips: add support for Onion Omega2+

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -48,6 +48,7 @@ ramips_setup_interfaces()
 	microwrt|\
 	mpr-a2|\
 	ncs601w|\
+	omega2p | \
 	timecloud|\
 	w150m|\
 	widora-neo|\
@@ -342,7 +343,8 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 28)
 		;;
 	linkits7688 | \
-	linkits7688d)
+	linkits7688d | \
+	omega2p)
 		wan_mac=$(mtd_get_mac_binary factory 4)
 		lan_mac=$(mtd_get_mac_binary factory 46)
 		;;

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -173,6 +173,9 @@ get_status_led() {
 	newifi-d1)
 		status_led="$board:blue:status"
 		;;
+	omega2p)
+		status_led="omega2p:amber:system"
+		;;
 	oy-0001|\
 	sl-r7205|\
 	zbt-we826)

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -352,6 +352,9 @@ ramips_board_detect() {
 	*"NW718")
 		name="nw718"
 		;;
+	*"Onion Omega2+")
+		name="omega2p"
+		;;
 	*"OY-0001")
 		name="oy-0001"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -103,6 +103,7 @@ platform_check_image() {
 	newifi-d1|\
 	nixcore|\
 	nw718|\
+	omega2p|\
 	oy-0001|\
 	pbr-d1|\
 	pbr-m1|\

--- a/target/linux/ramips/dts/omega2p.dts
+++ b/target/linux/ramips/dts/omega2p.dts
@@ -1,0 +1,185 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "onion,omega", "mediatek,mt7628an-soc";
+	model = "Onion Omega2+";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		system {
+			label = "omega2p:amber:system";
+			gpios = <&gpio1 12 1>;
+			default-state = "on";
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wps {
+			label = "reset";
+			gpios = <&gpio1 6 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "gpio";
+			ralink,function = "gpio";
+		};
+
+		perst {
+			ralink,group = "perst";
+			ralink,function = "gpio";
+		};
+
+		pwm0 {
+			ralink,function = "gpio";
+			ralink,group = "pwm0";
+		};
+
+		pwm1 {
+			ralink,function = "gpio";
+			ralink,group = "pwm1";
+		};
+
+		refclk {
+			ralink,group = "refclk";
+			ralink,function = "gpio";
+		};
+
+		i2s {
+			ralink,group = "i2s";
+			ralink,function = "gpio";
+		};
+
+		spis {
+			ralink,group = "spis";
+			ralink,function = "gpio";
+		};
+
+		wled_kn {
+			ralink,group = "wled_kn";
+			ralink,function = "gpio";
+		};
+
+		wled_an {
+			ralink,group = "wled_an";
+			ralink,function = "gpio";
+		};
+
+		wdt {
+			ralink,group = "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80", "mx25l25635e";
+		spi-max-frequency = <40000000>;
+		m25p,chunked-io = <31>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x1fb0000>;
+		};
+	};
+
+	spidev@1 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "linux,spidev";
+		reg = <1>;
+		spi-max-frequency = <40000000>;
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&sdhci {
+	status = "okay";
+	mediatek,cd-low;
+};
+
+&wmac {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7688.mk
+++ b/target/linux/ramips/image/mt7688.mk
@@ -11,6 +11,14 @@ define Device/LinkIt7688
 endef
 TARGET_DEVICES += LinkIt7688
 
+define Device/omega2p
+  DTS := omega2p
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DEVICE_TITLE := Onion Omega2+
+  DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools kmod-sdhci-mt7620
+endef
+TARGET_DEVICES += omega2p
+
 define Device/pbr-d1
   DTS := PBR-D1
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
Onion Omega2+ CPU: MT7688AN MIPS24KEc @580MHz Flash: 32MB RAM: DDR2 128MB
WLAN: Built-in SoC 1T1R 802.11b/g/n (2.4GHz), Ethernet: 10/100 PHY (on pin-headers), USB: 1x2.0 (on pin-headers)

Signed-off-by: Nita Vesa werecatf@gmail.com