### PR TITLE
ipq806x: Fix wireless support for Netgear Nighthawk X4S D7800

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -52,16 +52,17 @@ case "$FIRMWARE" in
 		ath10kcal_extract "radio" 4096 12064
 # 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary default-mac 8) -1)
 		;;
+	d7800 |\
+	r7500v2 |\
+	r7800)
+		ath10kcal_extract "art" 4096 12064
+		;;
 	ea8500)
 		hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		ath10kcal_extract "art" 4096 12064
 		;;
 	nbg6817)
 		ath10kcal_extract "0:ART" 4096 12064
-		;;
-         r7500v2 |\
-         r7800)
-		ath10kcal_extract "art" 4096 12064
 		;;
 	vr2600v)
 		ath10kcal_extract "ART" 4096 12064
@@ -74,16 +75,17 @@ case "$FIRMWARE" in
 		ath10kcal_extract "radio" 20480 12064
 # 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary default-mac 8) -2)
 		;;
+	d7800 |\
+	r7500v2 |\
+	r7800)
+		ath10kcal_extract "art" 20480 12064
+		;;
 	ea8500)
 		hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		ath10kcal_extract "art" 20480 12064
 		;;
 	nbg6817)
 		ath10kcal_extract "0:ART" 20480 12064
-		;;
-        r7500v2 |\
-        r7800)
-		ath10kcal_extract "art" 20480 12064
 		;;
 	vr2600v)
 		ath10kcal_extract "ART" 20480 12064

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -15,11 +15,13 @@ case "$board" in
 	c2600)
 		echo $(macaddr_add $(mtd_get_mac_binary default-mac 8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
 		;;
-	ea8500)
-		echo $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) $(($PHYNBR + 1)) ) > /sys${DEVPATH}/macaddress
-		;;
+	d7800 |\
+	r7500v2 |\	
 	r7800)
 		echo $(macaddr_add $(mtd_get_mac_binary art 6)  $(($PHYNBR + 1)) ) > /sys${DEVPATH}/macaddress
+		;;
+	ea8500)
+		echo $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) $(($PHYNBR + 1)) ) > /sys${DEVPATH}/macaddress
 		;;
 	vr2600v)
 		echo $(macaddr_add $(mtd_get_mac_binary default-mac 0)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
D7800 has a simular hardware to R7800 and uses dual QCA9980 for both 2.4GHz and 5GHz band.
However there is no proper initialization for them, which causes a kernel panic due to failed firmware loading.

This patch adds d7800 to ath10k caldata extraction list.
I can get two functional wireless bands after making changes to it.

Signed-off-by: Zhang Jingye <934526987@qq.com>