### PR TITLE
ramips: split mt76 firmware from kmod package

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mt76
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=
@@ -20,17 +20,44 @@ STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backpor
 include $(INCLUDE_DIR)/kernel.mk
 include $(INCLUDE_DIR)/package.mk
 
-define KernelPackage/mt76
+define KernelPackage/mt76-default
   SUBMENU:=Wireless Drivers
-  TITLE:=MediaTek MT76x2/MT7603 wireless driver
   DEPENDS:= \
 	+kmod-mac80211 @PCI_SUPPORT @!LINUX_3_18 \
 	+@DRIVER_11AC_SUPPORT +@DRIVER_11N_SUPPORT +@DRIVER_11W_SUPPORT
+endef
+
+define KernelPackage/mt76
+  SUBMENU:=Wireless Drivers
+  TITLE:=MediaTek MT76x2/MT7603 wireless driver (metapackage)
+  DEPENDS:= \
+	+kmod-mt76-core +kmod-mt76x2 +kmod-mt7603
+endef
+
+define KernelPackage/mt76-core
+  $(KernelPackage/mt76-default)
+  TITLE:=MediaTek MT76xx wireless driver
   FILES:=\
-	$(PKG_BUILD_DIR)/mt76.ko \
-	$(PKG_BUILD_DIR)/mt76x2e.ko \
+	$(PKG_BUILD_DIR)/mt76.ko
+  AUTOLOAD:=$(call AutoLoad,50,mac80211 mt76)
+endef
+
+define KernelPackage/mt76x2
+  $(KernelPackage/mt76-default)
+  TITLE:=MediaTek MT76x2 wireless driver
+  DEPENDS+=+kmod-mt76-core
+  FILES:=\
+	$(PKG_BUILD_DIR)/mt76x2e.ko
+  AUTOLOAD:=$(call AutoLoad,51,mt76x2e)
+endef
+
+define KernelPackage/mt7603
+  $(KernelPackage/mt76-default)
+  TITLE:=MediaTek MT7603 wireless driver
+  DEPENDS+=+kmod-mt76-core
+  FILES:=\
 	$(PKG_BUILD_DIR)/mt7603e.ko
-  AUTOLOAD:=$(call AutoLoad,50,mac80211 mt76 mt76x2e mt7603e)
+  AUTOLOAD:=$(call AutoLoad,51,mt7603e)
 endef
 
 NOSTDINC_FLAGS = \
@@ -55,18 +82,28 @@ define Build/Compile
 		modules
 endef
 
-define KernelPackage/mt76/install
+define KernelPackage/mt76x2/install
 	$(INSTALL_DIR) $(1)/lib/firmware
 	cp \
-		$(if $(CONFIG_TARGET_ramips_mt7628) || $(CONFIG_TARGET_ramips_mt7688), \
-			$(PKG_BUILD_DIR)/firmware/mt7628_e1.bin \
-			$(PKG_BUILD_DIR)/firmware/mt7628_e2.bin \
-		) \
-		$(PKG_BUILD_DIR)/firmware/mt7603_e1.bin \
-		$(PKG_BUILD_DIR)/firmware/mt7603_e2.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7662_rom_patch.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7662.bin \
 		$(1)/lib/firmware
 endef
 
+define KernelPackage/mt7603/install
+	$(INSTALL_DIR) $(1)/lib/firmware
+	cp $(if $(filter y, \
+		$(CONFIG_TARGET_ramips_mt7628) $(CONFIG_TARGET_ramips_mt7688)), \
+			$(PKG_BUILD_DIR)/firmware/mt7628_e1.bin \
+			$(PKG_BUILD_DIR)/firmware/mt7628_e2.bin \
+			,\
+			$(PKG_BUILD_DIR)/firmware/mt7603_e1.bin \
+			$(PKG_BUILD_DIR)/firmware/mt7603_e2.bin \
+		) \
+		$(1)/lib/firmware
+endef
+
+$(eval $(call KernelPackage,mt76-core))
+$(eval $(call KernelPackage,mt76x2))
+$(eval $(call KernelPackage,mt7603))
 $(eval $(call KernelPackage,mt76))


### PR DESCRIPTION
This patch moves the mt76 firmware from `kmod-mt76` to `mt76-firmware`.
This is a metapackage, comprised of three subpackages for mt7603, mt7628
and mt7662.

By adding `mt76-firmware` as `DEFAULT_PACKAGE` for all mt76 targets, the
previous behaviour of including the firmware in all images is left
unchanged, unless explicity unselected in `DEVICE_PACKAGES`.

This is especially beneficial for devices with small flash chips, since
the mt76 firmware currently requires ~160K on squashfs after compression.

Signed-off-by: Joseph C. Lehner <joseph.c.lehner@gmail.com>