### PR TITLE
rt5350: added pcm interface in .dtsi

### DIFF
--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -229,6 +229,19 @@
 			interrupts = <7>;
 		};
 
+		pcm: pcm@2000 {
+			compatible = "ralink,rt5350-pcm";
+			reg = <0x2000 0x800>;
+
+			resets = <&rstctrl 11>;
+			reset-names = "pcm";
+
+			interrupt-parent = <&intc>;
+			interrupts = <4>;
+
+			status = "disabled";
+                };
+
 		gdma: gdma@2800 {
 			compatible = "ralink,rt3883-gdma";
 			reg = <0x2800 0x800>;


### PR DESCRIPTION
Added the missing audio pcm interface in the .dtsi file for the
rt5350 device. The update has been verified from the data get
from the datasheet and is very similar to the mt7620a.dtsi

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>