### PR TITLE
hostapd: expose wps_independent and ap_setup_locked as uci options

### DIFF
--- a/package/network/services/hostapd/files/netifd.sh
+++ b/package/network/services/hostapd/files/netifd.sh
@@ -150,6 +150,7 @@ hostapd_common_add_bss_config() {
 	config_add_string wpa_psk_file
 
 	config_add_boolean wps_pushbutton wps_label ext_registrar wps_pbc_in_m1
+	config_add_int wps_ap_setup_locked wps_independent
 	config_add_string wps_device_type wps_device_name wps_manufacturer wps_pin
 
 	config_add_boolean ieee80211r pmk_r1_push
@@ -183,8 +184,8 @@ hostapd_set_bss_options() {
 	json_get_vars \
 		wep_rekey wpa_group_rekey wpa_pair_rekey wpa_master_rekey \
 		maxassoc max_inactivity disassoc_low_ack isolate auth_cache \
-		wps_pushbutton wps_label ext_registrar wps_pbc_in_m1 \
-		wps_device_type wps_device_name wps_manufacturer wps_pin \
+		wps_pushbutton wps_label ext_registrar wps_pbc_in_m1 wps_ap_setup_locked \
+		wps_independent wps_device_type wps_device_name wps_manufacturer wps_pin \
 		macfilter ssid wmm uapsd hidden short_preamble rsn_preauth \
 		iapp_interface eapol_version acct_server acct_secret acct_port \
 		dynamic_vlan
@@ -331,11 +332,12 @@ hostapd_set_bss_options() {
 		append bss_conf "eap_server=1" "$N"
 		[ -n "$wps_pin" ] && append bss_conf "ap_pin=$wps_pin" "$N"
 		append bss_conf "wps_state=$wps_state" "$N"
-		append bss_conf "ap_setup_locked=0" "$N"
 		append bss_conf "device_type=$wps_device_type" "$N"
 		append bss_conf "device_name=$wps_device_name" "$N"
 		append bss_conf "manufacturer=$wps_manufacturer" "$N"
 		append bss_conf "config_methods=$config_methods" "$N"
+		[ -n "$wps_ap_setup_locked" ] && append bss_conf "ap_setup_locked=$wps_ap_setup_locked" "$N"
+		[ -n "$wps_independent" ] && append bss_conf "wps_independent=$wps_independent" "$N"
 		[ "$wps_pbc_in_m1" -gt 0 ] && append bss_conf "pbc_in_m1=$wps_pbc_in_m1" "$N"
 	}
 

--- a/package/network/services/hostapd/files/netifd.sh
+++ b/package/network/services/hostapd/files/netifd.sh
@@ -323,6 +323,7 @@ hostapd_set_bss_options() {
 		set_default wps_device_type "6-0050F204-1"
 		set_default wps_device_name "Lede AP"
 		set_default wps_manufacturer "www.lede-project.org"
+		set_default wps_independent 1
 
 		wps_state=2
 		[ -n "$wps_configured" ] && wps_state=1
@@ -336,8 +337,8 @@ hostapd_set_bss_options() {
 		append bss_conf "device_name=$wps_device_name" "$N"
 		append bss_conf "manufacturer=$wps_manufacturer" "$N"
 		append bss_conf "config_methods=$config_methods" "$N"
+		append bss_conf "wps_independent=$wps_independent" "$N"
 		[ -n "$wps_ap_setup_locked" ] && append bss_conf "ap_setup_locked=$wps_ap_setup_locked" "$N"
-		[ -n "$wps_independent" ] && append bss_conf "wps_independent=$wps_independent" "$N"
 		[ "$wps_pbc_in_m1" -gt 0 ] && append bss_conf "pbc_in_m1=$wps_pbc_in_m1" "$N"
 	}
 


### PR DESCRIPTION
The first configuration option, `wps_independent`, determines if WPS operations, such as a WPS push button trigger event, should apply to all wireless networks within the same `hostapd` process ([the current `hostapd` default](http://lists.infradead.org/pipermail/hostap/2016-March/035301.html)), or only to the relevant wireless network (any non-zero value). 

The UCI option is named the same as the `hostapd` option, `wps_independent`, as this is already in line with the existing UCI naming for WPS options.

The default `wps_independent` setting of `0` prevents you from selectively enabling and using WPS push button configuration on a subset of wireless networks, such as a Guest network, whilst leaving WPS disabled on an Internal network. An OpenWrt [bug report](https://dev.openwrt.org/ticket/19485) and [forum topic](https://forum.openwrt.org/viewtopic.php?pid=272476) exists for this particular issue, which is resolved by setting `wps_independent` to a non-zero value.

In some circumstances, the default setting can also lead to enrollees being admitted to the wrong wireless network within the same `hostapd` process.

The second configuration option, `ap_setup_locked`, when set to `1`, will disallow new registrars. This is currently hardcoded to `0` in LEDE, disabling this locking. Alternatively, a value of `2` can be used to enable read only access to AP settings.

To group this with the other WPS options, the UCI option name of `wps_ap_setup_locked` was selected, which differs from the `hostapd` option name `ap_setup_locked`.

Whilst outside the scope of this pull request, changing the LEDE default for one or both of these options to `1` may be worth considering.

Signed-off-by: Steven Honson <steven@honson.id.au>