### PR TITLE
ustream-ssl: remove extra DEFAULT_VARIANT from libustream-polarssl

### DIFF
--- a/package/libs/ustream-ssl/Makefile
+++ b/package/libs/ustream-ssl/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ustream-ssl
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(LEDE_GIT)/project/ustream-ssl.git
@@ -47,7 +47,6 @@ define Package/libustream-polarssl
   TITLE += (polarssl)
   DEPENDS += +libpolarssl
   VARIANT:=polarssl
-  DEFAULT_VARIANT:=1
 endef
 
 define Package/libustream-mbedtls


### PR DESCRIPTION
Currently both libustream-polarssl and libustream-mbedtls variants define themselves as the DEFAULT_VARIANT. (most likely due to copy-paste error in the creation of the -mbedtls variant)
https://github.com/lede-project/source/blob/master/package/libs/ustream-ssl/Makefile#L50
https://github.com/lede-project/source/blob/master/package/libs/ustream-ssl/Makefile#L58

Remove extra DEFAULT_VARIANT from libustream-polarssl and leave libustream-mbedtls as the default.

Luci-ssl was switched to default on mbedtls by https://github.com/openwrt/luci/commit/974194b440572e56d645f148316d53d65fd0a782 and PR #653 is cleaning curl. 

After #653 and this PR have been implemented, I think that the packages in the core LEDE repo defaulting to polarssl have been corrected to default into mbedtls in future, which should decrease dependency conflicts in opkg.