### PR TITLE
x86: add kernel module for AMD CS5535/CS5536 audio chipset

### DIFF
--- a/target/linux/x86/modules.mk
+++ b/target/linux/x86/modules.mk
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2017 Cezary Jackiewicz <cezary@eko.one.pll>
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+define KernelPackage/sound-cs5535audio
+  TITLE:=CS5535/CS5536 Audio Controller
+  DEPENDS:=@TARGET_x86_geode +kmod-ac97
+  KCONFIG:=CONFIG_SND_CS5535AUDIO
+  FILES:=$(LINUX_DIR)/sound/pci/cs5535audio/snd-cs5535audio.ko
+  AUTOLOAD:=$(call AutoLoad,36,snd-cs5535audio)
+  $(call AddDepends/sound)
+endef
+
+define KernelPackage/sound-cs5535audio/description
+ Support for the integrated AC97 sound device on motherboards
+ with AMD CS5535/CS5536 chipsets.
+endef
+
+$(eval $(call KernelPackage,sound-cs5535audio))


### PR DESCRIPTION
Add support for the integrated AC97 sound device on motherboards
with AMD CS5535/CS5536 chipsets.
Tested on Wyse Winterm S30.

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>