### PR TITLE
opkg: clarify messages and errors related to downloads

### DIFF
--- a/package/system/opkg/Makefile
+++ b/package/system/opkg/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=opkg
-PKG_RELEASE:=16
+PKG_RELEASE:=17
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=http://git.yoctoproject.org/git/opkg

--- a/package/system/opkg/patches/290-clarify-download-errors.patch
+++ b/package/system/opkg/patches/290-clarify-download-errors.patch
@@ -1,0 +1,61 @@
+--- a/libopkg/opkg_cmd.c
++++ b/libopkg/opkg_cmd.c
+@@ -85,6 +85,7 @@ opkg_update_cmd(int argc, char **argv)
+      char *tmp;
+      int err;
+      int failures;
++     int pkglist_dl_error;
+      char *lists_dir;
+      pkg_src_list_elt_t *iter;
+      pkg_src_t *src;
+@@ -130,15 +131,19 @@ opkg_update_cmd(int argc, char **argv)
+ 	      sprintf_alloc(&url, "%s/%s", src->value, src->gzip ? "Packages.gz" : "Packages");
+ 
+ 	  sprintf_alloc(&list_file_name, "%s/%s", lists_dir, src->name);
++	  pkglist_dl_error = 0;
+ 	  if (opkg_download(url, list_file_name, NULL, NULL, 0)) {
+ 	       failures++;
++	       pkglist_dl_error = 1;
++	       opkg_msg(NOTICE, "*** Failed to download the package list from %s\n\n",
++			    url);
+ 	  } else {
+-	       opkg_msg(NOTICE, "Updated list of available packages in %s.\n",
++	       opkg_msg(NOTICE, "Updated list of available packages in %s\n",
+ 			    list_file_name);
+ 	  }
+ 	  free(url);
+ #if defined(HAVE_GPGME) || defined(HAVE_OPENSSL) || defined(HAVE_USIGN)
+-          if (conf->check_signature) {
++          if (pkglist_dl_error == 0 && conf->check_signature) {
+               /* download detached signitures to verify the package lists */
+               /* get the url for the sig file */
+               if (src->extra_data)	/* debian style? */
+@@ -156,7 +161,7 @@ opkg_update_cmd(int argc, char **argv)
+               err = opkg_download(url, tmp_file_name, NULL, NULL, 0);
+               if (err) {
+                   failures++;
+-                  opkg_msg(NOTICE, "Signature check failed.\n");
++                  opkg_msg(NOTICE, "Signature file download failed.\n");
+               } else {
+                   err = opkg_verify_file (list_file_name, tmp_file_name);
+                   if (err == 0)
+--- a/libopkg/opkg_download.c
++++ b/libopkg/opkg_download.c
+@@ -91,7 +91,7 @@ opkg_download(const char *src, const cha
+     char *src_base = basename(src_basec);
+     char *tmp_file_location;
+ 
+-    opkg_msg(NOTICE,"Downloading %s.\n", src);
++    opkg_msg(NOTICE,"Downloading %s\n", src);
+ 
+     if (str_starts_with(src, "file:")) {
+ 	const char *file_src = src + 5;
+@@ -175,6 +175,8 @@ opkg_download(const char *src, const cha
+ 
+       if (res) {
+ 	opkg_msg(ERROR, "Failed to download %s, wget returned %d.\n", src, res);
++	if (res == 4)
++	    opkg_msg(ERROR, "Check your network settings and connectivity.\n\n");
+ 	free(tmp_file_location);
+ 	return -1;
+       }


### PR DESCRIPTION
I git tired seeing forum discussion about "opkg update" errors due to network config errors (wget returns 4 error) and looked a bit into opkg's error messaging related to package list updates. This PR clarifies things with five changes:

Clarify opkg's messages related to downloads:

* more visible error message for package list download failure:
   `*** Failed to download the package list from http://downloads.lede...`
* separate error message for signature file download error:
    `Signature file download failed.`
   (previously a signature file download failure was reported with identical error message as a real signature check failure.)
* if wget returns 4 indicating a network failure, signal the network error more clearly to the user:
     `Check your network settings and connectivity.`
* remove '.' from end of filenames and URLs in order to ease copy-pasting into console, forum & bug tracker. The '.' at the end of URL has been problematic as e.g. forum software's URL detection includes that in URL after copy-pasting. So quite many links in the forum discussion have been wrong, causing misunderstandings.

Additionally, it makes no sense to try signature check and report errors about it, if the package list itself was not downloaded. So,
* try signature check only if the package list was downloaded ok.

----
Run-tested with ipq806x/R7800 with r3070-afd2827c5c

cc to @jow- as the maintainer for opkg.

---
Example of the new output below. First case shows the error messages related to missing sig file in /tmp/koe and a wrong URL to package list. Second case simulates network failure (and wget error 4):

```
root@lede:~# opkg update
Downloading file:///tmp/koe/Packages.gz
Updated list of available packages in /var/opkg-lists/test
Downloading file:///tmp/koe/Packages.sig
Signature file download failed.
Remove wrong Signature file.
Downloading http://downloads.lede-project.org/snapshots/targets/ipq806x/generic/packages/Packages.gz
Updated list of available packages in /var/opkg-lists/reboot_core
Downloading http://downloads.lede-project.org/snapshots/targets/ipq806x/generic/packages/Packages.sig
Signature check passed.
Downloading http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/baxxx/Packages.gz
*** Failed to download the package list from http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/baxxx/Packages.gz

Downloading http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/luci/Packages.gz
Updated list of available packages in /var/opkg-lists/reboot_luci
Downloading http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/luci/Packages.sig
Signature check passed.
Collected errors:
 * copy_file: ///tmp/koe/Packages.sig: No such file or directory.
 * file_copy: Failed to copy file ///tmp/koe/Packages.sig to /var/opkg-lists/test.sig.
 * opkg_download: Failed to download http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/baxxx/Packages.gz, wget returned 8.

root@lede:~# ifdown wan
root@lede:~# ifdown wan6
root@lede:~# opkg update
Downloading file:///tmp/koe/Packages.gz
Updated list of available packages in /var/opkg-lists/test
Downloading file:///tmp/koe/Packages.sig
Signature file download failed.
Remove wrong Signature file.
Downloading http://downloads.lede-project.org/snapshots/targets/ipq806x/generic/packages/Packages.gz
*** Failed to download the package list from http://downloads.lede-project.org/snapshots/targets/ipq806x/generic/packages/Packages.gz

Downloading http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/baxxx/Packages.gz
*** Failed to download the package list from http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/baxxx/Packages.gz

Downloading http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/luci/Packages.gz
*** Failed to download the package list from http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/luci/Packages.gz

Collected errors:
 * copy_file: ///tmp/koe/Packages.sig: No such file or directory.
 * file_copy: Failed to copy file ///tmp/koe/Packages.sig to /var/opkg-lists/test.sig.
 * opkg_download: Failed to download http://downloads.lede-project.org/snapshots/targets/ipq806x/generic/packages/Packages.gz, wget returned 4.
 * opkg_download: Check your network settings and connectivity.

 * opkg_download: Failed to download http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/baxxx/Packages.gz, wget returned 4.
 * opkg_download: Check your network settings and connectivity.

 * opkg_download: Failed to download http://downloads.lede-project.org/snapshots/packages/arm_cortex-a15_neon-vfpv4/luci/Packages.gz, wget returned 4.
 * opkg_download: Check your network settings and connectivity.

```