### PR TITLE
toolchain/binutils: Switch to 2.27 as default version

### DIFF
--- a/toolchain/binutils/Config.in
+++ b/toolchain/binutils/Config.in
@@ -2,7 +2,7 @@
 
 choice
 	prompt "Binutils Version" if TOOLCHAINOPTS
-	default BINUTILS_USE_VERSION_2_25_1 if !arc
+	default BINUTILS_USE_VERSION_2_27 if !arc
 	default BINUTILS_USE_VERSION_2_26_ARC if arc
 	help
 	  Select the version of binutils you wish to use.

--- a/toolchain/binutils/Config.version
+++ b/toolchain/binutils/Config.version
@@ -1,8 +1,8 @@
 config BINUTILS_VERSION_2_25_1
-	default y if (!TOOLCHAINOPTS && !arc)
 	bool
 
 config BINUTILS_VERSION_2_27
+	default y if (!TOOLCHAINOPTS && !arc)
 	bool
 
 config BINUTILS_VERSION_2_26_ARC


### PR DESCRIPTION
Use 2.27 as default which is the current relese.
Makes it easier to get support and submit patches upstream if needed.

Tested on ar71xx, mt7621, kirkwood (arm)

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>