### PR TITLE
[RFC] base-files: tell the kernel about ubox's modprobe if no /sbin/modprobe

### DIFF
--- a/package/base-files/files/etc/init.d/boot
+++ b/package/base-files/files/etc/init.d/boot
@@ -36,6 +36,9 @@ boot() {
 	grep -q debugfs /proc/filesystems && /bin/mount -o noatime -t debugfs debugfs /sys/kernel/debug
 	[ "$FAILSAFE" = "true" ] && touch /tmp/.failsafe
 
+	[ ! -x /sbin/modprobe -a -x /usr/sbin/modprobe ] && \
+		echo /usr/sbin/modprobe > /proc/sys/kernel/modprobe
+
 	/sbin/kmodloader
 
 	[ ! -f /etc/config/wireless ] && {


### PR DESCRIPTION
Not sure how valid this fix is.
Since ubox's /usr/sbin/modprobe points to /sbin/kmodloader
and the arguments it takes, differ from the default /sbin/modprobe.

The main gist of things is that the kernel's default is

```
root@(none):/# cat /proc/sys/kernel/modprobe
/sbin/modprobe
```

I got a case [ for `python-iptables` package ] not working
because it tries to read `/proc/sys/kernel/modprobe` and fail
when trying to run `/sbin/modprobe`.

My proposed fix [ well, up for discussion first ] is to
update `/proc/sys/kernel/modprobe` with `/usr/sbin/modprobe`
if it's available and no `/sbin/modprobe` is available by default.

Tested on LEDE trunk 1fb673ee12cad775acf8cb89fc8608e8c3c457a2
On x86_64.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>