### PR TITLE
scripts/feeds: Reuse TOPDIR if defined in environment

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -9,7 +9,8 @@ use strict;
 use Cwd 'abs_path';
 
 chdir "$FindBin::Bin/..";
-$ENV{TOPDIR}=getcwd();
+$ENV{TOPDIR} //= getcwd();
+chdir $ENV{TOPDIR};
 $ENV{GIT_CONFIG_PARAMETERS}="'core.autocrlf=false'";
 $ENV{GREP_OPTIONS}="";
 


### PR DESCRIPTION
The feeds script sets value of TOPDIR in a way that is inconsistent
with how toplevel Makefile sets it. The inconsistency appears when one
wants to have multiple "builds" from a single source. The "build" is a
directory full of symlinks to LEDE source. When make is invoked in
such a directory, make's TOPDIR is set to that directory, whereas
scripts/feeds sets TOPDIR to the top of LEDE source, which results in
creating feeds directory inside the LEDE source instead of in the
build directory.

This patch changes the script so that it uses the TOPDIR value form
the environment if it exists. The result is that 'make
package/symlinks' correctly fetches feeds to the build directory
instead in the source.

Signed-off-by: Michal Sojka <sojkam1@fel.cvut.cz>