### PR TITLE
fstools: Only block mount on fstab restart

### DIFF
--- a/package/system/fstools/Makefile
+++ b/package/system/fstools/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fstools
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(LEDE_GIT)/project/fstools.git

--- a/package/system/fstools/files/fstab.init
+++ b/package/system/fstools/files/fstab.init
@@ -11,6 +11,15 @@ start() {
 	echo "this file has been obsoleted. please call \"/sbin/block mount\" directly"
 }
 
+restart() {
+	start
+}
+
+# Block umount on LuCI apply does bad things
+reload() {
+	/sbin/block mount
+}
+
 stop() {
 	/sbin/block umount
 }


### PR DESCRIPTION
On systems using external storage (not extroot) with
block-mount, bad behaviour occurs when the fstab LuCI
app commits a change because this calls
/etc/init.d/fstab restart which does a block umount,
which can result in problematic unmounts.

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>