### PR TITLE
build: introduce default HOST_MAKE_VARS for host-builds

### DIFF
--- a/include/host-build.mk
+++ b/include/host-build.mk
@@ -67,6 +67,11 @@ HOST_CONFIGURE_ARGS = \
 	--localstatedir=$(HOST_BUILD_PREFIX)/var \
 	--sbindir=$(HOST_BUILD_PREFIX)/bin
 
+HOST_MAKE_VARS = \
+	CFLAGS="$(HOST_CFLAGS)" \
+	CXXFLAGS="$(HOST_CPPFLAGS)" \
+	LDFLAGS="$(HOST_LDFLAGS)"
+
 HOST_MAKE_FLAGS =
 
 HOST_CONFIGURE_CMD = $(BASH) ./configure
@@ -89,7 +94,8 @@ define Host/Configure
 endef
 
 define Host/Compile/Default
-	+$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) \
+	+$(HOST_MAKE_VARS) \
+	$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) \
 		$(HOST_MAKE_FLAGS) \
 		$(1)
 endef


### PR DESCRIPTION
Inspired/adapted from `package-defaults.mk` MAKE_VARS.

Build tested on Mac & Linux.
On hash: 593240075f8d3074164ffce99ab67a88277f9fb3

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>