### PR TITLE
linux: addition of patch to allow mtd m25p80 device to reboot

### DIFF
--- a/target/linux/generic/patches-4.4/481-mtd-add-spi-flash-reset-code.patch
+++ b/target/linux/generic/patches-4.4/481-mtd-add-spi-flash-reset-code.patch
@@ -1,0 +1,25 @@
+Index: linux-4.4.40/drivers/mtd/devices/m25p80.c
+===================================================================
+--- linux-4.4.40.orig/drivers/mtd/devices/m25p80.c
++++ linux-4.4.40/drivers/mtd/devices/m25p80.c
+@@ -261,6 +261,12 @@ static int m25p_remove(struct spi_device
+ {
+ 	struct m25p	*flash = spi_get_drvdata(spi);
+ 
++	// addition for reboot: spi flash reset code
++        flash->command[0] = 0x66;
++        spi_write(flash->spi,flash->command,1);
++        flash->command[0] = 0x99;
++        spi_write(flash->spi,flash->command,1);
++
+ 	/* Clean up MTD stuff. */
+ 	return mtd_device_unregister(&flash->spi_nor.mtd);
+ }
+@@ -328,6 +334,7 @@ static struct spi_driver m25p80_driver =
+ 	.id_table	= m25p_ids,
+ 	.probe	= m25p_probe,
+ 	.remove	= m25p_remove,
++	.shutdown = m25p_remove, // addition for spi flash reset code
+ 
+ 	/* REVISIT: many of these chips have deep power-down modes, which
+ 	 * should clearly be entered on suspend() to minimize power use.


### PR DESCRIPTION
Addition of mtd driver patch for m25p80 device:
* the existing m25p_remove() function is added to the spi driver as a shutdown function
* modified the m25p_remove() function to write SPI flash reset codes before performing a shutdown

Signed-off-by: Lazar Demin <lazar@onion.io>