### PR TITLE
ramips: update ZyXEL Keenetic boards

### DIFF
--- a/target/linux/ramips/dts/kn_rc.dts
+++ b/target/linux/ramips/dts/kn_rc.dts
@@ -56,6 +56,17 @@
 			linux,code = <BTN_0>;
 		};
 	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb_power {
+			gpio-export,name = "usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		};
+	};
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/kn_rf.dts
+++ b/target/linux/ramips/dts/kn_rf.dts
@@ -56,6 +56,17 @@
 			linux,code = <BTN_0>;
 		};
 	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb_power {
+			gpio-export,name = "usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		};
+	};
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/kng_rc.dts
+++ b/target/linux/ramips/dts/kng_rc.dts
@@ -62,6 +62,17 @@
 		};
 	};
 
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb_power {
+			gpio-export,name = "usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
 	rtl8367rb {
 		compatible = "realtek,rtl8367b";
 		cpu_port = <7>;

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -469,7 +469,7 @@ define Device/kng_rc
   DEVICE_TITLE := ZyXEL Keenetic Viva
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport kmod-switch-rtl8366-smi kmod-switch-rtl8367b
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to 64k | check-size $$$$(IMAGE_SIZE) | \
 	zyimage -d 8997 -v "ZyXEL Keenetic Viva"
 endef
 TARGET_DEVICES += kng_rc


### PR DESCRIPTION
add: Export gpio to allow power management of USB port.
fix: For Keenetic Viva fix squashfs alignment as ZyXEL web-flasher requires to be aligned to 64kb.