### PR TITLE
netifd: remove dead function in init script

### DIFF
--- a/package/network/config/netifd/files/etc/init.d/network
+++ b/package/network/config/netifd/files/etc/init.d/network
@@ -31,11 +31,6 @@ reload_service() {
 	/sbin/wifi reload_legacy
 }
 
-stop() {
-	/sbin/wifi down
-	procd_kill network ''
-}
-
 service_running() {
 	ubus -t 30 wait_for network.interface
 	/sbin/wifi reload_legacy


### PR DESCRIPTION
stop() is defined but never actually called since
it's overwritten by rc.common due to USE_PROCD=1.

This dead stop() function exists since commit 73179a188c6eed4db08ed5f9e109fae17db6575e but never worked as intended.