### PR TITLE
build: add devel option to store build config in firmware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,10 @@ diffconfig: FORCE
 	$(SCRIPT_DIR)/diffconfig.sh > $(BIN_DIR)/config.seed
 
 prepare: .config $(tools/stamp-compile) $(toolchain/stamp-compile)
+	$(_SINGLE)$(SUBMAKE) -r diffconfig
+
 world: prepare $(target/stamp-compile) $(package/stamp-compile) $(package/stamp-install) $(target/stamp-install) FORCE
 	$(_SINGLE)$(SUBMAKE) -r package/index
-	$(_SINGLE)$(SUBMAKE) -r diffconfig
 	$(_SINGLE)$(SUBMAKE) -r checksum
 
 .PHONY: clean dirclean prereq prepare world package/symlinks package/symlinks-install package/symlinks-clean

--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -67,6 +67,12 @@ menu "Global build settings"
 		  This removes all ipkg/opkg status data files from the target directory
 		  before building the root filesystem.
 
+	config INCLUDE_CONFIG
+		bool "Include build configuration in firmware" if DEVEL
+		default n
+		help
+		  If enabled, config.seed will be stored in /etc/build.config of firmware.
+
 	config COLLECT_KERNEL_DEBUG
 		bool
 		prompt "Collect kernel debug information"

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -168,6 +168,10 @@ define Package/base-files/install
 				echo "$$$${conffile##$(1)}" >> $(1)/CONTROL/conffiles; \
 		fi \
 	done
+
+	$(if $(CONFIG_INCLUDE_CONFIG), \
+		echo -e "# Build configuration for board $(BOARD)/$(SUBTARGET)/$(PROFILE)\n" >$(1)/etc/build.config; \
+		cat $(BIN_DIR)/config.seed >>$(1)/etc/build.config)
 endef
 
 ifneq ($(DUMP),1)


### PR DESCRIPTION
Store cleaned .config in /etc/build.config

This developer option simplifies to recompile custom image as it only required to extract config from firmware and build a new one.

Signed-off-by: Vitaly Chekryzhev <13hakta@gmail.com>