### PR TITLE
ramips: simplify EX2700 network config

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -172,8 +172,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "9@eth0"
 		;;
-	cf-wr800n|\
-	ex2700)
+	cf-wr800n)
 		ucidef_add_switch "switch0" \
 			"4:lan" "6t@eth0"
 		;;
@@ -184,6 +183,7 @@ ramips_setup_interfaces()
 	cs-qr10|\
 	d105|\
 	dch-m225|\
+	ex2700|\
 	hpm|\
 	mzk-ex300np|\
 	mzk-ex750np|\


### PR DESCRIPTION
Don't create a vlan for the Netgear EX2700's only Ethernet port.

Signed-off-by: Joseph C. Lehner <joseph.c.lehner@gmail.com>