### PR TITLE
Makefile: ensure that BIN_DIR exists for diffconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ checksum: FORCE
 	$(call sha256sums,$(BIN_DIR))
 
 diffconfig: FORCE
+	mkdir -p $(BIN_DIR)
 	$(SCRIPT_DIR)/diffconfig.sh > $(BIN_DIR)/config.seed
 
 prepare: .config $(tools/stamp-install) $(toolchain/stamp-install)


### PR DESCRIPTION
Ensure that BIN_DIR exists when the diffconfig target needs it. Otherwise 'make diffconfig' fails after 'make clean'

The error can be generated just by running ` make clean ; make diffconfig `

I noticed the problem when evaluating PR #673 .  Normal make would fail when run after "make clean", because after #673 the diffconfig target was run before the BIN_DIR is created in the make process.

My change adds a mkdir to diffconfig target in order to ensure that it can be run also after make clean.

Before this patch:
```
perus@u1610:/xxx/lede$ make clean
 make[1] clean
perus@u1610:/xxx/lede$ make diffconfig V=s
make[1]: Entering directory '/xxx/lede'
/xxx/lede/scripts/diffconfig.sh > /xxx/lede/bin/targets/ar71xx/generic/config.seed
bash: /xxxt/lede/bin/targets/ar71xx/generic/config.seed: No such file or directory
Makefile:91: recipe for target 'diffconfig' failed
make[1]: *** [diffconfig] Error 1
```

After this patch:
```
perus@u1610:/xxx/lede$ make clean
 make[1] clean
perus@u1610:/xxx/lede$ make diffconfig V=s
make[1]: Entering directory '/xxx/lede'
mkdir -p /xxx/lede/bin/targets/ar71xx/generic
/xxx/lede/scripts/diffconfig.sh > /xxx/lede/bin/targets/ar71xx/generic/config.seed
make[1]: Leaving directory '/Openwrt/lede'
```

