### PR TITLE
ramips: split mt76 firmware from kmod package

### DIFF
--- a/package/firmware/mt76-firmware/Makefile
+++ b/package/firmware/mt76-firmware/Makefile
@@ -1,0 +1,76 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mt76-firmware
+PKG_RELEASE=1
+
+PKG_LICENSE:=GPLv2
+PKG_LICENSE_FILES:=
+
+PKG_SOURCE_URL:=https://github.com/openwrt/mt76
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2017-01-15
+PKG_SOURCE_VERSION:=85d12fea1abe8654f694dc6594781f85168aa2c2
+PKG_MIRROR_HASH:=d07c019a3f836860409c58c303195df832f5dc31168201c3fa7d23f4f5927a79
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/mt76-firmware-default
+  SECTION:=firmware
+  CATEGORY:=Firmware
+  URL:=$(PKG_SOURCE_URL)
+  DEPENDS:=
+endef
+
+define Package/mt76-firmware
+$(Package/mt76-firmware-default)
+  TITLE:=MediaTek MT76x2/MT7603 firmware
+  DEPENDS:=+mt76-firmware-mt7603 \
+	  +mt76-firmware-mt7628 \
+	  +mt76-firmware-mt7662
+endef
+
+define Package/mt76-firmware-mt7603
+$(Package/mt76-firmware-default)
+  TITLE:=MediaTek MT7603 firmware
+endef
+
+define Package/mt76-firmware-mt7603/install
+	$(INSTALL_DIR) $(1)/lib-firmware
+	cp \
+		$(PKG_BUILD_DIR)/firmware/mt7603_e1.bin \
+		$(PKG_BUILD_DIR)/firmware/mt7603_e2.bin \
+		$(1)/lib/firmware
+endef
+
+define Package/mt76-firmware-mt7628
+$(Package/mt76-firmware-default)
+  TITLE:=MediaTek MT7628 firmware
+endef
+
+define Package/mt76-firmware-mt7628/install
+	$(INSTALL_DIR) $(1)/lib-firmware
+	cp \
+		$(PKG_BUILD_DIR)/firmware/mt7628_e1.bin \
+		$(PKG_BUILD_DIR)/firmware/mt7628_e2.bin \
+		$(1)/lib/firmware
+endef
+
+define Package/mt76-firmware-mt7662
+$(Package/mt76-firmware-default)
+  TITLE:=MediaTek MT7662 firmware
+endef
+
+define Package/mt76-firmware-mt7662/install
+	$(INSTALL_DIR) $(1)/lib-firmware
+	cp \
+		$(PKG_BUILD_DIR)/firmware/mt7662_rom_patch.bin \
+		$(PKG_BUILD_DIR)/firmware/mt7662.bin \
+		$(1)/lib/firmware
+endef
+
+$(eval $(call BuildPackage,mt76-firmware-mt7603))
+$(eval $(call BuildPackage,mt76-firmware-mt7628))
+$(eval $(call BuildPackage,mt76-firmware-mt7662))
+$(eval $(call BuildPackage,mt76-firmware))

--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -55,18 +55,4 @@ define Build/Compile
 		modules
 endef
 
-define KernelPackage/mt76/install
-	$(INSTALL_DIR) $(1)/lib/firmware
-	cp \
-		$(if $(CONFIG_TARGET_ramips_mt7628) || $(CONFIG_TARGET_ramips_mt7688), \
-			$(PKG_BUILD_DIR)/firmware/mt7628_e1.bin \
-			$(PKG_BUILD_DIR)/firmware/mt7628_e2.bin \
-		) \
-		$(PKG_BUILD_DIR)/firmware/mt7603_e1.bin \
-		$(PKG_BUILD_DIR)/firmware/mt7603_e2.bin \
-		$(PKG_BUILD_DIR)/firmware/mt7662_rom_patch.bin \
-		$(PKG_BUILD_DIR)/firmware/mt7662.bin \
-		$(1)/lib/firmware
-endef
-
 $(eval $(call KernelPackage,mt76))

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -99,7 +99,7 @@ define Device/rb750gr3
   DTS := RB750Gr3
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := MikroTik RB750Gr3
-  DEVICE_PACKAGES := kmod-usb3 uboot-envtools -kmod-mt76 -kmod-rt2x00-lib -kmod-mac80211 -kmod-cfg80211 -wpad-mini -iwinfo
+  DEVICE_PACKAGES := kmod-usb3 uboot-envtools -kmod-mt76 -firmware-mt76 -kmod-rt2x00-lib -kmod-mac80211 -kmod-cfg80211 -wpad-mini -iwinfo
 endef
 TARGET_DEVICES += rb750gr3
 
@@ -140,7 +140,7 @@ define Device/ubnt-erx
   KERNEL_INITRAMFS := $$(KERNEL) | ubnt-erx-factory-image $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.tar
   IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
   DEVICE_TITLE := Ubiquiti EdgeRouter X
-  DEVICE_PACKAGES := -kmod-mt76 -kmod-rt2x00-lib -kmod-mac80211 -kmod-cfg80211 -wpad-mini -iwinfo
+  DEVICE_PACKAGES := -kmod-mt76 -firmware-mt76 -kmod-rt2x00-lib -kmod-mac80211 -kmod-cfg80211 -wpad-mini -iwinfo
 endef
 TARGET_DEVICES += ubnt-erx
 

--- a/target/linux/ramips/mt7620/target.mk
+++ b/target/linux/ramips/mt7620/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT7620 based boards
 FEATURES+=usb
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc kmod-mt76
+DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc kmod-mt76 mt76-firmware
 
 define Target/Description
 	Build firmware images for Ralink MT7620 based boards.

--- a/target/linux/ramips/mt7621/target.mk
+++ b/target/linux/ramips/mt7621/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT7621 based boards
 FEATURES+=usb rtc nand
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-mt76
+DEFAULT_PACKAGES += kmod-mt76 mt76-firmware
 
 KERNEL_PATCHVER:=4.4
 

--- a/target/linux/ramips/mt7628/target.mk
+++ b/target/linux/ramips/mt7628/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT7628 based boards
 FEATURES+=usb
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-mt76
+DEFAULT_PACKAGES += kmod-mt76 mt76-firmware
 
 define Target/Description
 	Build firmware images for Ralink MT7628 based boards.

--- a/target/linux/ramips/mt7688/target.mk
+++ b/target/linux/ramips/mt7688/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT7688 based boards
 FEATURES+=usb
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-mt76
+DEFAULT_PACKAGES += kmod-mt76 mt76-firmware
 
 define Target/Description
 	Build firmware images for Ralink MT7688 based boards.


### PR DESCRIPTION
This patch moves the mt76 firmware from `kmod-mt76` to `mt76-firmware`.
This is a metapackage, comprised of three subpackages for mt7603, mt7628
and mt7662.

By adding `mt76-firmware` as `DEFAULT_PACKAGE` for all mt76 targets, the
previous behaviour of including the firmware in all images is left
unchanged, unless explicity unselected in `DEVICE_PACKAGES`.

This is especially beneficial for devices with small flash chips, since
the mt76 firmware currently requires ~160K on squashfs after compression.

Signed-off-by: Joseph C. Lehner <joseph.c.lehner@gmail.com>