### PR TITLE
uboot-envtools: add nsa310b envs

### DIFF
--- a/package/boot/uboot-envtools/files/kirkwood
+++ b/package/boot/uboot-envtools/files/kirkwood
@@ -18,6 +18,7 @@ dockstar|\
 guruplug-server-plus|\
 ib62x0|\
 linksys-viper|\
+nsa310b|\
 pogo_e02|\
 sheevaplug|\
 sheevaplug-esata)


### PR DESCRIPTION
accessing the u-boot's envs on this device is required to read the mac address.
These are the envs of the new u-boot, not of the stock one.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>