### PR TITLE
ramips: Added Onion Omega2 and Omega2+

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -53,6 +53,8 @@ ramips_setup_interfaces()
 	microwrt|\
 	mpr-a2|\
 	ncs601w|\
+	omega2 | \
+	omega2p | \
 	timecloud|\
 	w150m|\
 	widora-neo|\
@@ -361,6 +363,11 @@ ramips_setup_macs()
 	newifi-d1)
 		lan_mac=$(cat /sys/class/net/eth0/address)
 		lan_mac=$(macaddr_add "$lan_mac" 2)
+		;;
+	omega2|\
+	omega2p)
+		wan_mac=$(mtd_get_mac_binary factory 4)
+		lan_mac=$(mtd_get_mac_binary factory 46)
 		;;
 	oy-0001)
 		lan_mac=$(mtd_get_mac_binary factory 40)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -172,6 +172,10 @@ get_status_led() {
 	newifi-d1)
 		status_led="$board:blue:status"
 		;;
+	omega2| \
+	omega2p)
+		status_led="$board:amber:system"
+		;;
 	oy-0001|\
 	sl-r7205|\
 	zbt-we826)

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -364,6 +364,12 @@ ramips_board_detect() {
 	*"NW718")
 		name="nw718"
 		;;
+	*"Onion Omega2")
+		name="omega2"
+		;;
+	*"Onion Omega2+")
+		name="omega2p"
+		;;
 	*"OY-0001")
 		name="oy-0001"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -102,6 +102,8 @@ platform_check_image() {
 	newifi-d1|\
 	nixcore|\
 	nw718|\
+	omega2|\
+	omega2p|\
 	oy-0001|\
 	pbr-d1|\
 	pbr-m1|\

--- a/target/linux/ramips/dts/OMEGA2.dts
+++ b/target/linux/ramips/dts/OMEGA2.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+
+#include "OMEGA2.dtsi"
+
+/ {
+	model = "Onion Omega2";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+};
+
+&firmware {
+	reg = <0x50000 0xfb0000>;
+};
+
+&system_led {
+	label = "omega2:amber:system";
+};

--- a/target/linux/ramips/dts/OMEGA2.dtsi
+++ b/target/linux/ramips/dts/OMEGA2.dtsi
@@ -1,0 +1,174 @@
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "onion,omega", "mediatek,mt7628an-soc";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		system_led: system {
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "gpio";
+			ralink,function = "gpio";
+		};
+
+		perst {
+			ralink,group = "perst";
+			ralink,function = "gpio";
+		};
+
+		refclk {
+			ralink,group = "refclk";
+			ralink,function = "gpio";
+		};
+
+		i2s {
+			ralink,group = "i2s";
+			ralink,function = "gpio";
+		};
+
+		spis {
+			ralink,group = "spis";
+			ralink,function = "gpio";
+		};
+
+		wled_kn {
+			ralink,group = "wled_kn";
+			ralink,function = "gpio";
+		};
+
+		wled_an {
+			ralink,group = "wled_an";
+			ralink,function = "gpio";
+		};
+
+		wdt {
+			ralink,group = "wdt";
+			ralink,function = "gpio";
+		};
+
+		pwm0 {
+			ralink,group = "pwm0";
+			ralink,function = "gpio";
+		};
+
+		pwm1 {
+			ralink,group = "pwm1";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+		m25p,chunked-io = <31>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		firmware: partition@50000 {
+			label = "firmware";
+		};
+	};
+
+	spidev@1 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "linux,spidev";
+		reg = <1>;
+		spi-max-frequency = <40000000>;
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&sdhci {
+	status = "okay";
+	mediatek,cd-low;
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/dts/OMEGA2P.dts
+++ b/target/linux/ramips/dts/OMEGA2P.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+
+#include "OMEGA2.dtsi"
+
+/ {
+	model = "Onion Omega2+";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+};
+
+&firmware {
+	reg = <0x50000 0x1fb0000>;
+};
+
+&system_led {
+	label = "omega2p:amber:system";
+};

--- a/target/linux/ramips/image/mt7688.mk
+++ b/target/linux/ramips/image/mt7688.mk
@@ -34,3 +34,19 @@ define Device/widora-neo
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += widora-neo
+
+define Device/omega2
+  DTS := OMEGA2
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Onion Omega2
+  DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools
+endef
+TARGET_DEVICES += omega2
+
+define Device/omega2p
+  DTS := OMEGA2P
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DEVICE_TITLE := Onion Omega2+
+  DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools kmod-sdhci-mt7620
+endef
+TARGET_DEVICES += omega2p


### PR DESCRIPTION
*Updated with amended commit on Jan 13*
This patch adds support for the Onion Omega2 and Omega2+ (https://onion.io)

Specifications:
- SoC: MediaTek MT7688AN (580MHz, ramips)
- Omega2
  - RAM: 64MB DDR
  - Storage: 16MB NOR SPI flash onboard
- Omega2+
  - RAM: 128MB DDR
  - Storage: 32MB NOR SPI flash onboard + microSD slot
- Wireless: Built into MT7688AN (mt76) with onboard 1x chip antenna and u.FL connecter
- Ethernet: 1x100M pins on Omega2 & Omega2+, can use Ethernet Expansion and an Omega Dock to get a physical Ethernet port
- Strongly recommend using the Omega2 & Omega2+ with a Dock (Expansion Dock, Power Dock, Arduino Dock 2, Mini Dock)
  - All Docks Provide:
    - Micro-USB port to provide power to the Omega
      - On the Expansion and Mini Docks, can also access the terminal (UART0) via serial
    - USB 2.0 socket connected to Omega
  - Just the Expansion Dock, Power Dock, and Arduino Dock 2 provide:
    - Omega GPIO breakout
    - Allows for connection of Omega Expansions:
      - Ethernet Expansion
      - Relay Expansion
      - PWM Expansion
      - OLED Expansion
      - Ethernet Expansion
      - Proto Expansion
      - Cellular Expansion

Signed-off-by: Lazar Demin <lazar@onion.io>