### PR TITLE
ar71xx: base-files: cleanups and fixes in lib/ar71xx.sh

### DIFF
--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -74,25 +74,25 @@ ubnt_xm_board_detect() {
 
 	magic="$(ubnt_get_mtd_part_magic)"
 	case ${magic:0:3} in
-		"e00"|\
-		"e01"|\
-		"e80")
-			model="Ubiquiti NanoStation M"
-			;;
-		"e0a")
-			model="Ubiquiti NanoStation loco M"
-			;;
-		"e1b"|\
-		"e1d")
-			model="Ubiquiti Rocket M"
-			;;
-		"e20"|\
-		"e2d")
-			model="Ubiquiti Bullet M"
-			;;
-		"e30")
-			model="Ubiquiti PicoStation M"
-			;;
+	"e00"|\
+	"e01"|\
+	"e80")
+		model="Ubiquiti NanoStation M"
+		;;
+	"e0a")
+		model="Ubiquiti NanoStation loco M"
+		;;
+	"e1b"|\
+	"e1d")
+		model="Ubiquiti Rocket M"
+		;;
+	"e20"|\
+	"e2d")
+		model="Ubiquiti Bullet M"
+		;;
+	"e30")
+		model="Ubiquiti PicoStation M"
+		;;
 	esac
 
 	[ -z "$model" ] || AR71XX_MODEL="${model}${magic:3:1}"

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -33,10 +33,10 @@ wndr3700_board_detect() {
 
 	magic="$(ar71xx_get_mtd_part_magic firmware)"
 	case $magic in
-	"33373030")
+	33373030)
 		machine="NETGEAR WNDR3700"
 		;;
-	"33373031")
+	33373031)
 		model="$(ar71xx_get_mtd_offset_size_format art 41 32 %c)"
 		# Use awk to remove everything unprintable
 		model_stripped="$(ar71xx_get_mtd_offset_size_format art 41 32 %c | LC_CTYPE=C awk -v 'FS=[^[:print:]]' '{print $1; exit}')"
@@ -74,23 +74,23 @@ ubnt_xm_board_detect() {
 
 	magic="$(ubnt_get_mtd_part_magic)"
 	case ${magic:0:3} in
-	"e00"|\
-	"e01"|\
-	"e80")
+	e00|\
+	e01|\
+	e80)
 		model="Ubiquiti NanoStation M"
 		;;
-	"e0a")
+	e0a)
 		model="Ubiquiti NanoStation loco M"
 		;;
-	"e1b"|\
-	"e1d")
+	e1b|\
+	e1d)
 		model="Ubiquiti Rocket M"
 		;;
-	"e20"|\
-	"e2d")
+	e20|\
+	e2d)
 		model="Ubiquiti Bullet M"
 		;;
-	"e30")
+	e30)
 		model="Ubiquiti PicoStation M"
 		;;
 	esac
@@ -145,115 +145,115 @@ tplink_board_detect() {
 	hwver=" v${hwver#0}"
 
 	case "$hwid" in
-	"015000"*)
+	015000*)
 		model="EasyLink EL-M150"
 		;;
-	"015300"*)
+	015300*)
 		model="EasyLink EL-MINI"
 		;;
-	"044401"*)
+	044401*)
 		model="ANTMINER-S1"
 		;;
-	"044403"*)
+	044403*)
 		model="ANTMINER-S3"
 		;;
-	"44440101"*)
+	44440101*)
 		model="ANTROUTER-R1"
 		;;
-	"120000"*)
+	120000*)
 		model="MERCURY MAC1200R"
 		;;
-	"007260"*)
+	007260*)
 		model="TellStick ZNet Lite"
 		;;
-	"066601"*)
+	066601*)
 		model="OMYlink OMY-G1"
 		;;
-	"066602"*)
+	066602*)
 		model="OMYlink OMY-X1"
 		;;
-	"3C0001"*)
+	3C0001*)
 		model="OOLITE"
 		;;
-	"3C0002"*)
+	3C0002*)
 		model="MINIBOX_V1"
 		;;
-	"070301"*)
+	070301*)
 		model="TP-Link TL-WR703N"
 		;;
-	"071000"*)
+	071000*)
 		model="TP-Link TL-WR710N"
 
 		if [ "$hwid" = '07100002' -a "$mid" = '00000002' ]; then
 			hwver=' v2.1'
 		fi
 		;;
-	"072001"*)
+	072001*)
 		model="TP-Link TL-WR720N"
 		;;
-	"070100"*)
+	070100*)
 		model="TP-Link TL-WA701N/ND"
 		;;
-	"073000"*)
+	073000*)
 		model="TP-Link TL-WA730RE"
 		;;
-	"074000"*)
+	074000*)
 		model="TP-Link TL-WR740N/ND"
 		;;
-	"074100"*)
+	074100*)
 		model="TP-Link TL-WR741N/ND"
 		;;
-	"074300"*)
+	074300*)
 		model="TP-Link TL-WR743N/ND"
 		;;
-	"075000"*)
+	075000*)
 		model="TP-Link TL-WA750RE"
 		;;
-	"721000"*)
+	721000*)
 		model="TP-Link TL-WA7210N"
 		;;
-	"751000"*)
+	751000*)
 		model="TP-Link TL-WA7510N"
 		;;
-	"080100"*)
+	080100*)
 		model="TP-Link TL-WA801N/ND"
 		;;
-	"080200"*)
+	080200*)
 		model="TP-Link TL-WR802N"
 		;;
-	"083000"*)
+	083000*)
 		model="TP-Link TL-WA830RE"
 
 		if [ "$hwver" = ' v10' ]; then
 			hwver=' v1'
 		fi
 		;;
-	"084100"*)
+	084100*)
 		model="TP-Link TL-WR841N/ND"
 
 		if [ "$hwid" = '08410002' -a "$mid" = '00000002' ]; then
 			hwver=' v1.5'
 		fi
 		;;
-	"084200"*)
+	084200*)
 		model="TP-Link TL-WR842N/ND"
 		;;
-	"084300"*)
+	084300*)
 		model="TP-Link TL-WR843N/ND"
 		;;
-	"085000"*)
+	085000*)
 		model="TP-Link TL-WA850RE"
 		;;
-	"086000"*)
+	086000*)
 		model="TP-Link TL-WA860RE"
 		;;
-	"090100"*)
+	090100*)
 		model="TP-Link TL-WA901N/ND"
 		;;
-	"094000"*)
+	094000*)
 		model="TP-Link TL-WR940N"
 		;;
-	"094100"*)
+	094100*)
 		if [ "$hwid" = "09410002" -a "$mid" = "00420001" ]; then
 			model="Rosewill RNX-N360RT"
 			hwver=""
@@ -261,75 +261,75 @@ tplink_board_detect() {
 			model="TP-Link TL-WR941N/ND"
 		fi
 		;;
-	"104100"*)
+	104100*)
 		model="TP-Link TL-WR1041N/ND"
 		;;
-	"104300"*)
+	104300*)
 		model="TP-Link TL-WR1043N/ND"
 		;;
-	"254300"*)
+	254300*)
 		model="TP-Link TL-WR2543N/ND"
 		;;
-	"001001"*)
+	001001*)
 		model="TP-Link TL-MR10U"
 		;;
-	"001101"*)
+	001101*)
 		model="TP-Link TL-MR11U"
 		;;
-	"001201"*)
+	001201*)
 		model="TP-Link TL-MR12U"
 		;;
-	"001301"*)
+	001301*)
 		model="TP-Link TL-MR13U"
 		;;
-	"302000"*)
+	302000*)
 		model="TP-Link TL-MR3020"
 		;;
-	"304000"*)
+	304000*)
 		model="TP-Link TL-MR3040"
 		;;
-	"322000"*)
+	322000*)
 		model="TP-Link TL-MR3220"
 		;;
-	"342000"*)
+	342000*)
 		model="TP-Link TL-MR3420"
 		;;
-	"332000"*)
+	332000*)
 		model="TP-Link TL-WDR3320"
 		;;
-	"350000"*)
+	350000*)
 		model="TP-Link TL-WDR3500"
 		;;
-	"360000"*)
+	360000*)
 		model="TP-Link TL-WDR3600"
 		;;
-	"430000"*)
+	430000*)
 		model="TP-Link TL-WDR4300"
 		;;
-	"430080"*)
+	430080*)
 		iw reg set IL
 		model="TP-Link TL-WDR4300 (IL)"
 		;;
-	"431000"*)
+	431000*)
 		model="TP-Link TL-WDR4310"
 		;;
-	"49000002")
+	49000002)
 		model="TP-Link TL-WDR4900"
 		;;
-	"65000002")
+	65000002)
 		model="TP-Link TL-WDR6500"
 		;;
-	"453000"*)
+	453000*)
 		model="Mercury MW4530R"
 		;;
-	"934100"*)
+	934100*)
 		model="NC-LINK SMART-300"
 		;;
-	"c50000"*)
+	c50000*)
 		model="TP-Link Archer C5"
 		;;
-	"750000"*|\
-	"c70000"*)
+	750000*|\
+	c70000*)
 		model="TP-Link Archer C7"
 		;;
 	*)
@@ -382,16 +382,16 @@ ar71xx_board_detect() {
 	*"Oolite V1.0")
 		name="oolite"
 		;;
-	*"AC1750DB")
+	*AC1750DB)
 		name="f9k1115v2"
 		;;
-	*"AirGateway")
+	*AirGateway)
 		name="airgateway"
 		;;
 	*"AirGateway Pro")
 		name="airgatewaypro"
 		;;
-	*"AirRouter")
+	*AirRouter)
 		name="airrouter"
 		;;
 	*"ALFA Network AP120C")
@@ -502,11 +502,11 @@ ar71xx_board_detect() {
 	*CF-E530N)
 		name="cf-e530n"
 		;;
-	*"CPE210/220")
+	*CPE210/220)
 		name="cpe210"
 		tplink_pharos_board_detect
 		;;
-	*"CPE510/520")
+	*CPE510/520)
 		name="cpe510"
 		tplink_pharos_board_detect
 		;;
@@ -591,13 +591,13 @@ ar71xx_board_detect() {
 	*"Domino Pi")
 		name="gl-domino"
 		;;
-	*"DW33D")
+	*DW33D)
 		name="dw33d"
 		;;
 	*E2100L)
 		name="e2100l"
 		;;
-	*"EAP120")
+	*EAP120)
 		name="eap120"
 		tplink_pharos_board_detect
 		;;
@@ -623,10 +623,10 @@ ar71xx_board_detect() {
 	*"GL AR300")
 		name="gl-ar300"
 		;;
-	*"GL-AR300M")
+	*GL-AR300M)
 		name="gl-ar300m"
 		;;
-	*"GL-MIFI")
+	*GL-MIFI)
 		name="gl-mifi"
 		;;
 	*"EnGenius EPG5000")
@@ -664,7 +664,7 @@ ar71xx_board_detect() {
 	*JWAP230)
 		name="jwap230"
 		;;
-	*"Hornet-UB")
+	*Hornet-UB)
 		local size
 		size=$(awk '/firmware/ { print $2 }' /proc/mtd)
 
@@ -679,7 +679,7 @@ ar71xx_board_detect() {
 	*LS-SR71)
 		name="ls-sr71"
 		;;
-	*"MAC1200R")
+	*MAC1200R)
 		name="mc-mac1200r"
 		;;
 	*"MiniBox V1.0")
@@ -727,7 +727,7 @@ ar71xx_board_detect() {
 	*MZK-W300NH)
 		name="mzk-w300nh"
 		;;
-	*"NBG460N/550N/550NH")
+	*NBG460N/550N/550NH)
 		name="nbg460n_550n_550nh"
 		;;
 	*"Zyxel NBG6616")
@@ -766,10 +766,10 @@ ar71xx_board_detect() {
 	*"OM5P ACv2")
 		name="om5p-acv2"
 		;;
-	*"OMY-X1")
+	*OMY-X1)
 		name="omy-x1"
 		;;
-	*"OMY-G1")
+	*OMY-G1)
 		name="omy-g1"
 		;;
 	*"Onion Omega")
@@ -787,7 +787,7 @@ ar71xx_board_detect() {
 	*"Qihoo 360 C301")
 		name="qihoo-c301"
 		;;
-	*"RE450")
+	*RE450)
 		name="re450"
 		;;
 	*"RouterBOARD 411/A/AH")
@@ -902,7 +902,7 @@ ar71xx_board_detect() {
 	*SC450)
 		name="sc450"
 		;;
-	*"SMART-300")
+	*SMART-300)
 		name="smart-300"
 		;;
 	"Smart Electronics Black Swift board"*)
@@ -1016,10 +1016,10 @@ ar71xx_board_detect() {
 	*"TL-WDR3320 v2")
 		name="tl-wdr3320-v2"
 		;;
-	*"TL-WDR3500")
+	*TL-WDR3500)
 		name="tl-wdr3500"
 		;;
-	*"TL-WDR3600/4300/4310")
+	*TL-WDR3600/4300/4310)
 		name="tl-wdr4300"
 		;;
 	*"TL-WDR4900 v2")
@@ -1076,40 +1076,40 @@ ar71xx_board_detect() {
 	*"TL-WR710N v1")
 		name="tl-wr710n"
 		;;
-	*"TL-WR720N"*)
+	*TL-WR720N*)
 		name="tl-wr720n-v3"
 		;;
-	*"TL-WR810N")
+	*TL-WR810N)
 		name="tl-wr810n"
 		;;
-	*"TL-MR10U")
+	*TL-MR10U)
 		name="tl-mr10u"
 		;;
-	*"TL-MR11U")
+	*TL-MR11U)
 		name="tl-mr11u"
 		;;
-	*"TL-MR12U")
+	*TL-MR12U)
 		name="tl-mr12u"
 		;;
 	*"TL-MR13U v1")
 		name="tl-mr13u"
 		;;
-	*"Tube2H")
+	*Tube2H)
 		name="tube2h"
 		;;
 	*UniFi)
 		name="unifi"
 		;;
-	*"UniFi-AC-LITE")
+	*UniFi-AC-LITE)
 		name="unifiac-lite"
 		;;
-	*"UniFi-AC-PRO")
+	*UniFi-AC-PRO)
 		name="unifiac-pro"
 		;;
 	*"UniFi AP Pro")
 		name="uap-pro"
 		;;
-	"WeIO"*)
+	WeIO*)
 		name="weio"
 		;;
 	*WHR-G301N)
@@ -1148,16 +1148,16 @@ ar71xx_board_detect() {
 	*WNDAP360)
 		name="wndap360"
 		;;
-	*"WNDR3700/WNDR3800/WNDRMAC")
+	*WNDR3700/WNDR3800/WNDRMAC)
 		wndr3700_board_detect "$machine"
 		;;
-	*"R6100")
+	*R6100)
 		name="r6100"
 		;;
-	*"WNDR3700v4")
+	*WNDR3700v4)
 		name="wndr3700v4"
 		;;
-	*"WNDR4300")
+	*WNDR4300)
 		name="wndr4300"
 		;;
 	*"WNR2000 V4")
@@ -1190,10 +1190,10 @@ ar71xx_board_detect() {
 	*"WRTnode2Q board")
 		name="wrtnode2q"
 		;;
-	*"WZR-450HP2")
+	*WZR-450HP2)
 		name="wzr-450hp2"
 		;;
-	*"WZR-HP-AG300H/WZR-600DHP")
+	*WZR-HP-AG300H/WZR-600DHP)
 		name="wzr-hp-ag300h"
 		;;
 	*WZR-HP-G300NH)

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -418,34 +418,34 @@ ar71xx_board_detect() {
 	*Antminer-S3)
 		name="antminer-s3"
 		;;
-	*"Arduino Yun")
+	*Yun)
 		name="arduino-yun"
 		;;
-	*"AP121 reference board")
+	*"AP121 reference"*)
 		name="ap121"
 		;;
 	*AP121-MINI)
 		name="ap121-mini"
 		;;
-	*"AP132 reference board")
+	*AP132*)
 		name="ap132"
 		;;
-	*"AP136-010 reference board")
+	*AP136-010*)
 		name="ap136-010"
 		;;
-	*"AP136-020 reference board")
+	*AP136-020*)
 		name="ap136-020"
 		;;
-	*"AP135-020 reference board")
+	*AP135-020*)
 		name="ap135-020"
 		;;
-	*"AP143 reference board")
+	*AP143*)
 		name="ap143"
 		;;
-	*"AP147-010 reference board")
+	*AP147-010*)
 		name="ap147-010"
 		;;
-	*"AP152 reference board")
+	*AP152*)
 		name="ap152"
 		;;
 	*AP90Q)
@@ -533,7 +533,7 @@ ar71xx_board_detect() {
 	*"DAP-2695 rev. A1")
 		name="dap-2695-a1"
 		;;
-	*"DB120 reference board")
+	*DB120*)
 		name="db120"
 		;;
 	*"DGL-5500 rev. A1")
@@ -629,13 +629,13 @@ ar71xx_board_detect() {
 	*GL-MIFI)
 		name="gl-mifi"
 		;;
-	*"EnGenius EPG5000")
+	*EPG5000)
 		name="epg5000"
 		;;
-	*"EnGenius ESR1750")
+	*ESR1750)
 		name="esr1750"
 		;;
-	*"EnGenius ESR900")
+	*ESR900)
 		name="esr900"
 		;;
 	*JA76PF)
@@ -718,7 +718,7 @@ ar71xx_board_detect() {
 	*"My Net N750")
 		name="mynet-n750"
 		;;
-	*"WD My Net Wi-Fi Range Extender")
+	*"My Net Wi-Fi Range"*)
 		name="mynet-rext"
 		;;
 	*MZK-W04NU)
@@ -730,10 +730,10 @@ ar71xx_board_detect() {
 	*NBG460N/550N/550NH)
 		name="nbg460n_550n_550nh"
 		;;
-	*"Zyxel NBG6616")
+	*NBG6616)
 		name="nbg6616"
 		;;
-	*"Zyxel NBG6716")
+	*NBG6716)
 		name="nbg6716"
 		;;
 	*OM2P)
@@ -778,7 +778,7 @@ ar71xx_board_detect() {
 	*PB42)
 		name="pb42"
 		;;
-	*"PB44 reference board")
+	*PB44*)
 		name="pb44"
 		;;
 	*"PQI Air Pen")
@@ -905,10 +905,10 @@ ar71xx_board_detect() {
 	*SMART-300)
 		name="smart-300"
 		;;
-	"Smart Electronics Black Swift board"*)
+	*"Black Swift board"*)
 		name="bsb"
 		;;
-	*"Telldus TellStick ZNet Lite")
+	*"TellStick ZNet Lite")
 		name="tellstick-znet-lite"
 		;;
 	*SOM9331)
@@ -1187,7 +1187,7 @@ ar71xx_board_detect() {
 	*WRT400N)
 		name="wrt400n"
 		;;
-	*"WRTnode2Q board")
+	*WRTnode2Q*)
 		name="wrtnode2q"
 		;;
 	*WZR-450HP2)
@@ -1229,16 +1229,16 @@ ar71xx_board_detect() {
 	*EmbWir-Dorin-Router)
 		name="ew-dorin-router"
 		;;
-	"8devices Carambola2"*)
+	*Carambola2*)
 		name="carambola2"
 		;;
-	*"Sitecom WLR-8100")
+	*WLR-8100)
 		name="wlr8100"
 		;;
-	*"BHU BXU2000n-2 rev. A1")
+	*"BXU2000n-2 rev. A1")
 		name="bxu2000n-2-a1"
 		;;
-	*"HiWiFi HC6361")
+	*HC6361)
 		name="hiwifi-hc6361"
 		;;
 	esac

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -145,6 +145,21 @@ tplink_board_detect() {
 	hwver=" v${hwver#0}"
 
 	case "$hwid" in
+	001001*)
+		model="TP-Link TL-MR10U"
+		;;
+	001101*)
+		model="TP-Link TL-MR11U"
+		;;
+	001201*)
+		model="TP-Link TL-MR12U"
+		;;
+	001301*)
+		model="TP-Link TL-MR13U"
+		;;
+	007260*)
+		model="TellStick ZNet Lite"
+		;;
 	015000*)
 		model="EasyLink EL-M150"
 		;;
@@ -157,26 +172,14 @@ tplink_board_detect() {
 	044403*)
 		model="ANTMINER-S3"
 		;;
-	44440101*)
-		model="ANTROUTER-R1"
-		;;
-	120000*)
-		model="MERCURY MAC1200R"
-		;;
-	007260*)
-		model="TellStick ZNet Lite"
-		;;
 	066601*)
 		model="OMYlink OMY-G1"
 		;;
 	066602*)
 		model="OMYlink OMY-X1"
 		;;
-	3C0001*)
-		model="OOLITE"
-		;;
-	3C0002*)
-		model="MINIBOX_V1"
+	070100*)
+		model="TP-Link TL-WA701N/ND"
 		;;
 	070301*)
 		model="TP-Link TL-WR703N"
@@ -190,9 +193,6 @@ tplink_board_detect() {
 		;;
 	072001*)
 		model="TP-Link TL-WR720N"
-		;;
-	070100*)
-		model="TP-Link TL-WA701N/ND"
 		;;
 	073000*)
 		model="TP-Link TL-WA730RE"
@@ -208,12 +208,6 @@ tplink_board_detect() {
 		;;
 	075000*)
 		model="TP-Link TL-WA750RE"
-		;;
-	721000*)
-		model="TP-Link TL-WA7210N"
-		;;
-	751000*)
-		model="TP-Link TL-WA7510N"
 		;;
 	080100*)
 		model="TP-Link TL-WA801N/ND"
@@ -267,20 +261,11 @@ tplink_board_detect() {
 	104300*)
 		model="TP-Link TL-WR1043N/ND"
 		;;
+	120000*)
+		model="MERCURY MAC1200R"
+		;;
 	254300*)
 		model="TP-Link TL-WR2543N/ND"
-		;;
-	001001*)
-		model="TP-Link TL-MR10U"
-		;;
-	001101*)
-		model="TP-Link TL-MR11U"
-		;;
-	001201*)
-		model="TP-Link TL-MR12U"
-		;;
-	001301*)
-		model="TP-Link TL-MR13U"
 		;;
 	302000*)
 		model="TP-Link TL-MR3020"
@@ -291,17 +276,23 @@ tplink_board_detect() {
 	322000*)
 		model="TP-Link TL-MR3220"
 		;;
-	342000*)
-		model="TP-Link TL-MR3420"
-		;;
 	332000*)
 		model="TP-Link TL-WDR3320"
+		;;
+	342000*)
+		model="TP-Link TL-MR3420"
 		;;
 	350000*)
 		model="TP-Link TL-WDR3500"
 		;;
 	360000*)
 		model="TP-Link TL-WDR3600"
+		;;
+	3C0001*)
+		model="OOLITE"
+		;;
+	3C0002*)
+		model="MINIBOX_V1"
 		;;
 	430000*)
 		model="TP-Link TL-WDR4300"
@@ -313,24 +304,33 @@ tplink_board_detect() {
 	431000*)
 		model="TP-Link TL-WDR4310"
 		;;
+	44440101*)
+		model="ANTROUTER-R1"
+		;;
+	453000*)
+		model="Mercury MW4530R"
+		;;
 	49000002)
 		model="TP-Link TL-WDR4900"
 		;;
 	65000002)
 		model="TP-Link TL-WDR6500"
 		;;
-	453000*)
-		model="Mercury MW4530R"
+	721000*)
+		model="TP-Link TL-WA7210N"
+		;;
+	750000*|\
+	c70000*)
+		model="TP-Link Archer C7"
+		;;
+	751000*)
+		model="TP-Link TL-WA7510N"
 		;;
 	934100*)
 		model="NC-LINK SMART-300"
 		;;
 	c50000*)
 		model="TP-Link Archer C5"
-		;;
-	750000*|\
-	c70000*)
-		model="TP-Link Archer C7"
 		;;
 	*)
 		hwver=""
@@ -363,11 +363,11 @@ gl_inet_board_detect() {
 	local size="$(mtd_get_part_size 'firmware')"
 
 	case "$size" in
-	8192000)
-		AR71XX_MODEL='GL-iNet 6408A v1'
-		;;
 	16580608)
 		AR71XX_MODEL='GL-iNet 6416A v1'
+		;;
+	8192000)
+		AR71XX_MODEL='GL-iNet 6408A v1'
 		;;
 	esac
 }
@@ -379,9 +379,6 @@ ar71xx_board_detect() {
 	machine=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo)
 
 	case "$machine" in
-	*"Oolite V1.0")
-		name="oolite"
-		;;
 	*AC1750DB)
 		name="f9k1115v2"
 		;;
@@ -418,9 +415,6 @@ ar71xx_board_detect() {
 	*Antminer-S3)
 		name="antminer-s3"
 		;;
-	*Yun)
-		name="arduino-yun"
-		;;
 	*"AP121 reference"*)
 		name="ap121"
 		;;
@@ -430,14 +424,14 @@ ar71xx_board_detect() {
 	*AP132*)
 		name="ap132"
 		;;
+	*AP135-020*)
+		name="ap135-020"
+		;;
 	*AP136-010*)
 		name="ap136-010"
 		;;
 	*AP136-020*)
 		name="ap136-020"
-		;;
-	*AP135-020*)
-		name="ap135-020"
 		;;
 	*AP143*)
 		name="ap143"
@@ -472,8 +466,15 @@ ar71xx_board_detect() {
 	*BHR-4GRV2)
 		name="bhr-4grv2"
 		;;
-	*CAP324)
-		name="cap324"
+	*"Black Swift board"*)
+		name="bsb"
+		;;
+	*"Bullet M")
+		name="bullet-m"
+		ubnt_xm_board_detect
+		;;
+	*"BXU2000n-2 rev. A1")
+		name="bxu2000n-2-a1"
 		;;
 	*C-55)
 		name="c-55"
@@ -481,8 +482,14 @@ ar71xx_board_detect() {
 	*C-60)
 		name="c-60"
 		;;
+	*CAP324)
+		name="cap324"
+		;;
 	*CAP4200AG)
 		name="cap4200ag"
+		;;
+	*Carambola2*)
+		name="carambola2"
 		;;
 	*"CF-E316N v2")
 		name="cf-e316n-v2"
@@ -516,14 +523,6 @@ ar71xx_board_detect() {
 	*CPE870)
 		name="cpe870"
 		;;
-	*WBS210)
-		name="wbs210"
-		tplink_pharos_board_detect
-		;;
-	*WBS510)
-		name="wbs510"
-		tplink_pharos_board_detect
-		;;
 	*CR3000)
 		name="cr3000"
 		;;
@@ -549,6 +548,9 @@ ar71xx_board_detect() {
 	*"DIR-600 rev. A1")
 		name="dir-600-a1"
 		;;
+	*"DIR-615 rev. C1")
+		name="dir-615-c1"
+		;;
 	*"DIR-615 rev. E1")
 		name="dir-615-e1"
 		;;
@@ -573,11 +575,14 @@ ar71xx_board_detect() {
 	*"dLAN Hotspot")
 		name="dlan-hotspot"
 		;;
+	*"dLAN pro 1200+ WiFi ac")
+		name="dlan-pro-1200-ac"
+		;;
 	*"dLAN pro 500 Wireless+")
 		name="dlan-pro-500-wp"
 		;;
-	*"dLAN pro 1200+ WiFi ac")
-		name="dlan-pro-1200-ac"
+	*"Domino Pi")
+		name="gl-domino"
 		;;
 	*DR344)
 		name="dr344"
@@ -587,9 +592,6 @@ ar71xx_board_detect() {
 		;;
 	*"Dragino v2")
 		name="dragino2"
-		;;
-	*"Domino Pi")
-		name="gl-domino"
 		;;
 	*DW33D)
 		name="dw33d"
@@ -613,21 +615,11 @@ ar71xx_board_detect() {
 	*EL-MINI)
 		name="el-mini"
 		;;
-	*"GL-CONNECT INET v1")
-		name="gl-inet"
-		gl_inet_board_detect
+	*EmbWir-Dorin)
+		name="ew-dorin"
 		;;
-	*"GL AR150")
-		name="gl-ar150"
-		;;
-	*"GL AR300")
-		name="gl-ar300"
-		;;
-	*GL-AR300M)
-		name="gl-ar300m"
-		;;
-	*GL-MIFI)
-		name="gl-mifi"
+	*EmbWir-Dorin-Router)
+		name="ew-dorin-router"
 		;;
 	*EPG5000)
 		name="epg5000"
@@ -638,31 +630,24 @@ ar71xx_board_detect() {
 	*ESR900)
 		name="esr900"
 		;;
-	*JA76PF)
-		name="ja76pf"
+	*"GL AR150")
+		name="gl-ar150"
 		;;
-	*JA76PF2)
-		name="ja76pf2"
+	*"GL AR300")
+		name="gl-ar300"
 		;;
-	*"Bullet M")
-		name="bullet-m"
-		ubnt_xm_board_detect
+	*GL-AR300M)
+		name="gl-ar300m"
 		;;
-	*"Loco M XW")
-		name="loco-m-xw"
+	*"GL-CONNECT INET v1")
+		name="gl-inet"
+		gl_inet_board_detect
 		;;
-	*"Nanostation M")
-		name="nanostation-m"
-		ubnt_xm_board_detect
+	*GL-MIFI)
+		name="gl-mifi"
 		;;
-	*"Nanostation M XW")
-		name="nanostation-m-xw"
-		;;
-	*JWAP003)
-		name="jwap003"
-		;;
-	*JWAP230)
-		name="jwap230"
+	*HC6361)
+		name="hiwifi-hc6361"
 		;;
 	*Hornet-UB)
 		local size
@@ -675,6 +660,21 @@ ar71xx_board_detect() {
 		if [ "x$size" = "x00f90000" ]; then
 			name="hornet-ub-x2"
 		fi
+		;;
+	*JA76PF)
+		name="ja76pf"
+		;;
+	*JA76PF2)
+		name="ja76pf2"
+		;;
+	*JWAP003)
+		name="jwap003"
+		;;
+	*JWAP230)
+		name="jwap230"
+		;;
+	*"Loco M XW")
+		name="loco-m-xw"
 		;;
 	*LS-SR71)
 		name="ls-sr71"
@@ -691,20 +691,20 @@ ar71xx_board_detect() {
 	*MR16)
 		name="mr16"
 		;;
-	*MR18)
-		name="mr18"
-		;;
-	*MR600v2)
-		name="mr600v2"
-		;;
 	*MR1750)
 		name="mr1750"
 		;;
 	*MR1750v2)
 		name="mr1750v2"
 		;;
+	*MR18)
+		name="mr18"
+		;;
 	*MR600)
 		name="mr600"
+		;;
+	*MR600v2)
+		name="mr600v2"
 		;;
 	*MR900)
 		name="mr900"
@@ -727,6 +727,13 @@ ar71xx_board_detect() {
 	*MZK-W300NH)
 		name="mzk-w300nh"
 		;;
+	*"Nanostation M")
+		name="nanostation-m"
+		ubnt_xm_board_detect
+		;;
+	*"Nanostation M XW")
+		name="nanostation-m-xw"
+		;;
 	*NBG460N/550N/550NH)
 		name="nbg460n_550n_550nh"
 		;;
@@ -738,9 +745,6 @@ ar71xx_board_detect() {
 		;;
 	*OM2P)
 		name="om2p"
-		;;
-	*OM2Pv2)
-		name="om2pv2"
 		;;
 	*"OM2P HS")
 		name="om2p-hs"
@@ -754,11 +758,11 @@ ar71xx_board_detect() {
 	*"OM2P LC")
 		name="om2p-lc"
 		;;
+	*OM2Pv2)
+		name="om2pv2"
+		;;
 	*OM5P)
 		name="om5p"
-		;;
-	*"OM5P AN")
-		name="om5p-an"
 		;;
 	*"OM5P AC")
 		name="om5p-ac"
@@ -766,14 +770,20 @@ ar71xx_board_detect() {
 	*"OM5P ACv2")
 		name="om5p-acv2"
 		;;
-	*OMY-X1)
-		name="omy-x1"
+	*"OM5P AN")
+		name="om5p-an"
 		;;
 	*OMY-G1)
 		name="omy-g1"
 		;;
+	*OMY-X1)
+		name="omy-x1"
+		;;
 	*"Onion Omega")
 		name="onion-omega"
+		;;
+	*"Oolite V1.0")
+		name="oolite"
 		;;
 	*PB42)
 		name="pb42"
@@ -787,8 +797,36 @@ ar71xx_board_detect() {
 	*"Qihoo 360 C301")
 		name="qihoo-c301"
 		;;
+	*R6100)
+		name="r6100"
+		;;
 	*RE450)
 		name="re450"
+		;;
+	*"Rocket M")
+		name="rocket-m"
+		ubnt_xm_board_detect
+		;;
+	*"Rocket M TI")
+		name="rocket-m-ti"
+		;;
+	*"Rocket M XW")
+		name="rocket-m-xw"
+		;;
+	*"RouterBOARD 2011L")
+		name="rb-2011l"
+		;;
+	*"RouterBOARD 2011UAS")
+		name="rb-2011uas"
+		;;
+	*"RouterBOARD 2011UAS-2HnD")
+		name="rb-2011uas-2hnd"
+		;;
+	*"RouterBOARD 2011UiAS")
+		name="rb-2011uias"
+		;;
+	*"RouterBOARD 2011UiAS-2HnD")
+		name="rb-2011uias-2hnd"
 		;;
 	*"RouterBOARD 411/A/AH")
 		name="rb-411"
@@ -832,11 +870,11 @@ ar71xx_board_detect() {
 	*"RouterBOARD 911G-2HPnD")
 		name="rb-911g-2hpnd"
 		;;
-	*"RouterBOARD 911G-5HPnD")
-		name="rb-911g-5hpnd"
-		;;
 	*"RouterBOARD 911G-5HPacD")
 		name="rb-911g-5hpacd"
+		;;
+	*"RouterBOARD 911G-5HPnD")
+		name="rb-911g-5hpnd"
 		;;
 	*"RouterBOARD 912UAG-2HPnD")
 		name="rb-912uag-2hpnd"
@@ -853,36 +891,11 @@ ar71xx_board_detect() {
 	*"RouterBOARD 951Ui-2HnD")
 		name="rb-951ui-2hnd"
 		;;
-	*"RouterBOARD 2011L")
-		name="rb-2011l"
-		;;
-	*"RouterBOARD 2011UAS")
-		name="rb-2011uas"
-		;;
-	*"RouterBOARD 2011UiAS")
-		name="rb-2011uias"
-		;;
-	*"RouterBOARD 2011UAS-2HnD")
-		name="rb-2011uas-2hnd"
-		;;
-	*"RouterBOARD 2011UiAS-2HnD")
-		name="rb-2011uias-2hnd"
-		;;
 	*"RouterBOARD SXT Lite2")
 		name="rb-sxt2n"
 		;;
 	*"RouterBOARD SXT Lite5")
 		name="rb-sxt5n"
-		;;
-	*"Rocket M")
-		name="rocket-m"
-		ubnt_xm_board_detect
-		;;
-	*"Rocket M TI")
-		name="rocket-m-ti"
-		;;
-	*"Rocket M XW")
-		name="rocket-m-xw"
 		;;
 	*RouterStation)
 		name="routerstation"
@@ -905,17 +918,14 @@ ar71xx_board_detect() {
 	*SMART-300)
 		name="smart-300"
 		;;
-	*"Black Swift board"*)
-		name="bsb"
-		;;
-	*"TellStick ZNet Lite")
-		name="tellstick-znet-lite"
-		;;
 	*SOM9331)
 		name="som9331"
 		;;
 	*SR3200)
 		name="sr3200"
+		;;
+	*"TellStick ZNet Lite")
+		name="tellstick-znet-lite"
 		;;
 	*TEW-632BRP)
 		name="tew-632brp"
@@ -932,23 +942,17 @@ ar71xx_board_detect() {
 	*TEW-823DRU)
 		name="tew-823dru"
 		;;
-	*"TL-WR1041N v2")
-		name="tl-wr1041n-v2"
+	*TL-MR10U)
+		name="tl-mr10u"
 		;;
-	*TL-WR1043ND)
-		name="tl-wr1043nd"
+	*TL-MR11U)
+		name="tl-mr11u"
 		;;
-	*"TL-WR1043ND v2")
-		name="tl-wr1043nd-v2"
+	*TL-MR12U)
+		name="tl-mr12u"
 		;;
-	*"TL-WR1043ND v4")
-		name="tl-wr1043nd-v4"
-		;;
-	*TL-WR2543N*)
-		name="tl-wr2543n"
-		;;
-	*"DIR-615 rev. C1")
-		name="dir-615-c1"
+	*"TL-MR13U v1")
+		name="tl-mr13u"
 		;;
 	*TL-MR3020)
 		name="tl-mr3020"
@@ -983,23 +987,20 @@ ar71xx_board_detect() {
 	*"TL-WA7510N v1")
 		name="tl-wa7510n"
 		;;
-	*TL-WA850RE)
-		name="tl-wa850re"
-		;;
-	*TL-WA860RE)
-		name="tl-wa860re"
-		;;
-	*"TL-WA830RE v2")
-		name="tl-wa830re-v2"
-		;;
 	*"TL-WA801ND v2")
 		name="tl-wa801nd-v2"
 		;;
 	*"TL-WA801ND v3")
 		name="tl-wa801nd-v3"
 		;;
-	*"TL-WR802N v1")
-		name="tl-wr802n-v1"
+	*"TL-WA830RE v2")
+		name="tl-wa830re-v2"
+		;;
+	*TL-WA850RE)
+		name="tl-wa850re"
+		;;
+	*TL-WA860RE)
+		name="tl-wa860re"
 		;;
 	*TL-WA901ND)
 		name="tl-wa901nd"
@@ -1031,44 +1032,20 @@ ar71xx_board_detect() {
 	*TL-WPA8630)
 		name="tl-wpa8630"
 		;;
-	*TL-WR741ND)
-		name="tl-wr741nd"
+	*"TL-WR1041N v2")
+		name="tl-wr1041n-v2"
 		;;
-	*"TL-WR741ND v4")
-		name="tl-wr741nd-v4"
+	*TL-WR1043ND)
+		name="tl-wr1043nd"
 		;;
-	*"TL-WR841N v1")
-		name="tl-wr841n-v1"
+	*"TL-WR1043ND v2")
+		name="tl-wr1043nd-v2"
 		;;
-	*"TL-WR841N/ND v7")
-		name="tl-wr841n-v7"
+	*"TL-WR1043ND v4")
+		name="tl-wr1043nd-v4"
 		;;
-	*"TL-WR841N/ND v8")
-		name="tl-wr841n-v8"
-		;;
-	*"TL-WR841N/ND v9")
-		name="tl-wr841n-v9"
-		;;
-	*"TL-WR841N/ND v11")
-		name="tl-wr841n-v11"
-		;;
-	*"TL-WR842N/ND v2")
-		name="tl-wr842n-v2"
-		;;
-	*"TL-WR842N/ND v3")
-		name="tl-wr842n-v3"
-		;;
-	*TL-WR941ND)
-		name="tl-wr941nd"
-		;;
-	*"TL-WR941N/ND v5")
-		name="tl-wr941nd-v5"
-		;;
-	*"TL-WR941N/ND v6")
-		name="tl-wr941nd-v6"
-		;;
-	*"TL-WR940N v4")
-		name="tl-wr940n-v4"
+	*TL-WR2543N*)
+		name="tl-wr2543n"
 		;;
 	*"TL-WR703N v1")
 		name="tl-wr703n"
@@ -1079,20 +1056,50 @@ ar71xx_board_detect() {
 	*TL-WR720N*)
 		name="tl-wr720n-v3"
 		;;
+	*TL-WR741ND)
+		name="tl-wr741nd"
+		;;
+	*"TL-WR741ND v4")
+		name="tl-wr741nd-v4"
+		;;
+	*"TL-WR802N v1")
+		name="tl-wr802n-v1"
+		;;
 	*TL-WR810N)
 		name="tl-wr810n"
 		;;
-	*TL-MR10U)
-		name="tl-mr10u"
+	*"TL-WR841N v1")
+		name="tl-wr841n-v1"
 		;;
-	*TL-MR11U)
-		name="tl-mr11u"
+	*"TL-WR841N/ND v11")
+		name="tl-wr841n-v11"
 		;;
-	*TL-MR12U)
-		name="tl-mr12u"
+	*"TL-WR841N/ND v7")
+		name="tl-wr841n-v7"
 		;;
-	*"TL-MR13U v1")
-		name="tl-mr13u"
+	*"TL-WR841N/ND v8")
+		name="tl-wr841n-v8"
+		;;
+	*"TL-WR841N/ND v9")
+		name="tl-wr841n-v9"
+		;;
+	*"TL-WR842N/ND v2")
+		name="tl-wr842n-v2"
+		;;
+	*"TL-WR842N/ND v3")
+		name="tl-wr842n-v3"
+		;;
+	*"TL-WR940N v4")
+		name="tl-wr940n-v4"
+		;;
+	*"TL-WR941N/ND v5")
+		name="tl-wr941nd-v5"
+		;;
+	*"TL-WR941N/ND v6")
+		name="tl-wr941nd-v6"
+		;;
+	*TL-WR941ND)
+		name="tl-wr941nd"
 		;;
 	*Tube2H)
 		name="tube2h"
@@ -1100,14 +1107,28 @@ ar71xx_board_detect() {
 	*UniFi)
 		name="unifi"
 		;;
+	*"UniFi AP Pro")
+		name="uap-pro"
+		;;
 	*UniFi-AC-LITE)
 		name="unifiac-lite"
 		;;
 	*UniFi-AC-PRO)
 		name="unifiac-pro"
 		;;
-	*"UniFi AP Pro")
-		name="uap-pro"
+	*"UniFiAP Outdoor")
+		name="unifi-outdoor"
+		;;
+	*"UniFiAP Outdoor+")
+		name="unifi-outdoor-plus"
+		;;
+	*WBS210)
+		name="wbs210"
+		tplink_pharos_board_detect
+		;;
+	*WBS510)
+		name="wbs510"
+		tplink_pharos_board_detect
 		;;
 	WeIO*)
 		name="weio"
@@ -1115,17 +1136,47 @@ ar71xx_board_detect() {
 	*WHR-G301N)
 		name="whr-g301n"
 		;;
+	*WHR-HP-G300N)
+		name="whr-hp-g300n"
+		;;
 	*WHR-HP-GN)
 		name="whr-hp-gn"
 		;;
 	*WLAE-AG300N)
 		name="wlae-ag300n"
 		;;
-	*"UniFiAP Outdoor")
-		name="unifi-outdoor"
+	*WLR-8100)
+		name="wlr8100"
 		;;
-	*"UniFiAP Outdoor+")
-		name="unifi-outdoor-plus"
+	*WNDAP360)
+		name="wndap360"
+		;;
+	*WNDR3700/WNDR3800/WNDRMAC)
+		wndr3700_board_detect "$machine"
+		;;
+	*WNDR3700v4)
+		name="wndr3700v4"
+		;;
+	*WNDR4300)
+		name="wndr4300"
+		;;
+	*"WNR1000 V2")
+		name="wnr1000-v2"
+		;;
+	*WNR2000)
+		name="wnr2000"
+		;;
+	*"WNR2000 V3")
+		name="wnr2000-v3"
+		;;
+	*"WNR2000 V4")
+		name="wnr2000-v4"
+		;;
+	*WNR2200)
+		name="wnr2200"
+		;;
+	*"WNR612 V2")
+		name="wnr612-v2"
 		;;
 	*WP543)
 		name="wp543"
@@ -1144,39 +1195,6 @@ ar71xx_board_detect() {
 		;;
 	*WPJ558)
 		name="wpj558"
-		;;
-	*WNDAP360)
-		name="wndap360"
-		;;
-	*WNDR3700/WNDR3800/WNDRMAC)
-		wndr3700_board_detect "$machine"
-		;;
-	*R6100)
-		name="r6100"
-		;;
-	*WNDR3700v4)
-		name="wndr3700v4"
-		;;
-	*WNDR4300)
-		name="wndr4300"
-		;;
-	*"WNR2000 V4")
-		name="wnr2000-v4"
-		;;
-	*"WNR2000 V3")
-		name="wnr2000-v3"
-		;;
-	*WNR2000)
-		name="wnr2000"
-		;;
-	*WNR2200)
-		name="wnr2200"
-		;;
-	*"WNR612 V2")
-		name="wnr612-v2"
-		;;
-	*"WNR1000 V2")
-		name="wnr1000-v2"
 		;;
 	*WPN824N)
 		name="wpn824n"
@@ -1199,17 +1217,17 @@ ar71xx_board_detect() {
 	*WZR-HP-G300NH)
 		name="wzr-hp-g300nh"
 		;;
-	*WZR-HP-G450H)
-		name="wzr-hp-g450h"
-		;;
 	*WZR-HP-G300NH2)
 		name="wzr-hp-g300nh2"
 		;;
-	*WHR-HP-G300N)
-		name="whr-hp-g300n"
+	*WZR-HP-G450H)
+		name="wzr-hp-g450h"
 		;;
 	*XD3200)
 		name="xd3200"
+		;;
+	*Yun)
+		name="arduino-yun"
 		;;
 	*Z1)
 		name="z1"
@@ -1222,24 +1240,6 @@ ar71xx_board_detect() {
 		;;
 	*ZCN-1523H-5)
 		name="zcn-1523h-5"
-		;;
-	*EmbWir-Dorin)
-		name="ew-dorin"
-		;;
-	*EmbWir-Dorin-Router)
-		name="ew-dorin-router"
-		;;
-	*Carambola2*)
-		name="carambola2"
-		;;
-	*WLR-8100)
-		name="wlr8100"
-		;;
-	*"BXU2000n-2 rev. A1")
-		name="bxu2000n-2-a1"
-		;;
-	*HC6361)
-		name="hiwifi-hc6361"
 		;;
 	esac
 

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -379,35 +379,62 @@ ar71xx_board_detect() {
 	machine=$(awk 'BEGIN{FS="[ \t]+:[ \t]"} /machine/ {print $2}' /proc/cpuinfo)
 
 	case "$machine" in
+	Abicom*)
+		case "$machine" in
+		*SC1750)
+			name="sc1750"
+			;;
+		*SC300M)
+			name="sc300m"
+			;;
+		*SC450)
+			name="sc450"
+			;;
+		esac
+		;;
 	*AC1750DB)
 		name="f9k1115v2"
 		;;
-	*AirGateway)
-		name="airgateway"
+	ALFA*)
+		case "$machine" in
+		*AP120C)
+			name="alfa-ap120c"
+			;;
+		*AP96)
+			name="alfa-ap96"
+			;;
+		*Hornet-UB)
+			local size
+			size=$(awk '/firmware/ { print $2 }' /proc/mtd)
+
+			if [ "x$size" = "x00790000" ]; then
+				name="hornet-ub"
+			fi
+
+			if [ "x$size" = "x00f90000" ]; then
+				name="hornet-ub-x2"
+			fi
+			;;
+		*N2/N5)
+			name="alfa-nx"
+			;;
+		*Tube2H)
+			name="tube2h"
+			;;
+		esac
 		;;
-	*"AirGateway Pro")
-		name="airgatewaypro"
-		;;
-	*AirRouter)
-		name="airrouter"
-		;;
-	*"ALFA Network AP120C")
-		name="alfa-ap120c"
-		;;
-	*"ALFA Network AP96")
-		name="alfa-ap96"
-		;;
-	*"ALFA Network N2/N5")
-		name="alfa-nx"
-		;;
-	*ALL0258N)
-		name="all0258n"
-		;;
-	*ALL0305)
-		name="all0305"
-		;;
-	*ALL0315N)
-		name="all0315n"
+	Allnet*)
+		case "$machine" in
+		*ALL0258N)
+			name="all0258n"
+			;;
+		*ALL0305)
+			name="all0305"
+			;;
+		*ALL0315N)
+			name="all0315n"
+			;;
+		esac
 		;;
 	*Antminer-S1)
 		name="antminer-s1"
@@ -415,63 +442,88 @@ ar71xx_board_detect() {
 	*Antminer-S3)
 		name="antminer-s3"
 		;;
-	*"AP121 reference"*)
-		name="ap121"
-		;;
-	*AP121-MINI)
-		name="ap121-mini"
-		;;
-	*AP132*)
-		name="ap132"
-		;;
-	*AP135-020*)
-		name="ap135-020"
-		;;
-	*AP136-010*)
-		name="ap136-010"
-		;;
-	*AP136-020*)
-		name="ap136-020"
-		;;
-	*AP143*)
-		name="ap143"
-		;;
-	*AP147-010*)
-		name="ap147-010"
-		;;
-	*AP152*)
-		name="ap152"
-		;;
-	*AP90Q)
-		name="ap90q"
-		;;
-	*"Archer C5")
-		name="archer-c5"
-		;;
-	*"Archer C59 v1")
-		name="archer-c59-v1"
-		;;
-	*"Archer C60 v1")
-		name="archer-c60-v1"
-		;;
-	*"Archer C7")
-		name="archer-c7"
-		;;
-	*"Atheros AP96")
-		name="ap96"
+	*Atheros*)
+		case "$machine" in
+		*AP121*)
+			name="ap121"
+			;;
+		*AP121-MINI)
+			name="ap121-mini"
+			;;
+		*AP132*)
+			name="ap132"
+			;;
+		*AP135-020*)
+			name="ap135-020"
+			;;
+		*AP136-010*)
+			name="ap136-010"
+			;;
+		*AP136-020*)
+			name="ap136-020"
+			;;
+		*AP143*)
+			name="ap143"
+			;;
+		*AP147-010*)
+			name="ap147-010"
+			;;
+		*AP152*)
+			name="ap152"
+			;;
+		*AP96)
+			name="ap96"
+			;;
+		*DB120*)
+			name="db120"
+			;;
+		*PB42)
+			name="pb42"
+			;;
+		*PB44*)
+			name="pb44"
+			;;
+		esac
 		;;
 	*AW-NR580)
 		name="aw-nr580"
 		;;
-	*BHR-4GRV2)
-		name="bhr-4grv2"
-		;;
 	*"Black Swift board"*)
 		name="bsb"
 		;;
-	*"Bullet M")
-		name="bullet-m"
-		ubnt_xm_board_detect
+	Buffalo*)
+		case "$machine" in
+		*BHR-4GRV2)
+			name="bhr-4grv2"
+			;;
+		*WHR-G301N)
+			name="whr-g301n"
+			;;
+		*WHR-HP-G300N)
+			name="whr-hp-g300n"
+			;;
+		*WHR-HP-GN)
+			name="whr-hp-gn"
+			;;
+		*WLAE-AG300N)
+			name="wlae-ag300n"
+			;;
+		*WZR-450HP2)
+			name="wzr-450hp2"
+			;;
+		*WZR-HP-AG300H/WZR-600DHP)
+			name="wzr-hp-ag300h"
+			;;
+		*WZR-HP-G300NH)
+			name="wzr-hp-g300nh"
+			;;
+		*WZR-HP-G300NH2)
+			name="wzr-hp-g300nh2"
+			;;
+		*WZR-HP-G450H)
+			name="wzr-hp-g450h"
+			;;
+		esac
 		;;
 	*"BXU2000n-2 rev. A1")
 		name="bxu2000n-2-a1"
@@ -491,37 +543,49 @@ ar71xx_board_detect() {
 	*Carambola2*)
 		name="carambola2"
 		;;
-	*"CF-E316N v2")
-		name="cf-e316n-v2"
+	COMFAST*)
+		case "$machine" in
+		*"E316N v2")
+			name="cf-e316n-v2"
+			;;
+		*"E320N v2")
+			name="cf-e320n-v2"
+			;;
+		*"E380AC v1")
+			name="cf-e380ac-v1"
+			;;
+		*"E380AC v2")
+			name="cf-e380ac-v2"
+			;;
+		*E520N)
+			name="cf-e520n"
+			;;
+		*E530N)
+			name="cf-e530n"
+			;;
+		esac
 		;;
-	*"CF-E320N v2")
-		name="cf-e320n-v2"
-		;;
-	*"CF-E380AC v1")
-		name="cf-e380ac-v1"
-		;;
-	*"CF-E380AC v2")
-		name="cf-e380ac-v2"
-		;;
-	*CF-E520N)
-		name="cf-e520n"
-		;;
-	*CF-E530N)
-		name="cf-e530n"
-		;;
-	*CPE210/220)
-		name="cpe210"
-		tplink_pharos_board_detect
-		;;
-	*CPE510/520)
-		name="cpe510"
-		tplink_pharos_board_detect
-		;;
-	*CPE830)
-		name="cpe830"
-		;;
-	*CPE870)
-		name="cpe870"
+	Compex*)
+		case "$machine" in
+		*WP543)
+			name="wp543"
+			;;
+		*WPE72)
+			name="wpe72"
+			;;
+		*WPJ342)
+			name="wpj342"
+			;;
+		*WPJ344)
+			name="wpj344"
+			;;
+		*WPJ531)
+			name="wpj531"
+			;;
+		*WPJ558)
+			name="wpj558"
+			;;
+		esac
 		;;
 	*CR3000)
 		name="cr3000"
@@ -529,48 +593,49 @@ ar71xx_board_detect() {
 	*CR5000)
 		name="cr5000"
 		;;
-	*"DAP-2695 rev. A1")
-		name="dap-2695-a1"
-		;;
-	*DB120*)
-		name="db120"
-		;;
-	*"DGL-5500 rev. A1")
-		name="dgl-5500-a1"
-		;;
-	*"DHP-1565 rev. A1")
-		name="dhp-1565-a1"
-		;;
-	*"DIR-505 rev. A1")
-		name="dir-505-a1"
-		dir505_board_detect
-		;;
-	*"DIR-600 rev. A1")
-		name="dir-600-a1"
-		;;
-	*"DIR-615 rev. C1")
-		name="dir-615-c1"
-		;;
-	*"DIR-615 rev. E1")
-		name="dir-615-e1"
-		;;
-	*"DIR-615 rev. E4")
-		name="dir-615-e4"
-		;;
-	*"DIR-615 rev. I1")
-		name="dir-615-i1"
-		;;
-	*"DIR-825 rev. B1")
-		name="dir-825-b1"
-		;;
-	*"DIR-825 rev. C1")
-		name="dir-825-c1"
-		;;
-	*"DIR-835 rev. A1")
-		name="dir-835-a1"
-		;;
-	*"DIR-869 rev. A1")
-		name="dir-869-a1"
+	D-Link*)
+		case "$machine" in
+		*"DAP-2695 rev. A1")
+			name="dap-2695-a1"
+			;;
+		*"DGL-5500 rev. A1")
+			name="dgl-5500-a1"
+			;;
+		*"DHP-1565 rev. A1")
+			name="dhp-1565-a1"
+			;;
+		*"DIR-505 rev. A1")
+			name="dir-505-a1"
+			dir505_board_detect
+			;;
+		*"DIR-600 rev. A1")
+			name="dir-600-a1"
+			;;
+		*"DIR-615 rev. C1")
+			name="dir-615-c1"
+			;;
+		*"DIR-615 rev. E1")
+			name="dir-615-e1"
+			;;
+		*"DIR-615 rev. E4")
+			name="dir-615-e4"
+			;;
+		*"DIR-615 rev. I1")
+			name="dir-615-i1"
+			;;
+		*"DIR-825 rev. B1")
+			name="dir-825-b1"
+			;;
+		*"DIR-825 rev. C1")
+			name="dir-825-c1"
+			;;
+		*"DIR-835 rev. A1")
+			name="dir-835-a1"
+			;;
+		*"DIR-869 rev. A1")
+			name="dir-869-a1"
+			;;
+		esac
 		;;
 	*"dLAN Hotspot")
 		name="dlan-hotspot"
@@ -599,13 +664,6 @@ ar71xx_board_detect() {
 	*E2100L)
 		name="e2100l"
 		;;
-	*EAP120)
-		name="eap120"
-		tplink_pharos_board_detect
-		;;
-	*"EAP300 v2")
-		name="eap300v2"
-		;;
 	*EAP7660D)
 		name="eap7660d"
 		;;
@@ -621,14 +679,21 @@ ar71xx_board_detect() {
 	*EmbWir-Dorin-Router)
 		name="ew-dorin-router"
 		;;
-	*EPG5000)
-		name="epg5000"
-		;;
-	*ESR1750)
-		name="esr1750"
-		;;
-	*ESR900)
-		name="esr900"
+	EnGenius*)
+		case "$machine" in
+		*"EAP300 v2")
+			name="eap300v2"
+			;;
+		*EPG5000)
+			name="epg5000"
+			;;
+		*ESR1750)
+			name="esr1750"
+			;;
+		*ESR900)
+			name="esr900"
+			;;
+		esac
 		;;
 	*"GL AR150")
 		name="gl-ar150"
@@ -649,77 +714,131 @@ ar71xx_board_detect() {
 	*HC6361)
 		name="hiwifi-hc6361"
 		;;
-	*Hornet-UB)
-		local size
-		size=$(awk '/firmware/ { print $2 }' /proc/mtd)
-
-		if [ "x$size" = "x00790000" ]; then
-			name="hornet-ub"
-		fi
-
-		if [ "x$size" = "x00f90000" ]; then
-			name="hornet-ub-x2"
-		fi
-		;;
-	*JA76PF)
-		name="ja76pf"
-		;;
-	*JA76PF2)
-		name="ja76pf2"
-		;;
-	*JWAP003)
-		name="jwap003"
-		;;
-	*JWAP230)
-		name="jwap230"
-		;;
-	*"Loco M XW")
-		name="loco-m-xw"
-		;;
-	*LS-SR71)
-		name="ls-sr71"
+	jjPlus*)
+		case "$machine" in
+		*JA76PF)
+			name="ja76pf"
+			;;
+		*JA76PF2)
+			name="ja76pf2"
+			;;
+		*JWAP003)
+			name="jwap003"
+			;;
+		*JWAP230)
+			name="jwap230"
+			;;
+		esac
 		;;
 	*MAC1200R)
 		name="mc-mac1200r"
 		;;
+	Meraki*)
+		case "$machine" in
+		*MR12)
+			name="mr12"
+			;;
+		*MR16)
+			name="mr16"
+			;;
+		*MR18)
+			name="mr18"
+			;;
+		*Z1)
+			name="z1"
+			;;
+		esac
+		;;
+	MikroTik*)
+		case "$machine" in
+		*2011L)
+			name="rb-2011l"
+			;;
+		*2011UAS)
+			name="rb-2011uas"
+			;;
+		*2011UAS-2HnD)
+			name="rb-2011uas-2hnd"
+			;;
+		*2011UiAS)
+			name="rb-2011uias"
+			;;
+		*2011UiAS-2HnD)
+			name="rb-2011uias-2hnd"
+			;;
+		*411/A/AH)
+			name="rb-411"
+			;;
+		*411U)
+			name="rb-411u"
+			;;
+		*433/AH)
+			name="rb-433"
+			;;
+		*433UAH)
+			name="rb-433u"
+			;;
+		*435G)
+			name="rb-435g"
+			;;
+		*450)
+			name="rb-450"
+			;;
+		*450G)
+			name="rb-450g"
+			;;
+		*493/AH)
+			name="rb-493"
+			;;
+		*493G)
+			name="rb-493g"
+			;;
+		*750)
+			name="rb-750"
+			;;
+		*750GL)
+			name="rb-750gl"
+			;;
+		*751)
+			name="rb-751"
+			;;
+		*751G)
+			name="rb-751g"
+			;;
+		*911G-2HPnD)
+			name="rb-911g-2hpnd"
+			;;
+		*911G-5HPacD)
+			name="rb-911g-5hpacd"
+			;;
+		*911G-5HPnD)
+			name="rb-911g-5hpnd"
+			;;
+		*912UAG-2HPnD)
+			name="rb-912uag-2hpnd"
+			;;
+		*912UAG-5HPnD)
+			name="rb-912uag-5hpnd"
+			;;
+		*941-2nD)
+			name="rb-941-2nd"
+			;;
+		*951G-2HnD)
+			name="rb-951g-2hnd"
+			;;
+		*951Ui-2HnD)
+			name="rb-951ui-2hnd"
+			;;
+		*"SXT Lite2")
+			name="rb-sxt2n"
+			;;
+		*"SXT Lite5")
+			name="rb-sxt5n"
+			;;
+		esac
+		;;
 	*"MiniBox V1.0")
 		name="minibox-v1"
-		;;
-	*MR12)
-		name="mr12"
-		;;
-	*MR16)
-		name="mr16"
-		;;
-	*MR1750)
-		name="mr1750"
-		;;
-	*MR1750v2)
-		name="mr1750v2"
-		;;
-	*MR18)
-		name="mr18"
-		;;
-	*MR600)
-		name="mr600"
-		;;
-	*MR600v2)
-		name="mr600v2"
-		;;
-	*MR900)
-		name="mr900"
-		;;
-	*MR900v2)
-		name="mr900v2"
-		;;
-	*"My Net N600")
-		name="mynet-n600"
-		;;
-	*"My Net N750")
-		name="mynet-n750"
-		;;
-	*"My Net Wi-Fi Range"*)
-		name="mynet-rext"
 		;;
 	*MZK-W04NU)
 		name="mzk-w04nu"
@@ -727,51 +846,45 @@ ar71xx_board_detect() {
 	*MZK-W300NH)
 		name="mzk-w300nh"
 		;;
-	*"Nanostation M")
-		name="nanostation-m"
-		ubnt_xm_board_detect
-		;;
-	*"Nanostation M XW")
-		name="nanostation-m-xw"
-		;;
-	*NBG460N/550N/550NH)
-		name="nbg460n_550n_550nh"
-		;;
-	*NBG6616)
-		name="nbg6616"
-		;;
-	*NBG6716)
-		name="nbg6716"
-		;;
-	*OM2P)
-		name="om2p"
-		;;
-	*"OM2P HS")
-		name="om2p-hs"
-		;;
-	*"OM2P HSv2")
-		name="om2p-hsv2"
-		;;
-	*"OM2P HSv3")
-		name="om2p-hsv3"
-		;;
-	*"OM2P LC")
-		name="om2p-lc"
-		;;
-	*OM2Pv2)
-		name="om2pv2"
-		;;
-	*OM5P)
-		name="om5p"
-		;;
-	*"OM5P AC")
-		name="om5p-ac"
-		;;
-	*"OM5P ACv2")
-		name="om5p-acv2"
-		;;
-	*"OM5P AN")
-		name="om5p-an"
+	NETGEAR*)
+		case "$machine" in
+		*R6100)
+			name="r6100"
+			;;
+		*WNDAP360)
+			name="wndap360"
+			;;
+		*WNDR3700/WNDR3800/WNDRMAC)
+			wndr3700_board_detect "$machine"
+			;;
+		*WNDR3700v4)
+			name="wndr3700v4"
+			;;
+		*WNDR4300)
+			name="wndr4300"
+			;;
+		*"WNR1000 V2")
+			name="wnr1000-v2"
+			;;
+		*WNR2000)
+			name="wnr2000"
+			;;
+		*"WNR2000 V3")
+			name="wnr2000-v3"
+			;;
+		*"WNR2000 V4")
+			name="wnr2000-v4"
+			;;
+		*WNR2200)
+			name="wnr2200"
+			;;
+		*"WNR612 V2")
+			name="wnr612-v2"
+			;;
+		*WPN824N)
+			name="wpn824n"
+			;;
+		esac
 		;;
 	*OMY-G1)
 		name="omy-g1"
@@ -785,11 +898,57 @@ ar71xx_board_detect() {
 	*"Oolite V1.0")
 		name="oolite"
 		;;
-	*PB42)
-		name="pb42"
-		;;
-	*PB44*)
-		name="pb44"
+	OpenMesh*)
+		case "$machine" in
+		*MR1750)
+			name="mr1750"
+			;;
+		*MR1750v2)
+			name="mr1750v2"
+			;;
+		*MR600)
+			name="mr600"
+			;;
+		*MR600v2)
+			name="mr600v2"
+			;;
+		*MR900)
+			name="mr900"
+			;;
+		*MR900v2)
+			name="mr900v2"
+			;;
+		*OM2P)
+			name="om2p"
+			;;
+		*"OM2P HS")
+			name="om2p-hs"
+			;;
+		*"OM2P HSv2")
+			name="om2p-hsv2"
+			;;
+		*"OM2P HSv3")
+			name="om2p-hsv3"
+			;;
+		*"OM2P LC")
+			name="om2p-lc"
+			;;
+		*OM2Pv2)
+			name="om2pv2"
+			;;
+		*OM5P)
+			name="om5p"
+			;;
+		*"OM5P AC")
+			name="om5p-ac"
+			;;
+		*"OM5P ACv2")
+			name="om5p-acv2"
+			;;
+		*"OM5P AN")
+			name="om5p-an"
+			;;
+		esac
 		;;
 	*"PQI Air Pen")
 		name="pqi-air-pen"
@@ -797,123 +956,8 @@ ar71xx_board_detect() {
 	*"Qihoo 360 C301")
 		name="qihoo-c301"
 		;;
-	*R6100)
-		name="r6100"
-		;;
-	*RE450)
-		name="re450"
-		;;
-	*"Rocket M")
-		name="rocket-m"
-		ubnt_xm_board_detect
-		;;
-	*"Rocket M TI")
-		name="rocket-m-ti"
-		;;
-	*"Rocket M XW")
-		name="rocket-m-xw"
-		;;
-	*"RouterBOARD 2011L")
-		name="rb-2011l"
-		;;
-	*"RouterBOARD 2011UAS")
-		name="rb-2011uas"
-		;;
-	*"RouterBOARD 2011UAS-2HnD")
-		name="rb-2011uas-2hnd"
-		;;
-	*"RouterBOARD 2011UiAS")
-		name="rb-2011uias"
-		;;
-	*"RouterBOARD 2011UiAS-2HnD")
-		name="rb-2011uias-2hnd"
-		;;
-	*"RouterBOARD 411/A/AH")
-		name="rb-411"
-		;;
-	*"RouterBOARD 411U")
-		name="rb-411u"
-		;;
-	*"RouterBOARD 433/AH")
-		name="rb-433"
-		;;
-	*"RouterBOARD 433UAH")
-		name="rb-433u"
-		;;
-	*"RouterBOARD 435G")
-		name="rb-435g"
-		;;
-	*"RouterBOARD 450")
-		name="rb-450"
-		;;
-	*"RouterBOARD 450G")
-		name="rb-450g"
-		;;
-	*"RouterBOARD 493/AH")
-		name="rb-493"
-		;;
-	*"RouterBOARD 493G")
-		name="rb-493g"
-		;;
-	*"RouterBOARD 750")
-		name="rb-750"
-		;;
-	*"RouterBOARD 750GL")
-		name="rb-750gl"
-		;;
-	*"RouterBOARD 751")
-		name="rb-751"
-		;;
-	*"RouterBOARD 751G")
-		name="rb-751g"
-		;;
-	*"RouterBOARD 911G-2HPnD")
-		name="rb-911g-2hpnd"
-		;;
-	*"RouterBOARD 911G-5HPacD")
-		name="rb-911g-5hpacd"
-		;;
-	*"RouterBOARD 911G-5HPnD")
-		name="rb-911g-5hpnd"
-		;;
-	*"RouterBOARD 912UAG-2HPnD")
-		name="rb-912uag-2hpnd"
-		;;
-	*"RouterBOARD 912UAG-5HPnD")
-		name="rb-912uag-5hpnd"
-		;;
-	*"RouterBOARD 941-2nD")
-		name="rb-941-2nd"
-		;;
-	*"RouterBOARD 951G-2HnD")
-		name="rb-951g-2hnd"
-		;;
-	*"RouterBOARD 951Ui-2HnD")
-		name="rb-951ui-2hnd"
-		;;
-	*"RouterBOARD SXT Lite2")
-		name="rb-sxt2n"
-		;;
-	*"RouterBOARD SXT Lite5")
-		name="rb-sxt5n"
-		;;
-	*RouterStation)
-		name="routerstation"
-		;;
-	*"RouterStation Pro")
-		name="routerstation-pro"
-		;;
 	*RW2458N)
 		name="rw2458n"
-		;;
-	*SC1750)
-		name="sc1750"
-		;;
-	*SC300M)
-		name="sc300m"
-		;;
-	*SC450)
-		name="sc450"
 		;;
 	*SMART-300)
 		name="smart-300"
@@ -921,283 +965,310 @@ ar71xx_board_detect() {
 	*SOM9331)
 		name="som9331"
 		;;
-	*SR3200)
-		name="sr3200"
-		;;
 	*"TellStick ZNet Lite")
 		name="tellstick-znet-lite"
 		;;
-	*TEW-632BRP)
-		name="tew-632brp"
-		;;
-	*TEW-673GRU)
-		name="tew-673gru"
-		;;
-	*TEW-712BR)
-		name="tew-712br"
-		;;
-	*TEW-732BR)
-		name="tew-732br"
-		;;
-	*TEW-823DRU)
-		name="tew-823dru"
-		;;
-	*TL-MR10U)
-		name="tl-mr10u"
-		;;
-	*TL-MR11U)
-		name="tl-mr11u"
-		;;
-	*TL-MR12U)
-		name="tl-mr12u"
-		;;
-	*"TL-MR13U v1")
-		name="tl-mr13u"
-		;;
-	*TL-MR3020)
-		name="tl-mr3020"
-		;;
-	*TL-MR3040)
-		name="tl-mr3040"
-		;;
-	*"TL-MR3040 v2")
-		name="tl-mr3040-v2"
-		;;
-	*TL-MR3220)
-		name="tl-mr3220"
-		;;
-	*"TL-MR3220 v2")
-		name="tl-mr3220-v2"
-		;;
-	*TL-MR3420)
-		name="tl-mr3420"
-		;;
-	*"TL-MR3420 v2")
-		name="tl-mr3420-v2"
-		;;
-	*"TL-WA701ND v2")
-		name="tl-wa701nd-v2"
-		;;
-	*"TL-WA7210N v2")
-		name="tl-wa7210n-v2"
-		;;
-	*TL-WA750RE)
-		name="tl-wa750re"
-		;;
-	*"TL-WA7510N v1")
-		name="tl-wa7510n"
-		;;
-	*"TL-WA801ND v2")
-		name="tl-wa801nd-v2"
-		;;
-	*"TL-WA801ND v3")
-		name="tl-wa801nd-v3"
-		;;
-	*"TL-WA830RE v2")
-		name="tl-wa830re-v2"
-		;;
-	*TL-WA850RE)
-		name="tl-wa850re"
-		;;
-	*TL-WA860RE)
-		name="tl-wa860re"
-		;;
-	*TL-WA901ND)
-		name="tl-wa901nd"
-		;;
-	*"TL-WA901ND v2")
-		name="tl-wa901nd-v2"
-		;;
-	*"TL-WA901ND v3")
-		name="tl-wa901nd-v3"
-		;;
-	*"TL-WA901ND v4")
-		name="tl-wa901nd-v4"
-		;;
-	*"TL-WDR3320 v2")
-		name="tl-wdr3320-v2"
-		;;
-	*TL-WDR3500)
-		name="tl-wdr3500"
-		;;
-	*TL-WDR3600/4300/4310)
-		name="tl-wdr4300"
-		;;
-	*"TL-WDR4900 v2")
-		name="tl-wdr4900-v2"
-		;;
-	*"TL-WDR6500 v2")
-		name="tl-wdr6500-v2"
-		;;
-	*TL-WPA8630)
-		name="tl-wpa8630"
-		;;
-	*"TL-WR1041N v2")
-		name="tl-wr1041n-v2"
-		;;
-	*TL-WR1043ND)
-		name="tl-wr1043nd"
-		;;
-	*"TL-WR1043ND v2")
-		name="tl-wr1043nd-v2"
-		;;
-	*"TL-WR1043ND v4")
-		name="tl-wr1043nd-v4"
-		;;
-	*TL-WR2543N*)
-		name="tl-wr2543n"
-		;;
-	*"TL-WR703N v1")
-		name="tl-wr703n"
-		;;
-	*"TL-WR710N v1")
-		name="tl-wr710n"
-		;;
-	*TL-WR720N*)
-		name="tl-wr720n-v3"
-		;;
-	*TL-WR741ND)
-		name="tl-wr741nd"
-		;;
-	*"TL-WR741ND v4")
-		name="tl-wr741nd-v4"
-		;;
-	*"TL-WR802N v1")
-		name="tl-wr802n-v1"
-		;;
-	*TL-WR810N)
-		name="tl-wr810n"
-		;;
-	*"TL-WR841N v1")
-		name="tl-wr841n-v1"
-		;;
-	*"TL-WR841N/ND v11")
-		name="tl-wr841n-v11"
-		;;
-	*"TL-WR841N/ND v7")
-		name="tl-wr841n-v7"
-		;;
-	*"TL-WR841N/ND v8")
-		name="tl-wr841n-v8"
-		;;
-	*"TL-WR841N/ND v9")
-		name="tl-wr841n-v9"
-		;;
-	*"TL-WR842N/ND v2")
-		name="tl-wr842n-v2"
-		;;
-	*"TL-WR842N/ND v3")
-		name="tl-wr842n-v3"
-		;;
-	*"TL-WR940N v4")
-		name="tl-wr940n-v4"
-		;;
-	*"TL-WR941N/ND v5")
-		name="tl-wr941nd-v5"
-		;;
-	*"TL-WR941N/ND v6")
-		name="tl-wr941nd-v6"
-		;;
-	*TL-WR941ND)
-		name="tl-wr941nd"
-		;;
-	*Tube2H)
-		name="tube2h"
-		;;
-	*UniFi)
-		name="unifi"
-		;;
-	*"UniFi AP Pro")
-		name="uap-pro"
-		;;
-	*UniFi-AC-LITE)
-		name="unifiac-lite"
-		;;
-	*UniFi-AC-PRO)
-		name="unifiac-pro"
-		;;
-	*"UniFiAP Outdoor")
-		name="unifi-outdoor"
-		;;
-	*"UniFiAP Outdoor+")
-		name="unifi-outdoor-plus"
-		;;
-	*WBS210)
-		name="wbs210"
-		tplink_pharos_board_detect
-		;;
-	*WBS510)
-		name="wbs510"
-		tplink_pharos_board_detect
+	TP-LINK*)
+		case "$machine" in
+		*C5)
+			name="archer-c5"
+			;;
+		*"C59 v1")
+			name="archer-c59-v1"
+			;;
+		*"C60 v1")
+			name="archer-c60-v1"
+			;;
+		*C7)
+			name="archer-c7"
+			;;
+		*CPE210/220)
+			name="cpe210"
+			tplink_pharos_board_detect
+			;;
+		*CPE510/520)
+			name="cpe510"
+			tplink_pharos_board_detect
+			;;
+		*EAP120)
+			name="eap120"
+			tplink_pharos_board_detect
+			;;
+		*MR10U)
+			name="tl-mr10u"
+			;;
+		*MR11U)
+			name="tl-mr11u"
+			;;
+		*MR12U)
+			name="tl-mr12u"
+			;;
+		*"MR13U v1")
+			name="tl-mr13u"
+			;;
+		*MR3020)
+			name="tl-mr3020"
+			;;
+		*MR3040)
+			name="tl-mr3040"
+			;;
+		*"MR3040 v2")
+			name="tl-mr3040-v2"
+			;;
+		*MR3220)
+			name="tl-mr3220"
+			;;
+		*"MR3220 v2")
+			name="tl-mr3220-v2"
+			;;
+		*MR3420)
+			name="tl-mr3420"
+			;;
+		*"MR3420 v2")
+			name="tl-mr3420-v2"
+			;;
+		*RE450)
+			name="re450"
+			;;
+		*"WA701ND v2")
+			name="tl-wa701nd-v2"
+			;;
+		*"WA7210N v2")
+			name="tl-wa7210n-v2"
+			;;
+		*WA750RE)
+			name="tl-wa750re"
+			;;
+		*"WA7510N v1")
+			name="tl-wa7510n"
+			;;
+		*"WA801ND v2")
+			name="tl-wa801nd-v2"
+			;;
+		*"WA801ND v3")
+			name="tl-wa801nd-v3"
+			;;
+		*"WA830RE v2")
+			name="tl-wa830re-v2"
+			;;
+		*WA850RE)
+			name="tl-wa850re"
+			;;
+		*WA860RE)
+			name="tl-wa860re"
+			;;
+		*WA901ND)
+			name="tl-wa901nd"
+			;;
+		*"WA901ND v2")
+			name="tl-wa901nd-v2"
+			;;
+		*"WA901ND v3")
+			name="tl-wa901nd-v3"
+			;;
+		*"WA901ND v4")
+			name="tl-wa901nd-v4"
+			;;
+		*WBS210)
+			name="wbs210"
+			tplink_pharos_board_detect
+			;;
+		*WBS510)
+			name="wbs510"
+			tplink_pharos_board_detect
+			;;
+		*"WDR3320 v2")
+			name="tl-wdr3320-v2"
+			;;
+		*WDR3500)
+			name="tl-wdr3500"
+			;;
+		*WDR3600/4300/4310)
+			name="tl-wdr4300"
+			;;
+		*"WDR4900 v2")
+			name="tl-wdr4900-v2"
+			;;
+		*"WDR6500 v2")
+			name="tl-wdr6500-v2"
+			;;
+		*WPA8630)
+			name="tl-wpa8630"
+			;;
+		*"WR1041N v2")
+			name="tl-wr1041n-v2"
+			;;
+		*WR1043ND)
+			name="tl-wr1043nd"
+			;;
+		*"WR1043ND v2")
+			name="tl-wr1043nd-v2"
+			;;
+		*"WR1043ND v4")
+			name="tl-wr1043nd-v4"
+			;;
+		*WR2543N*)
+			name="tl-wr2543n"
+			;;
+		*"WR703N v1")
+			name="tl-wr703n"
+			;;
+		*"WR710N v1")
+			name="tl-wr710n"
+			;;
+		*WR720N*)
+			name="tl-wr720n-v3"
+			;;
+		*WR741ND)
+			name="tl-wr741nd"
+			;;
+		*"WR741ND v4")
+			name="tl-wr741nd-v4"
+			;;
+		*"WR802N v1")
+			name="tl-wr802n-v1"
+			;;
+		*WR810N)
+			name="tl-wr810n"
+			;;
+		*"WR841N v1")
+			name="tl-wr841n-v1"
+			;;
+		*"WR841N/ND v11")
+			name="tl-wr841n-v11"
+			;;
+		*"WR841N/ND v7")
+			name="tl-wr841n-v7"
+			;;
+		*"WR841N/ND v8")
+			name="tl-wr841n-v8"
+			;;
+		*"WR841N/ND v9")
+			name="tl-wr841n-v9"
+			;;
+		*"WR842N/ND v2")
+			name="tl-wr842n-v2"
+			;;
+		*"WR842N/ND v3")
+			name="tl-wr842n-v3"
+			;;
+		*"WR940N v4")
+			name="tl-wr940n-v4"
+			;;
+		*"WR941N/ND v5")
+			name="tl-wr941nd-v5"
+			;;
+		*"WR941N/ND v6")
+			name="tl-wr941nd-v6"
+			;;
+		*WR941ND)
+			name="tl-wr941nd"
+			;;
+		esac
+
+		[ -z "$AR71XX_MODEL" ] && tplink_board_detect "$machine"
+		;;
+	TRENDnet*)
+		case "$machine" in
+		*632BRP)
+			name="tew-632brp"
+			;;
+		*673GRU)
+			name="tew-673gru"
+			;;
+		*712BR)
+			name="tew-712br"
+			;;
+		*732BR)
+			name="tew-732br"
+			;;
+		*823DRU)
+			name="tew-823dru"
+			;;
+		esac
+		;;
+	Ubiquiti*)
+		case "$machine" in
+		*AirGateway)
+			name="airgateway"
+			;;
+		*"AirGateway Pro")
+			name="airgatewaypro"
+			;;
+		*AirRouter)
+			name="airrouter"
+			;;
+		*"Bullet M")
+			name="bullet-m"
+			ubnt_xm_board_detect
+			;;
+		*"Loco M XW")
+			name="loco-m-xw"
+			;;
+		*LS-SR71)
+			name="ls-sr71"
+			;;
+		*"Nanostation M")
+			name="nanostation-m"
+			ubnt_xm_board_detect
+			;;
+		*"Nanostation M XW")
+			name="nanostation-m-xw"
+			;;
+		*"Rocket M")
+			name="rocket-m"
+			ubnt_xm_board_detect
+			;;
+		*"Rocket M TI")
+			name="rocket-m-ti"
+			;;
+		*"Rocket M XW")
+			name="rocket-m-xw"
+			;;
+		*RouterStation)
+			name="routerstation"
+			;;
+		*"RouterStation Pro")
+			name="routerstation-pro"
+			;;
+		*UniFi)
+			name="unifi"
+			;;
+		*"UniFi AP Pro")
+			name="uap-pro"
+			;;
+		*UniFi-AC-LITE)
+			name="unifiac-lite"
+			;;
+		*UniFi-AC-PRO)
+			name="unifiac-pro"
+			;;
+		*"UniFiAP Outdoor")
+			name="unifi-outdoor"
+			;;
+		*"UniFiAP Outdoor+")
+			name="unifi-outdoor-plus"
+			;;
+		esac
+		;;
+	"WD My Net"*)
+		case "$machine" in
+		*N600)
+			name="mynet-n600"
+			;;
+		*N750)
+			name="mynet-n750"
+			;;
+		*"Wi-Fi Range"*)
+			name="mynet-rext"
+			;;
+		esac
 		;;
 	WeIO*)
 		name="weio"
 		;;
-	*WHR-G301N)
-		name="whr-g301n"
-		;;
-	*WHR-HP-G300N)
-		name="whr-hp-g300n"
-		;;
-	*WHR-HP-GN)
-		name="whr-hp-gn"
-		;;
-	*WLAE-AG300N)
-		name="wlae-ag300n"
-		;;
 	*WLR-8100)
 		name="wlr8100"
-		;;
-	*WNDAP360)
-		name="wndap360"
-		;;
-	*WNDR3700/WNDR3800/WNDRMAC)
-		wndr3700_board_detect "$machine"
-		;;
-	*WNDR3700v4)
-		name="wndr3700v4"
-		;;
-	*WNDR4300)
-		name="wndr4300"
-		;;
-	*"WNR1000 V2")
-		name="wnr1000-v2"
-		;;
-	*WNR2000)
-		name="wnr2000"
-		;;
-	*"WNR2000 V3")
-		name="wnr2000-v3"
-		;;
-	*"WNR2000 V4")
-		name="wnr2000-v4"
-		;;
-	*WNR2200)
-		name="wnr2200"
-		;;
-	*"WNR612 V2")
-		name="wnr612-v2"
-		;;
-	*WP543)
-		name="wp543"
-		;;
-	*WPE72)
-		name="wpe72"
-		;;
-	*WPJ342)
-		name="wpj342"
-		;;
-	*WPJ344)
-		name="wpj344"
-		;;
-	*WPJ531)
-		name="wpj531"
-		;;
-	*WPJ558)
-		name="wpj558"
-		;;
-	*WPN824N)
-		name="wpn824n"
 		;;
 	*WRT160NL)
 		name="wrt160nl"
@@ -1208,29 +1279,27 @@ ar71xx_board_detect() {
 	*WRTnode2Q*)
 		name="wrtnode2q"
 		;;
-	*WZR-450HP2)
-		name="wzr-450hp2"
-		;;
-	*WZR-HP-AG300H/WZR-600DHP)
-		name="wzr-hp-ag300h"
-		;;
-	*WZR-HP-G300NH)
-		name="wzr-hp-g300nh"
-		;;
-	*WZR-HP-G300NH2)
-		name="wzr-hp-g300nh2"
-		;;
-	*WZR-HP-G450H)
-		name="wzr-hp-g450h"
-		;;
-	*XD3200)
-		name="xd3200"
-		;;
 	*Yun)
 		name="arduino-yun"
 		;;
-	*Z1)
-		name="z1"
+	YunCore*)
+		case "$machine" in
+		*AP90Q)
+			name="ap90q"
+			;;
+		*CPE830)
+			name="cpe830"
+			;;
+		*CPE870)
+			name="cpe870"
+			;;
+		*SR3200)
+			name="sr3200"
+			;;
+		*XD3200)
+			name="xd3200"
+			;;
+		esac
 		;;
 	*ZBT-WE1526)
 		name="zbt-we1526"
@@ -1241,10 +1310,20 @@ ar71xx_board_detect() {
 	*ZCN-1523H-5)
 		name="zcn-1523h-5"
 		;;
+	Zyxel*)
+		case "$machine" in
+		*NBG460N/550N/550NH)
+			name="nbg460n_550n_550nh"
+			;;
+		*NBG6616)
+			name="nbg6616"
+			;;
+		*NBG6716)
+			name="nbg6716"
+			;;
+		esac
+		;;
 	esac
-
-	[ -z "$AR71XX_MODEL" ] && [ "${machine:0:8}" = 'TP-LINK ' ] && \
-		tplink_board_detect "$machine"
 
 	[ -z "$name" ] && name="unknown"
 

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbsxtlite.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbsxtlite.c
@@ -230,9 +230,9 @@ static void __init rbsxtlite_setup(void)
 }
 
 
-MIPS_MACHINE(ATH79_MACH_RB_SXTLITE2ND, "sxt2n", "Mikrotik RouterBOARD SXT Lite2",
+MIPS_MACHINE(ATH79_MACH_RB_SXTLITE2ND, "sxt2n", "MikroTik RouterBOARD SXT Lite2",
 	    rbsxtlite_setup);
 
-MIPS_MACHINE(ATH79_MACH_RB_SXTLITE5ND, "sxt5n", "Mikrotik RouterBOARD SXT Lite5",
+MIPS_MACHINE(ATH79_MACH_RB_SXTLITE5ND, "sxt5n", "MikroTik RouterBOARD SXT Lite5",
 	    rbsxtlite_setup);
 

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wpa8630.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wpa8630.c
@@ -168,5 +168,5 @@ static void __init tl_wpa8630_setup(void)
 					tl_wpa8630_gpio_keys);
 }
 
-MIPS_MACHINE(ATH79_MACH_TL_WPA8630, "TL-WPA8630", "TP-Link TL-WPA8630",
+MIPS_MACHINE(ATH79_MACH_TL_WPA8630, "TL-WPA8630", "TP-LINK TL-WPA8630",
 	tl_wpa8630_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-wndap360.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-wndap360.c
@@ -102,4 +102,4 @@ static void __init wndap360_setup(void)
 		      art + WNDAP360_WMAC1_MAC_OFFSET);
 }
 
-MIPS_MACHINE(ATH79_MACH_WNDAP360, "WNDAP360", "Netgear WNDAP360", wndap360_setup);
+MIPS_MACHINE(ATH79_MACH_WNDAP360, "WNDAP360", "NETGEAR WNDAP360", wndap360_setup);


### PR DESCRIPTION
The following series includes general cleanups and fixes in **lib/ar71xx.sh** script and 3 related **mach-\*.c** files (fix in machine names).

Last patch (**ar71xx: base-files: improve code readability in lib/ar71xx.sh**) contains rather a heavy changes thus marked as **RFC**.

Summary change in **lib/ar71xx.sh** size: +307 bytes