### PR TITLE
tools/cmake: remove HOST_CONFIGURE_CMD and re-distribute the args & vars

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -19,15 +19,12 @@ HOST_CONFIGURE_PARALLEL:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 
-HOST_CONFIGURE_CMD := \
-	MAKEFLAGS="$(HOST_JOBS)" \
-	$(BASH) ./configure \
-		$(if $(MAKE_JOBSERVER),--parallel="$(MAKE_JOBSERVER)")
-
 HOST_CONFIGURE_VARS += \
+	MAKEFLAGS="$(HOST_JOBS)" \
 	CXXFLAGS="$(HOST_CFLAGS)"
 
 HOST_CONFIGURE_ARGS := \
+	$(if $(MAKE_JOBSERVER),--parallel="$(MAKE_JOBSERVER)") \
 	--prefix=$(STAGING_DIR_HOST)
 
 ifneq ($(findstring c,$(OPENWRT_VERBOSE)),)


### PR DESCRIPTION
The final semantic is the same, but this is a bit more correct.

Build tested on Windows 10 (yes, there is some
Ubuntu mode for Windows 10, and I've been also building LEDE
on it for a few weeks).

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>