### PR TITLE
kirkwood: add ZyXEL NSA310b

### DIFF
--- a/target/linux/kirkwood/base-files/etc/board.d/01_leds
+++ b/target/linux/kirkwood/base-files/etc/board.d/01_leds
@@ -38,6 +38,9 @@ case "$board" in
 "guruplug-server-plus")
 	ucidef_set_led_timer "health" "health" "guruplug:red:health" "200" "800"
 	;;
+"nsa310b")
+	ucidef_set_led_default "health" "health" "nsa310:green:sys" "1"
+	;;
 "sheevaplug" | \
 "sheevaplug-esata")
 	ucidef_set_led_timer "health" "health" "sheevaplug:blue:health" "200" "800"

--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -22,13 +22,17 @@ case "$board" in
 "sheevaplug-esata")
 	ucidef_set_interface_lan "eth0" "dhcp"
 	;;
+"guruplug-server-plus")
+	ucidef_set_interface_lan "eth0 eth1" "dhcp"
+	;;
 "linksys-audi"|\
 "linksys-viper")
 	ucidef_add_switch "switch0" \
 		"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "5@eth0" "6@eth1"
 	;;
-"guruplug-server-plus")
-	ucidef_set_interface_lan "eth0 eth1" "dhcp"
+"nsa310b")
+	ucidef_set_interface_lan "eth0" "dhcp"
+	ucidef_set_interface_macaddr "lan" $( fw_printenv ethaddr | awk -F"=" '{print $2}' )
 	;;
 *)
 	ucidef_set_interface_lan "eth0"

--- a/target/linux/kirkwood/base-files/etc/diag.sh
+++ b/target/linux/kirkwood/base-files/etc/diag.sh
@@ -20,6 +20,9 @@ get_status_led() {
 	linksys-viper)
 		status_led="viper:white:health"
 		;;
+	nsa310b)
+		status_led="nsa310:green:sys"
+		;;
 	esac
 }
 

--- a/target/linux/kirkwood/base-files/etc/init.d/nsa310_fancontrol
+++ b/target/linux/kirkwood/base-files/etc/init.d/nsa310_fancontrol
@@ -1,0 +1,21 @@
+#!/bin/sh /etc/rc.common
+
+START=98
+boot() {
+. /lib/functions.sh
+. /lib/kirkwood.sh
+
+#configuring lm85 onboard temp/fan controller to run the fan on its own
+#for more information, please read https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface
+
+path_to_hwmon='/sys/devices/platform/ocp@f1000000/f1011000.i2c/i2c-0/0-002e/hwmon/hwmon0'
+
+case $(kirkwood_board_name) in
+	nsa310b)
+	echo 2 > "$path_to_hwmon/pwm1_enable" # fan is on pwm1
+	echo 1 > "$path_to_hwmon/pwm1_auto_channels" # temp1 is the only one that changes
+	echo 23000 > "$path_to_hwmon/temp1_auto_temp_min"
+	echo 43000 > "$path_to_hwmon/temp1_auto_temp_max" # next step is 49600 millicelsius, or 50 celsius, 43 celsius is better
+		;;
+esac
+}

--- a/target/linux/kirkwood/base-files/lib/kirkwood.sh
+++ b/target/linux/kirkwood/base-files/lib/kirkwood.sh
@@ -57,6 +57,10 @@ kirkwood_board_detect() {
 		name="sheevaplug-esata"
 		;;
 
+	"ZyXEL NSA310b")
+		name="nsa310b"
+		;;
+
 	"ZyXEL NSA310S")
 		name="nsa310s"
 		;;

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
 KERNEL_LOADADDR:=0x8000
-TARGET_DEVICES = linksys-audi linksys-viper dockstar goflexnet goflexhome iconnect pogo_e02 ib62x0
+TARGET_DEVICES = linksys-audi linksys-viper dockstar goflexnet goflexhome iconnect pogo_e02 ib62x0 nsa310b
 
 UBI_OPTS := -m 2048 -p 128KiB -s 512
 UBIFS_OPTS := -m 2048 -e 126KiB -c 4096
@@ -78,6 +78,13 @@ define Device/iconnect
 $(Device/dockstar)
   DEVICE_TITLE := Iomega Iconnect
   DEVICE_DTS := kirkwood-iconnect
+endef
+
+define Device/nsa310b
+$(Device/dockstar)
+  DEVICE_TITLE := ZyXEL NSA310b
+  DEVICE_DTS := kirkwood-nsa310b
+  DEVICE_PACKAGES := kmod-r8169 kmod-gpio-button-hotplug kmod-hwmon-lm85
 endef
 
 define Device/pogo_e02

--- a/target/linux/kirkwood/patches-4.4/190-zyxel-nsa3xx-common-nand-partitions.patch
+++ b/target/linux/kirkwood/patches-4.4/190-zyxel-nsa3xx-common-nand-partitions.patch
@@ -1,0 +1,47 @@
+--- a/arch/arm/boot/dts/kirkwood-nsa3x0-common.dtsi
++++ b/arch/arm/boot/dts/kirkwood-nsa3x0-common.dtsi
+@@ -121,39 +121,15 @@
+ 
+ 	partition@0 {
+ 		label = "uboot";
+-		reg = <0x0000000 0x0100000>;
++		reg = <0x0000000 0x00c0000>;
+ 		read-only;
+ 	};
+ 	partition@100000 {
+ 		label = "uboot_env";
+-		reg = <0x0100000 0x0080000>;
++		reg = <0x00c0000 0x0080000>;
+ 	};
+-	partition@180000 {
+-		label = "key_store";
+-		reg = <0x0180000 0x0080000>;
+-	};
+-	partition@200000 {
+-		label = "info";
+-		reg = <0x0200000 0x0080000>;
+-	};
+-	partition@280000 {
+-		label = "etc";
+-		reg = <0x0280000 0x0a00000>;
+-	};
+-	partition@c80000 {
+-		label = "kernel_1";
+-		reg = <0x0c80000 0x0a00000>;
+-	};
+-	partition@1680000 {
+-		label = "rootfs1";
+-		reg = <0x1680000 0x2fc0000>;
+-	};
+-	partition@4640000 {
+-		label = "kernel_2";
+-		reg = <0x4640000 0x0a00000>;
+-	};
+-	partition@5040000 {
+-		label = "rootfs2";
+-		reg = <0x5040000 0x2fc0000>;
++	partition@140000 {
++		label = "ubi";
++		reg = <0x0140000 0x7ec0000>;
+ 	};
+ };

--- a/target/linux/kirkwood/patches-4.4/191-nsa310b.patch
+++ b/target/linux/kirkwood/patches-4.4/191-nsa310b.patch
@@ -1,0 +1,169 @@
+kirkwood: add nsa310b dtb, a zyxel nsa310 variant
+
+add support to a nsa310 variant with red/green usb led
+and lm85 temp/fan controller
+
+Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>
+
+NOTE: this patch can be upstreamed as-is, LEDE-specific
+		nand partitions are set in another patch
+
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -203,6 +203,7 @@ dtb-$(CONFIG_MACH_KIRKWOOD) += \
+ 	kirkwood-ns2mini.dtb \
+ 	kirkwood-nsa310.dtb \
+ 	kirkwood-nsa310a.dtb \
++	kirkwood-nsa310b.dtb \
+ 	kirkwood-openblocks_a6.dtb \
+ 	kirkwood-openblocks_a7.dtb \
+ 	kirkwood-openrd-base.dtb \
+--- /dev/null
++++ b/arch/arm/boot/dts/kirkwood-nsa310b.dts
+@@ -0,0 +1,146 @@
++/dts-v1/;
++
++#include "kirkwood-nsa3x0-common.dtsi"
++
++/*
++ * There are at least two different NSA310 designs. This variant has
++ * a red/green USB Led (same as nsa310) and a lm85 temp/fan controller.
++ */
++
++/ {
++	model = "ZyXEL NSA310b";
++	compatible = "zyxel,nsa310a", "zyxel,nsa310", "marvell,kirkwood-88f6281", "marvell,kirkwood";
++
++	memory {
++		device_type = "memory";
++		reg = <0x00000000 0x10000000>;
++	};
++
++	chosen {
++		bootargs = "console=ttyS0,115200";
++		stdout-path = "&uart0";
++	};
++
++	mbus {
++		pcie-controller {
++			status = "okay";
++
++			pcie@1,0 {
++				status = "okay";
++			};
++		};
++	};
++
++	ocp@f1000000 {
++		pinctrl: pin-controller@10000 {
++			pinctrl-0 = <&pmx_unknown>;
++			pinctrl-names = "default";
++
++			pmx_led_esata_green: pmx-led-esata-green {
++				marvell,pins = "mpp12";
++				marvell,function = "gpio";
++			};
++
++			pmx_led_esata_red: pmx-led-esata-red {
++				marvell,pins = "mpp13";
++				marvell,function = "gpio";
++			};
++
++			pmx_led_usb_green: pmx-led-usb-green {
++				marvell,pins = "mpp15";
++				marvell,function = "gpio";
++			};
++
++			pmx_led_usb_red: pmx-led-usb-red {
++				marvell,pins = "mpp16";
++				marvell,function = "gpio";
++			};
++
++			pmx_led_sys_green: pmx-led-sys-green {
++				marvell,pins = "mpp28";
++				marvell,function = "gpio";
++			};
++
++			pmx_led_sys_red: pmx-led-sys-red {
++				marvell,pins = "mpp29";
++				marvell,function = "gpio";
++			};
++
++			pmx_led_hdd_green: pmx-led-hdd-green {
++				marvell,pins = "mpp41";
++				marvell,function = "gpio";
++			};
++
++			pmx_led_hdd_red: pmx-led-hdd-red {
++				marvell,pins = "mpp42";
++				marvell,function = "gpio";
++			};
++
++			pmx_unknown: pmx-unknown {
++				marvell,pins = "mpp44";
++				marvell,function = "gpio";
++			};
++
++		};
++
++		i2c@11000 {
++			status = "okay";
++
++			lm85@2e {
++				compatible = "national,lm85";
++				reg = <0x2e>;
++			};
++		};
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++		pinctrl-0 = <&pmx_led_esata_green &pmx_led_esata_red
++			     &pmx_led_usb_green &pmx_led_usb_red
++			     &pmx_led_sys_green &pmx_led_sys_red
++			     &pmx_led_copy_green &pmx_led_copy_red
++			     &pmx_led_hdd_green &pmx_led_hdd_red>;
++		pinctrl-names = "default";
++
++		green-sys {
++			label = "nsa310:green:sys";
++			gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
++		};
++		red-sys {
++			label = "nsa310:red:sys";
++			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
++		};
++		green-hdd {
++			label = "nsa310:green:hdd";
++			gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
++		};
++		red-hdd {
++			label = "nsa310:red:hdd";
++			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
++		};
++		green-esata {
++			label = "nsa310:green:esata";
++			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
++		};
++		red-esata {
++			label = "nsa310:red:esata";
++			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
++		};
++		green-usb {
++			label = "nsa310:green:usb";
++			gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
++		};
++		red-usb {
++			label = "nsa310:red:usb";
++			gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
++		};
++		green-copy {
++			label = "nsa310:green:copy";
++			gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
++		};
++		red-copy {
++			label = "nsa310:red:copy";
++			gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
++		};
++	};
++};

--- a/target/linux/kirkwood/patches-4.4/192-nsa310s.patch
+++ b/target/linux/kirkwood/patches-4.4/192-nsa310s.patch
@@ -1,3 +1,13 @@
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -204,6 +204,7 @@ dtb-$(CONFIG_MACH_KIRKWOOD) += \
+ 	kirkwood-nsa310.dtb \
+ 	kirkwood-nsa310a.dtb \
+ 	kirkwood-nsa310b.dtb \
++	kirkwood-nsa310s.dtb \
+ 	kirkwood-openblocks_a6.dtb \
+ 	kirkwood-openblocks_a7.dtb \
+ 	kirkwood-openrd-base.dtb \
 --- /dev/null
 +++ b/arch/arm/boot/dts/kirkwood-nsa310s.dts
 @@ -0,0 +1,287 @@
@@ -288,13 +298,3 @@
 +		phy-handle = <&ethphy0>;
 +	};
 +};
---- a/arch/arm/boot/dts/Makefile
-+++ b/arch/arm/boot/dts/Makefile
-@@ -203,6 +203,7 @@ dtb-$(CONFIG_MACH_KIRKWOOD) += \
- 	kirkwood-ns2mini.dtb \
- 	kirkwood-nsa310.dtb \
- 	kirkwood-nsa310a.dtb \
-+	kirkwood-nsa310s.dtb \
- 	kirkwood-openblocks_a6.dtb \
- 	kirkwood-openblocks_a7.dtb \
- 	kirkwood-openrd-base.dtb \


### PR DESCRIPTION
kirkwood: add ZyXEL NSA310b

The ZyXEL NSA310 device is a Kirkwood based NAS:

- SoC: Marvell 88F6702 1200Mhz
- SDRAM memory: 256MB DDR2 400Mhz
- Gigabit ethernet: Realtek (over pcie)
- Flash memory: 128MB
- 1 Power button
- 1 Power LED (blue)
- 5 Status LED (green/red)
- 1 Copy/Sync button
- 1 Reset button
- 2 SATA II port (1 internal and 1 external)
- 2 USB 2.0 ports (1 front and 1 back)
- Smart fan

The stock u-boot cannot read ubi so it should be replaced with the
LEDE/OpenWRT's u-boot or with a u-boot from here
https://github.com/mibodhi/u-boot-kirkwood

This device's boot ROM supports "kwboot" tool
(in mainline u-boot, built automatically if CONFIG_KIRKWOOD is declared)
that sends an uboot image to the board over serial connection, it is very easy to unbrick.

The stock bootloader can use usb and read from FAT filesystems,
so the installation process is simple, place the uboot file on a USB flashdrive
formatted as FAT (here it is "openwrt-kirkwood-nsa310.bin", then connect TTL
to the board and write the following commands in the bootloader console:

usb reset
fatload usb 0 0x1000000 openwrt-kirkwood-nsa310.bin
nand write 0x1000000 0x00000 0x100000
reset

Now you are rebooting in the new u-boot, write this in its console to install the firmware:

usb reset
fatload usb 0 0x2000000 lede-kirkwood-nsa310b-squashfs-factory.bin
nand erase.part ubi
nand write 0x2000000 ubi 0x600000

If your firmware file is bigger than 6 MiBs you should write its size in hex
instead of 0x600000 above, or remove that number entirely (it will take a while in this case).

If you are using another uboot that can read ubi, set mtdparts like this

mtdparts=mtdparts=orion_nand:0x100000(uboot),0x80000(uboot_env),0x100000(second_stage_uboot),0x7b80000(ubi)

And set your bootcmd to be like this

bootcmd=run setenv bootargs; ubi part ubi; ubi read 0x800000 kernel; bootm 0x800000

Then you can install the firmware as described above.

After you installed (or configured) the u-boot for booting the firmware,
write the device's mac address in the ethaddr u-boot env.
The MAC address is usually on a sticker under the device (one of the two codes is the serial),
it should begin with "107BEF" as it is assigned to ZyXEL.

write in the u-boot console (use your MAC address instead of the example)

setenv ethaddr 10:7B:EF:00:00:00
saveenv

to save the mac address in the u-boot.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>