### PR TITLE
uboot-kirkwood: fix goflexhome/net bootcommand

### DIFF
--- a/package/boot/uboot-kirkwood/patches/150-goflexhome.patch
+++ b/package/boot/uboot-kirkwood/patches/150-goflexhome.patch
@@ -10,7 +10,7 @@
 -	"bootm 0x800000"
 +	"ubi part ubi; " \
 +	"ubi read 0x800000 kernel; " \
-+	"bootz 0x800000"
++	"bootm 0x800000"
  
  #define CONFIG_MTDPARTS \
 -	"mtdparts=orion_nand:1m(uboot),6M(uImage),-(root)\0"


### PR DESCRIPTION
Goflexhome/net use uImage, and to boot an uImage the u-boot
must use bootm command, not bootz.

Fixes the "i cannot boot LEDE with this u-boot" issue that I
found out myself with my goflexnet.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>

@blogic Can this patch be sent also in 17.01 branch?