### PR TITLE
tools/qemu: use default host configure rule ; set appropriate vars & args

### DIFF
--- a/tools/qemu/Makefile
+++ b/tools/qemu/Makefile
@@ -18,15 +18,13 @@ include $(INCLUDE_DIR)/host-build.mk
 
 HOST_CFLAGS += -I$(STAGING_DIR_HOST)/include/e2fsprogs
 
-define Host/Configure
-	(cd $(HOST_BUILD_DIR); \
-		CFLAGS="$(HOST_CFLAGS)" \
-		LDFLAGS="$(HOST_LDFLAGS)" \
-		$(HOST_CONFIGURE_CMD) \
-		--extra-cflags="$(HOST_CFLAGS)" \
-		--enable-uuid \
-	)
-endef
+HOST_CONFIGURE_VARS := \
+	CFLAGS="$(HOST_CFLAGS)" \
+	LDFLAGS="$(HOST_LDFLAGS)"
+
+HOST_CONFIGURE_ARGS := \
+	--extra-cflags="$(HOST_CFLAGS)" \
+	--enable-uuid
 
 define Host/Compile
 	$(MAKE) -C $(HOST_BUILD_DIR) qemu-img


### PR DESCRIPTION
Admittedly, this is my own OCD wanting to get rid of this.

Because I tried (a while back to upgrade QEMU to a newer version),
and (during that attempt) I tried to get rid of this.

Tested on Linux & Mac.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>