### PR TITLE
mvebu: set fan_ctrl.sh only on mamba

### DIFF
--- a/target/linux/mvebu/base-files/etc/crontabs/root
+++ b/target/linux/mvebu/base-files/etc/crontabs/root
@@ -1,1 +1,0 @@
-*/5 * * * * /sbin/fan_ctrl.sh

--- a/target/linux/mvebu/base-files/etc/uci-defaults/04_mambafan
+++ b/target/linux/mvebu/base-files/etc/uci-defaults/04_mambafan
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Copyright (C) 2017 LEDE-Project.org
+#
+
+. /lib/mvebu.sh
+
+board=$(mvebu_board_name)
+
+case "$board" in
+armada-xp-linksys-mamba)
+        # Set fan script execution in crontab
+        if grep -s -q fan_ctrl.sh /etc/crontabs/root
+                then
+                        exit 0
+                else
+                        echo "# mamba fan script runs every 5 minutes" >> /etc/crontabs/root
+                        echo "*/5 * * * * /sbin/fan_ctrl.sh" >> /etc/crontabs/root
+        fi
+        # Execute one time after initial flash (instead of waiting 5 min for cron)
+        /sbin/fan_ctrl.sh
+    ;;
+*)
+esac
+
+exit 0


### PR DESCRIPTION
Simple replacement of the default fan_ctrl.sh crontab for all mvebu devices (with or without fans).
Instead we will create this cron job only on the mamba device.

Signed-off-by: Hans Geiblinger <cybrnook2002yahoo.com>