### PR TITLE
brcm63xx: add support for Pirelli/ADB P.DG AV4202N

### DIFF
--- a/target/linux/brcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/brcm63xx/base-files/etc/board.d/01_leds
@@ -16,6 +16,9 @@ a4001n1)
 a4001n)
 	ucidef_set_led_usbdev "usb" "USB" "A4001N:green:usb" "1-1"
 	;;
+av4202n)
+	ucidef_set_led_netdev "wlan0" "WLAN" "AV4202N:blue:wifi" "wlan0"
+	;;
 dgnd3700v1_dgnd3800b)
 	ucidef_set_led_netdev "lan" "LAN" "DGND3700v1_3800B:green:lan" "eth0.1"
 	ucidef_set_led_netdev "wan" "WAN" "DGND3700v1_3800B:green:inet" "eth0.2"

--- a/target/linux/brcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/brcm63xx/base-files/etc/board.d/02_network
@@ -80,6 +80,7 @@ a4001n1 |\
 a4001n |\
 ar-5381u |\
 ar-5387un |\
+av4202n |\
 bcm963281tan |\
 bcm96328avng |\
 bcm96368mvngr |\

--- a/target/linux/brcm63xx/base-files/etc/diag.sh
+++ b/target/linux/brcm63xx/base-files/etc/diag.sh
@@ -18,6 +18,9 @@ set_state() {
 	ar-5387un)
 		status_led="AR-5387un:green:power"
 		;;
+	av4202n)
+		status_led="AV4202N:white:power"
+		;;
 	bcm96348gw)
 		status_led="96348GW:green:power"
 		;;

--- a/target/linux/brcm63xx/base-files/lib/brcm63xx.sh
+++ b/target/linux/brcm63xx/base-files/lib/brcm63xx.sh
@@ -18,6 +18,9 @@ brcm63xx_dt_detect() {
 	"ADB P.DG A4001N1")
 		board_name="a4001n1"
 		;;
+	"ADB P.DG AV4202N")
+		board_name="av4202n"
+		;;
 	"Alcatel RG100A")
 		board_name="rg100a"
 		;;

--- a/target/linux/brcm63xx/dts/av4202n.dts
+++ b/target/linux/brcm63xx/dts/av4202n.dts
@@ -1,0 +1,68 @@
+/dts-v1/;
+
+#include "bcm6368.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "ADB P.DG AV4202N";
+	compatible = "adb,av4202n", "brcm,bcm6368";
+
+	chosen {
+		bootargs = "root=/dev/mtdblock2 rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+		debounce-interval = <60>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+		wlan {
+			label = "wlan";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WLAN>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power_white {
+			label = "AV4202N:white:power";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+		power_red {
+			label = "AV4202N:red:power";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+		wan_white {
+			label = "AV4202N:white:wan";
+			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
+		};
+		wan_red {
+			label = "AV4202N:red:wan";
+			gpios = <&gpio0 27 GPIO_ACTIVE_LOW>;
+		};
+		phone_white {
+			label = "AV4202N:white:phone";
+			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+		};
+		phone_red {
+			label = "AV4202N:red:phone";
+			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+		};
+		wifi {
+			label = "AV4202N:blue:wifi";
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/brcm63xx/image/bcm63xx.mk
+++ b/target/linux/brcm63xx/image/bcm63xx.mk
@@ -200,6 +200,18 @@ define Device/A4001N1
 endef
 TARGET_DEVICES += A4001N1
 
+define Device/AV4202N
+  $(Device/bcm63xx)
+  IMAGE_OFFSET := 0x20000
+  DEVICE_TITLE := ADB P.DG AV4202N
+  DEVICE_DTS := av4202n
+  CFE_BOARD_ID := 96368_Swiss_S1
+  CFE_CHIP_ID := 6368
+  DEVICE_PACKAGES := \
+    $(USB2_PACKAGES) $(B43_PACKAGES)
+endef
+TARGET_DEVICES += AV4202N
+
 ### Alcatel ###
 define Device/RG100A
   $(Device/bcm63xx)

--- a/target/linux/brcm63xx/patches-4.4/576-board_AV4202N.patch
+++ b/target/linux/brcm63xx/patches-4.4/576-board_AV4202N.patch
@@ -1,0 +1,71 @@
+--- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
++++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
+@@ -1884,6 +1884,52 @@ static struct board_info __initdata boar
+  * known 6368 boards
+  */
+ #ifdef CONFIG_BCM63XX_CPU_6368
++static struct board_info __initdata board_AV4202N = {
++	.name				= "96368_Swiss_S1",
++	.expected_cpu_id		= 0x6368,
++
++	.has_uart0			= 1,
++	.has_pci			= 1,
++	.has_ohci0			= 1,
++	.has_ehci0			= 1,
++	.num_usbh_ports			= 2,
++
++	.has_enetsw			= 1,
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used	= 1,
++				.phy_id	= 1,
++				.name	= "port1",
++			},
++
++			[1] = {
++				.used	= 1,
++				.phy_id	= 2,
++				.name	= "port2",
++			},
++
++			[2] = {
++				.used	= 1,
++				.phy_id	= 3,
++				.name	= "port3",
++			},
++
++			[3] = {
++				.used	= 1,
++				.phy_id	= 4,
++				.name	= "port4",
++			},
++		},
++	},
++	.use_fallback_sprom	= 1,
++	.fallback_sprom = {
++		.pci_bus		= 0,
++		.pci_dev		= 1,
++	},
++
++};
++
+ static struct board_info __initdata board_96368mvwg = {
+ 	.name				= "96368MVWG",
+ 	.expected_cpu_id		= 0x6368,
+@@ -2648,6 +2694,7 @@ static const struct board_info __initcon
+ #endif
+ 
+ #ifdef CONFIG_BCM63XX_CPU_6368
++	&board_AV4202N,
+ 	&board_96368mvwg,
+ 	&board_96368mvngr,
+ 	&board_DGND3700v1_3800B,
+@@ -2755,6 +2802,7 @@ static struct of_device_id const bcm963x
+ 	{ .compatible = "sfr,nb6-ser-r0", .data = &board_nb6, },
+ #endif
+ #ifdef CONFIG_BCM63XX_CPU_6368
++	{ .compatible = "adb,av4202n", .data = &board_AV4202N, },
+ 	{ .compatible = "brcm,bcm96368mvngr", .data = &board_96368mvngr, },
+ 	{ .compatible = "brcm,bcm96368mvwg", .data = &board_96368mvwg, },
+ 	{ .compatible = "comtrend,vr-3025u", .data = &board_VR3025u, },


### PR DESCRIPTION
This patch adds support for the ADB P.DG AV4202N aka Pirelli PRG AV4202N [1].
In order to get switch triggered LEDs working, SWCONFIG_LEDS is
enabled in kernel configuration. (Here, also [2] comes into play)

What does not work: xDSL part (Broadcom proprietary), 2x FXS port (but there's a solution to that)
What works: Ethernet + switch (VLAN), Wifi, GPIO LEDs+Btn, USB, sysupgrade
See more details on the device in [3], also short info on FXS is there.

Although we don't have DSL support, the device features 16MB Flash, 64MB RAM, 2x 400MHz MIPS32, 2x USB2.0 and therefore is worth taking a look at.

What I'm note sure about: should I now update the info in OpenWrt's wiki at [1] (support status, installation procedure, ...)?

[1]:
https://wiki.openwrt.org/toh/adb/p.dg_av4202n

[2]:
https://github.com/lede-project/source/pull/644

[3]:
https://pwassi.privatedns.org/lede/av4202/