### PR TITLE
dnsmasq: use ubus signalling in ntp hotplug script

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasqsec.hotplug
+++ b/package/network/services/dnsmasq/files/dnsmasqsec.hotplug
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. /lib/functions/procd.sh
+
 TIMEVALIDFILE="/var/state/dnsmasqsec"
 
 [ "$ACTION" = stratum ] || exit 0
@@ -7,8 +9,6 @@ TIMEVALIDFILE="/var/state/dnsmasqsec"
 [ -f "$TIMEVALIDFILE" ] || {
 	echo "ntpd says time is valid" >$TIMEVALIDFILE
 	/etc/init.d/dnsmasq enabled && {
-		pid=$(pidof dnsmasq)
-		[ "$(readlink /proc/$pid/exe)" = "/usr/sbin/dnsmasq" ] && kill -SIGHUP $pid \
-		|| /etc/init.d/dnsmasq restart
+		procd_send_signal dnsmasq
 	}
 }


### PR DESCRIPTION
Use ubus process signalling instead of 'kill pidof dnsmasq' for
SIGHUP signalling to dnsmasq when ntp says time is valid.

Compile & run tested: ar71xx Archer C7 v2

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>