### PR TITLE
mbedtls: Enable CFB, RC4 and Camellia

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
 PKG_VERSION:=2.4.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-gpl.tgz

--- a/package/libs/mbedtls/patches/200-config.patch
+++ b/package/libs/mbedtls/patches/200-config.patch
@@ -9,15 +9,6 @@
  
  /* \} name SECTION: System support */
  
-@@ -347,7 +347,7 @@
-  *
-  * Enable Cipher Feedback mode (CFB) for symmetric ciphers.
-  */
--#define MBEDTLS_CIPHER_MODE_CFB
-+//#define MBEDTLS_CIPHER_MODE_CFB
- 
- /**
-  * \def MBEDTLS_CIPHER_MODE_CTR
 @@ -441,17 +441,17 @@
   *
   * Comment macros to disable the curve and functions for it
@@ -174,24 +165,6 @@
  
  /**
   * \def MBEDTLS_X509_ALLOW_EXTENSIONS_NON_V3
-@@ -1501,7 +1501,7 @@
-  *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
-  *      MBEDTLS_TLS_PSK_WITH_RC4_128_SHA
-  */
--#define MBEDTLS_ARC4_C
-+//#define MBEDTLS_ARC4_C
- 
- /**
-  * \def MBEDTLS_ASN1_PARSE_C
-@@ -1621,7 +1621,7 @@
-  *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
-  *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
-  */
--#define MBEDTLS_CAMELLIA_C
-+//#define MBEDTLS_CAMELLIA_C
- 
- /**
-  * \def MBEDTLS_CCM_C
 @@ -1635,7 +1635,7 @@
   * This module enables the AES-CCM ciphersuites, if other requisites are
   * enabled as well.


### PR DESCRIPTION
Enable Cipher Feedback mode (CFB), RC4 and Camellia as these
are required by some packages such as upstream shadowsocks-libev.

These changes makes the IPK package about 6kbyte larger on ar71xx.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>