### PR TITLE
ramips : fix mac address of miwifi-mini

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -357,6 +357,10 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_binary factory_info 13)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
+	miwifi-mini)
+		wan_mac=$(cat /sys/class/net/eth0/address)
+		lan_mac=$(macaddr_setbit_la "$wan_mac")
+		;;
 	m3|\
 	m4|\
 	x5|\

--- a/target/linux/ramips/dts/MIWIFI-MINI.dts
+++ b/target/linux/ramips/dts/MIWIFI-MINI.dts
@@ -119,7 +119,7 @@
 &ethernet {
 	pinctrl-names = "default";
 	pinctrl-0 = <&ephy_pins>;
-	mtd-mac-address = <&factory 0x4>;
+	mtd-mac-address = <&factory 0x28>;
 	mediatek,portmap = "llllw";
 };
 


### PR DESCRIPTION
For the miwifi-mini, the offset of ethernet mac should be 0x28, which you can easyily dump from 'Factory' partition. And, add the case of miwifi-mini in ramips_setup_macs()  will make the allocation of MAC address in a more properly way.