### PR TITLE
base-files: fix message of initscript wrapper

### DIFF
--- a/package/base-files/files/etc/profile
+++ b/package/base-files/files/etc/profile
@@ -44,7 +44,7 @@ fi
 
 service() {
 	[ -f "/etc/init.d/$1" ] || {
-		echo -n "$1 does not exist. the following services are available :"
+		echo "service "'"'"$1"'"'" not found, the following services are available:"
 		ls "/etc/init.d"
 		return 1
 	}


### PR DESCRIPTION
currently (after blogic's edit to my commit) it prints like this:

```
root@lede:/# service aa
aa does not exist. the following services are available :adblock       dnsmasq       gpio_switch   rpcd          system
boot          done          led           sqm           uhttpd
crelay        dropbear      log           sysctl        umount
cron          firewall      network       sysfixtime    urandom_seed
ddns          fstab         odhcpd        sysntpd
```

which looks pretty bad, and is even worse if someone writes only "service" without arguments, as it will print " does not exist. ...etc" which is confusing.

with this commit it looks like this:

```
root@lede:/# service
service "" not found, the following services are available:
adblock       dnsmasq       gpio_switch   rpcd          system
boot          done          led           sqm           uhttpd
crelay        dropbear      log           sysctl        umount
cron          firewall      network       sysfixtime    urandom_seed
ddns          fstab         odhcpd        sysntpd
```

Yes there is some play with " and ', it is to display "name" or just "" if no service name is entered (like in the example).

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>