### PR TITLE
ar71xx: fix network config for Mikrotik RB411U

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -84,6 +84,7 @@ ar71xx_setup_interfaces()
 	mr900v2|\
 	mynet-rext|\
 	rb-411|\
+	rb-411u|\
 	rb-911g-2hpnd|\
 	rb-911g-5hpacd|\
 	rb-911g-5hpnd|\


### PR DESCRIPTION
Mikrotik RB411U has only one ethernet port - eth0. This patch allows to create
correct config with one lan section.

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>