### PR TITLE
FB7360SL: reset PHYs when link status changes

### DIFF
--- a/target/linux/lantiq/dts/FRITZ7360SL.dts
+++ b/target/linux/lantiq/dts/FRITZ7360SL.dts
@@ -13,7 +13,6 @@
 		led-running = &power_green;
 
 		led-internet = &info_green;
-		led-dsl = &power_green;
 		led-wifi = &wifi;
 	};
 
@@ -70,7 +69,7 @@
 				};
 				phy-rst {
 					lantiq,pins = "io37", "io44";
-					lantiq,pull = <2>;
+					lantiq,pull = <0>;
 					lantiq,open-drain;
 					lantiq,output = <1>;
 				};
@@ -160,14 +159,12 @@
 			reg = <0>;
 			phy-mode = "rmii";
 			phy-handle = <&phy0>;
-			// gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
 		};
 		ethernet@1 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <1>;
 			phy-mode = "rmii";
 			phy-handle = <&phy1>;
-			// gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 		};
 		ethernet@2 {
 			compatible = "lantiq,xrx200-pdi-port";
@@ -189,11 +186,13 @@
 		compatible = "lantiq,xrx200-mdio";
 		phy0: ethernet-phy@0 {
 			reg = <0x00>;
-			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+			compatible = "ethernet-phy-id004d.d076", "ethernet-phy-ieee802.3-c22";
+			reset-gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
 		};
 		phy1: ethernet-phy@1 {
 			reg = <0x01>;
-			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+			compatible = "ethernet-phy-id004d.d076", "ethernet-phy-ieee802.3-c22";
+			reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 		};
 		phy11: ethernet-phy@11 {
 			reg = <0x11>;


### PR DESCRIPTION
Due to a hardware bug of Atheros at803x phys, the driver need to reset
the phys on link state change. (see: [drivers/net/phy/at803x.c:337]
The bug occurs when the FIFO Buffer contains queued TX/RX frames.

* Use the correct compatible string for the at803x phys connected to
switch port 0 and 1.

* Fix the pinmux of the gpio lines connected to the reset pin of the phys
and define the reset-pins to let the driver do the fixups.

Reproduce case:
1. Start a Download (a large linux ISO image should be enough >= 2GB)
2. Unplug many times the cable while downloading the iso file.
3. After 3 seconds Plugin the cable.
-> After repeating 3x times the steps (2. and 3.) your NIC connection LED should indicate a "on-off-on-off.. state. 

Signed-off-by: Mathias Kresin <dev@kresin.me>
Tested-by: Guido Lipke <lipkegu@gmail.com>