### PR TITLE
ramips: adding 3g led in dwr-512 uci-default

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -163,6 +163,9 @@ vr500)
 dir-860l-b1)
 	ucidef_set_led_netdev "wan" "wan" "$board:green:net" "eth0.2"
 	;;
+dwr-512-b)
+	ucidef_set_led_netdev "wan3g" "wan3g" "$board:green:3g" "usb0"
+	;;
 ex2700|\
 wn3000rpv3)
 	ucidef_set_led_default "power_r" "POWER (red)" "$board:red:power" "0"


### PR DESCRIPTION
The dwr-512 has an embedded 3g modem.
This patch enable by default the netdev trigger on the 3G front panel
led linked to the 3g network interface.

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>