### PR TITLE
wwan: adding 3G rssi led indication

### DIFF
--- a/package/network/utils/wwan/Makefile
+++ b/package/network/utils/wwan/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wwan
-PKG_VERSION:=2014-07-17
-PKG_RELEASE=1
+PKG_VERSION:=2017-01-14
+PKG_RELEASE=1.1
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=
@@ -24,6 +24,8 @@ endef
 define Package/wwan/install
 	$(INSTALL_DIR) $(1)/lib/netifd/proto/
 	$(CP) ./files/wwan.sh $(1)/lib/netifd/proto/
+	$(INSTALL_DIR) $(1)/bin/
+	$(INSTALL_BIN) ./files/set_3g_rssi_led.sh $(1)/bin/
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/usb
 	$(INSTALL_BIN) ./files/wwan.usb $(1)/etc/hotplug.d/usb/00_wwan.sh
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/usbmisc

--- a/package/network/utils/wwan/files/set_3g_rssi_led.sh
+++ b/package/network/utils/wwan/files/set_3g_rssi_led.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+
+. /lib/ramips.sh
+
+set_led_rssi_off() {
+	case $board in
+	dwr-512-b)
+		echo '0' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
+		echo '0' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+		;;
+	esac
+}
+set_led_rssi_1() {
+        case $board in
+        dwr-512-b)
+                echo '0' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
+                echo '255' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                ;;
+        esac
+}
+set_led_rssi_2() {
+        case $board in
+        dwr-512-b)
+                echo '255' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
+                echo '255' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                ;;
+        esac
+}
+set_led_rssi_3() {
+        case $board in
+        dwr-512-b)
+                echo '255' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
+                echo '128' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                ;;
+        esac
+}
+set_led_rssi_4() {
+        case $board in
+        dwr-512-b)
+                echo '255' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
+                echo '0' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                ;;
+        esac
+}
+set_led_rssi_5() {
+        case $board in
+        dwr-512-b)
+                echo '255' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
+                echo '0' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                ;;
+        esac
+}
+set_led_rssi_err() {
+        case $board in
+        dwr-512-b)
+                echo '0' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
+                echo '255' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
+                echo 'timer' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                ;;
+        esac
+}
+
+board=$(ramips_board_name)
+
+case "$1" in
+start)
+	until [ 0 -gt 1 ]; do
+		rssi3g=$(gcom -d /dev/ttyUSB0 -s /etc/gcom/getstrength.gcom|awk '/[CSQ]/ { print $2 }'|sed -e 's/,//')
+
+		if [ $rssi3g -eq 99 ]; then
+			set_led_rssi_err
+		elif [ $rssi3g -gt 24 ]; then
+			set_led_rssi_5
+		elif [ $rssi3g -gt 19 ]; then
+			set_led_rssi_4
+		elif [ $rssi3g -gt 14 ]; then
+			set_led_rssi_3
+		elif [ $rssi3g -gt 9 ]; then
+			set_led_rssi_2
+		elif [ $rssi3g -gt 1 ]; then
+			set_led_rssi_1
+		else
+			set_led_rssi_err;
+		fi
+
+		sleep 15;
+	done
+	;;
+stop)
+	set_led_rssi_off
+	;;
+test)
+	set_led_rssi_1
+	sleep 2;
+	set_led_rssi_2
+	sleep 2;
+	set_led_rssi_3
+	sleep 2;
+	set_led_rssi_4
+	sleep 2;
+	set_led_rssi_5
+	sleep 2;
+	set_led_rssi_err
+	sleep 2;
+	set_led_rssi_off
+esac
+

--- a/package/network/utils/wwan/files/set_3g_rssi_led.sh
+++ b/package/network/utils/wwan/files/set_3g_rssi_led.sh
@@ -5,65 +5,128 @@
 set_led_rssi_off() {
 	case $board in
 	dwr-512-b)
-		echo '0' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
-		echo '0' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
-                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+		echo '0' > /sys/class/leds/$board\:green\:sigstrength/brightness
+		echo '0' >   /sys/class/leds/$board\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/$board\:red\:sigstrength/trigger
+		;;
+	mr200)
+		echo '0' > /sys/class/leds/$board:white:signal1/brightness
+		echo '0' > /sys/class/leds/$board:white:signal2/brightness
+		echo '0' > /sys/class/leds/$board:white:signal3/brightness
+		echo '0' > /sys/class/leds/$board:white:signal4/brightness
+		echo 'none' > /sys/class/leds/$board:white:signal4/trigger
 		;;
 	esac
 }
 set_led_rssi_1() {
         case $board in
         dwr-512-b)
-                echo '0' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
-                echo '255' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
-                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                echo '0' > /sys/class/leds/$board\:green\:sigstrength/brightness
+                echo '255' >   /sys/class/leds/$board\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/$board\:red\:sigstrength/trigger
                 ;;
+	mr200)
+		echo '255' > /sys/class/leds/$board:white:signal1/brightness
+		echo '0' > /sys/class/leds/$board:white:signal2/brightness
+		echo '0' > /sys/class/leds/$board:white:signal3/brightness
+		echo '0' > /sys/class/leds/$board:white:signal4/brightness
+		echo 'none' > /sys/class/leds/$board:white:signal4/trigger
+		;;
         esac
 }
 set_led_rssi_2() {
         case $board in
         dwr-512-b)
-                echo '255' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
-                echo '255' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
-                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                echo '255' > /sys/class/leds/$board\:green\:sigstrength/brightness
+                echo '255' >   /sys/class/leds/$board\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/$board\:red\:sigstrength/trigger
                 ;;
+	mr200)
+		echo '255' > /sys/class/leds/$board:white:signal1/brightness
+		echo '255' > /sys/class/leds/$board:white:signal2/brightness
+		echo '0' > /sys/class/leds/$board:white:signal3/brightness
+		echo '0' > /sys/class/leds/$board:white:signal4/brightness
+		echo 'none' > /sys/class/leds/$board:white:signal4/trigger
+		;;
         esac
 }
 set_led_rssi_3() {
         case $board in
         dwr-512-b)
-                echo '255' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
-                echo '128' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
-                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                echo '255' > /sys/class/leds/$board\:green\:sigstrength/brightness
+                echo '128' >   /sys/class/leds/$board\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/$board\:red\:sigstrength/trigger
                 ;;
+	mr200)
+		echo '255' > /sys/class/leds/$board:white:signal1/brightness
+		echo '255' > /sys/class/leds/$board:white:signal2/brightness
+		echo '255' > /sys/class/leds/$board:white:signal3/brightness
+		echo '0' > /sys/class/leds/$board:white:signal4/brightness
+		echo 'none' > /sys/class/leds/$board:white:signal4/trigger
+		;;
         esac
 }
 set_led_rssi_4() {
         case $board in
         dwr-512-b)
-                echo '255' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
-                echo '0' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
-                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                echo '255' > /sys/class/leds/$board\:green\:sigstrength/brightness
+                echo '0' >   /sys/class/leds/$board\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/$board\:red\:sigstrength/trigger
                 ;;
+	mr200)
+		echo '255' > /sys/class/leds/$board:white:signal1/brightness
+		echo '255' > /sys/class/leds/$board:white:signal2/brightness
+		echo '255' > /sys/class/leds/$board:white:signal3/brightness
+		echo '255' > /sys/class/leds/$board:white:signal4/brightness
+		echo 'none' > /sys/class/leds/$board:white:signal4/trigger
+		;;
         esac
 }
 set_led_rssi_5() {
         case $board in
         dwr-512-b)
-                echo '255' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
-                echo '0' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
-                echo 'none' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                echo '255' > /sys/class/leds/$board\:green\:sigstrength/brightness
+                echo '0' >   /sys/class/leds/$board\:red\:sigstrength/brightness
+                echo 'none' >   /sys/class/leds/$board\:red\:sigstrength/trigger
                 ;;
+	mr200)
+		echo '255' > /sys/class/leds/$board:white:signal1/brightness
+		echo '255' > /sys/class/leds/$board:white:signal2/brightness
+		echo '255' > /sys/class/leds/$board:white:signal3/brightness
+		echo '255' > /sys/class/leds/$board:white:signal4/brightness
+		echo 'none' > /sys/class/leds/$board:white:signal4/trigger
+		;;
         esac
 }
 set_led_rssi_err() {
         case $board in
         dwr-512-b)
-                echo '0' > /sys/class/leds/dwr-512-b\:green\:sigstrength/brightness
-                echo '255' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/brightness
-                echo 'timer' >   /sys/class/leds/dwr-512-b\:red\:sigstrength/trigger
+                echo '0' > /sys/class/leds/$board\:green\:sigstrength/brightness
+                echo '255' >   /sys/class/leds/$board\:red\:sigstrength/brightness
+                echo 'timer' >   /sys/class/leds/$board\:red\:sigstrength/trigger
                 ;;
+	mr200)
+		echo '0' > /sys/class/leds/$board:white:signal1/brightness
+		echo '0' > /sys/class/leds/$board:white:signal2/brightness
+		echo '0' > /sys/class/leds/$board:white:signal3/brightness
+		echo '255' > /sys/class/leds/$board:white:signal4/brightness
+		echo 'timer' > /sys/class/leds/$board:white:signal4/trigger
+		;;
         esac
+}
+set_lte_led_on() {
+	case $board in
+	mr200)
+		echo '255' > /sys/class/leds/$board:white:4g/brightness
+		;;
+	esac
+}
+set_lte_led_off() {
+	case $board in
+		mr200)
+		echo '0' > /sys/class/leds/$board:white:4g/brightness
+	;;
+	esac
 }
 
 board=$(ramips_board_name)
@@ -72,6 +135,8 @@ case "$1" in
 start)
 	until [ 0 -gt 1 ]; do
 		rssi3g=$(gcom -d /dev/ttyUSB0 -s /etc/gcom/getstrength.gcom|awk '/[CSQ]/ { print $2 }'|sed -e 's/,//')
+		sleep 2
+		lte=$(gcom -d /dev/ttyUSB1 reg |awk -F[,] '/^\Registered/ {print $2}')
 
 		if [ $rssi3g -eq 99 ]; then
 			set_led_rssi_err
@@ -87,6 +152,12 @@ start)
 			set_led_rssi_1
 		else
 			set_led_rssi_err;
+		fi
+
+		if [ $lte -eq 7 ]; then
+			set_lte_led_on
+		else
+			set_lte_led_off;
 		fi
 
 		sleep 15;
@@ -107,6 +178,10 @@ test)
 	set_led_rssi_5
 	sleep 2;
 	set_led_rssi_err
+	sleep 2;
+	set_lte_led_on
+	sleep 2;
+	set_lte_led_off
 	sleep 2;
 	set_led_rssi_off
 esac

--- a/package/network/utils/wwan/files/wwan.sh
+++ b/package/network/utils/wwan/files/wwan.sh
@@ -99,6 +99,9 @@ proto_wwan_setup() {
 	comgt)		proto_3g_setup $@ ;;
 	*cdc_ncm)	proto_ncm_setup $@ ;;
 	esac
+
+	echo "Starting rssi_led_script"
+	nice -n10 set_3g_rssi_led.sh start &
 }
 
 proto_wwan_teardown() {
@@ -114,6 +117,12 @@ proto_wwan_teardown() {
 	comgt)		proto_3g_teardown $@ ;;
 	*cdc_ncm)	proto_ncm_teardown $@ ;;
 	esac
+
+	echo "Stopping rssi_led_script"
+	led_proc_id=$(ps | grep set_3g_rssi_led | awk '/start/ {print $1}')
+	echo "pid: $led_proc_id"
+	kill "$led_proc_id"
+	set_3g_rssi_led.sh stop
 }
 
 add_protocol wwan


### PR DESCRIPTION
Using this patch the system will provide the received
signal strength indication get from the the 3G modem,
driving properly the available leds.
The leds driving function is board dependent.
One example for the DWR-512 is added.

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>