### PR TITLE
octeon: fix mtd partitions for erlite on cmdline

### DIFF
--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -35,7 +35,7 @@ define Device/er
 endef
 TARGET_DEVICES += er
 
-ERLITE_CMDLINE:=-mtdparts=phys_mapped_flash:512k(boot0),512k(boot1),64k@1024k(eeprom) root=/dev/sda2 rootfstype=squashfs,ext4 rootwait
+ERLITE_CMDLINE:=-mtdparts=phys_mapped_flash:512k(boot0)ro,512k(boot1)ro,64k(eeprom)ro root=/dev/sda2 rootfstype=squashfs,ext4 rootwait
 define Device/erlite
   CMDLINE := $(ERLITE_CMDLINE) 
   DEVICE_TITLE := Ubiquiti EdgeRouter Lite


### PR DESCRIPTION
erlite mtdparts exposes boot0, boot1 and eeprom regions
as read/write.
this patch adds readonly flags, so these regions can't be
modified. same as it is already for ER profile.

Signed-off-by: Jiri Kastner <cz172638@gmail.com>