### PR TITLE
bnx2 driver support for the x86 architecture.

### DIFF
--- a/package/firmware/linux-firmware/broadcom.mk
+++ b/package/firmware/linux-firmware/broadcom.mk
@@ -64,3 +64,12 @@ define Package/brcmsmac-firmware/install
 		$(1)/lib/firmware/brcm/
 endef
 $(eval $(call BuildPackage,brcmsmac-firmware))
+
+Package/bnx2-firmware = $(call Package/firmware-default,Broadcom BCM5706/5708/5709/5716 firmware)
+define Package/bnx2-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/bnx2
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/bnx2/* \
+		$(1)/lib/firmware/bnx2/
+endef
+$(eval $(call BuildPackage,bnx2-firmware))

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -902,3 +902,19 @@ define KernelPackage/ethoc/description
 endef
 
 $(eval $(call KernelPackage,ethoc))
+
+
+define KernelPackage/bnx2
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=BCM5706/5708/5709/5716 ethernet adapter driver
+  DEPENDS:=@PCI_SUPPORT +bnx2-firmware
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/broadcom/bnx2.ko
+  KCONFIG:=CONFIG_BNX2
+  AUTOLOAD:=$(call AutoProbe,bnx2)
+endef
+
+define KernelPackage/bnx2/description
+  Kernel module for the BCM5706/5708/5709/5716 ethernet adapter
+endef
+
+$(eval $(call KernelPackage,bnx2))


### PR DESCRIPTION
Module and firmware packages for Broadcom BCM5706/5708/5709/5716 ethernet adapters.

Signed-off-by: gamanakis <g_amanakis@yahoo.com>