### PR TITLE
Fix dependency for hostapd

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -242,7 +242,7 @@ define Package/eapol-test
   SECTION:=net
   CATEGORY:=Network
   VARIANT:=supplicant-full
-  DEPENDS:=$(DRV_DEPENDS)
+  DEPENDS:=$(DRV_DEPENDS) +WPA_SUPPLICANT_OPENSSL:libopenssl
 endef
 
 


### PR DESCRIPTION
Fix hostapd dependencies leading to a build failure when building eapol_test.

Signed-off-by: Wilco Baan Hofman <wilco@baanhofman.nl>