### PR TITLE
libnl: Update to 3.2.29

### DIFF
--- a/package/libs/libnl/Makefile
+++ b/package/libs/libnl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnl
-PKG_VERSION:=3.2.28
+PKG_VERSION:=3.2.29
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/thom311/libnl/releases/download/libnl3_2_28
-PKG_HASH:=cd608992c656e8f6e3ab6c1391b162a5a51c49336b9219f7f390e61fc5437c41
+PKG_SOURCE_URL:=https://github.com/thom311/libnl/releases/download/libnl3_2_29
+PKG_HASH:=0beb593dc6abfffa18a5c787b27884979c1b7e7f1fd468c801e3cc938a685922
 PKG_LICENSE:=LGPL-2.1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Update libnl to 3.2.29

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>