### PR TITLE
rt5350: added the pcm interface in .dtsi

### DIFF
--- a/target/linux/ramips/dts/DWR-512-B.dts
+++ b/target/linux/ramips/dts/DWR-512-B.dts
@@ -120,8 +120,12 @@
 &pinctrl {
 	state_default: pinctrl0 {
 		gpio {
-			ralink,group = "i2c", "jtag", "uartf";
+			ralink,group = "i2c", "jtag";
 			ralink,function = "gpio";
+		};
+		pcm_gpio {
+			ralink,group = "uartf";
+			ralink,function = "pcm gpio";
 		};
 	};
 };

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -229,6 +229,19 @@
 			interrupts = <7>;
 		};
 
+		pcm: pcm@2000 {
+			compatible = "ralink,rt5350-pcm";
+			reg = <0x2000 0x800>;
+
+			resets = <&rstctrl 11>;
+			reset-names = "pcm";
+
+			interrupt-parent = <&intc>;
+			interrupts = <4>;
+
+			status = "disabled";
+                };
+
 		gdma: gdma@2800 {
 			compatible = "ralink,rt3883-gdma";
 			reg = <0x2800 0x800>;


### PR DESCRIPTION
This patch add the missing pcm interface in the rt5350 soc .dtsi.
The pcm interface is connected in the DWR-512 board, therefore its
.dts is configured to select the proper pinmux configuration.

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>