### PR TITLE
base-files: Wifi detect deprecation

### DIFF
--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -6,8 +6,8 @@
 
 usage() {
 	cat <<EOF
-Usage: $0 [down|detect|reload|status]
-enables (default), disables or detects a wifi configuration.
+Usage: $0 [config|down|reload|status]
+enables (default), disables or configures devices not yet configured.
 EOF
 	exit 1
 }

--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -145,6 +145,12 @@ wifi_reload() {
 	wifi_reload_legacy
 }
 
+wifi_detect_notice() {
+	>&2 echo "WARNING: Wifi detect is deprecated. Use wifi config instead"
+	>&2 echo "For more information, see commit 5f8f8a366136a07df661e31decce2458357c167a"
+	exit 1
+}
+
 wifi_config() {
 	[ ! -f /etc/config/wireless ] && touch /etc/config/wireless
 
@@ -229,7 +235,7 @@ scan_wifi
 
 case "$1" in
 	down) wifi_updown "disable" "$2";;
-	detect) ;;
+	detect) wifi_detect_notice ;;
 	config) wifi_config ;;
 	status) ubus_wifi_cmd "status" "$2";;
 	reload) wifi_reload "$2";;


### PR DESCRIPTION
Since commit 5f8f8a366136a07df661e31decce2458357c167a wifi detect does not work anymore, and instead it exists wifi config to configure unconfigured wireless devices.
The help/usage of wifi was not modified and was still saying that you can use wifi detect, without saying anything about wifi config.
I have changed wifi command usage and also added a function called when executing wifi detect that shows a Warning so users know that it's deprecated and exits with an error.
It can be done that when running wifi detect, wifi config is ran, but it makes no sense, as the commit 5f8f8a366136a07df661e31decce2458357c167a explains: there are different things.