### PR TITLE
mvebu: set fan_ctrl.sh only on mamba

### DIFF
--- a/target/linux/mvebu/base-files/etc/crontabs/root
+++ b/target/linux/mvebu/base-files/etc/crontabs/root
@@ -1,1 +1,0 @@
-*/5 * * * * /sbin/fan_ctrl.sh

--- a/target/linux/mvebu/base-files/etc/uci-defaults/04_mambafan
+++ b/target/linux/mvebu/base-files/etc/uci-defaults/04_mambafan
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Copyright (C) 2017 LEDE-Project.org
+#
+
+. /lib/mvebu.sh
+
+board=$(mvebu_board_name)
+
+case "$board" in
+armada-xp-linksys-mamba)
+        # Set one execution of the fan script during every start (waiting for cron)
+        echo "/sbin/fan_ctrl.sh" > /etc/rc.local
+        # Set fan script execution in crontab
+        echo "# mamba fan script runs every 5 minutes" >> /etc/crontabs/root
+        echo "*/5 * * * * /sbin/fan_ctrl.sh" >> /etc/crontabs/root
+        # Execute one time after initial flash (instead of waiting 5 min for cron)
+        /sbin/fan_ctrl.sh
+    ;;
+*)
+esac
+
+exit 0

--- a/target/linux/mvebu/base-files/etc/uci-defaults/04_mambafan
+++ b/target/linux/mvebu/base-files/etc/uci-defaults/04_mambafan
@@ -10,10 +10,20 @@ board=$(mvebu_board_name)
 case "$board" in
 armada-xp-linksys-mamba)
         # Set one execution of the fan script during every start (waiting for cron)
-        echo "/sbin/fan_ctrl.sh" > /etc/rc.local
+        if grep -q fan_ctrl.sh /etc/rc.local
+                then
+                        exit 0
+                else
+                        echo "/sbin/fan_ctrl.sh" > /etc/rc.local
+        fi                        
         # Set fan script execution in crontab
-        echo "# mamba fan script runs every 5 minutes" >> /etc/crontabs/root
-        echo "*/5 * * * * /sbin/fan_ctrl.sh" >> /etc/crontabs/root
+        if grep -q fan_ctrl.sh /etc/crontabs/root
+                then
+                        exit 0
+                else
+                        echo "# mamba fan script runs every 5 minutes" >> /etc/crontabs/root
+                        echo "*/5 * * * * /sbin/fan_ctrl.sh" >> /etc/crontabs/root
+        fi
         # Execute one time after initial flash (instead of waiting 5 min for cron)
         /sbin/fan_ctrl.sh
     ;;


### PR DESCRIPTION
Simple replacement of the default fan_ctrl.sh crontab for all mvebu devices (with or without fans). 
Instead we will create this cron job only on the mamba device.

Signed-off-by: Hans Geiblinger <cybrnook2002yahoo.com>