### PR TITLE
ccache, samba36: fix samba.org download addresses to use https

### DIFF
--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -67,7 +67,7 @@ menuconfig DEVEL
 		bool "Use ccache" if DEVEL
 		default n
 		help
-		  Compiler cache; see http://ccache.samba.org/.
+		  Compiler cache; see https://ccache.samba.org/
 
 	config EXTERNAL_KERNEL_TREE
 		string "Use external kernel tree" if DEVEL

--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -30,7 +30,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/ppp/Default
   SECTION:=net
   CATEGORY:=Network
-  URL:=http://ppp.samba.org/
+  URL:=https://ppp.samba.org/
 endef
 
 define Package/ppp

--- a/package/network/services/samba36/Makefile
+++ b/package/network/services/samba36/Makefile
@@ -11,8 +11,8 @@ PKG_NAME:=samba
 PKG_VERSION:=3.6.25
 PKG_RELEASE:=5
 
-PKG_SOURCE_URL:=http://ftp.samba.org/pub/samba \
-	http://ftp.samba.org/pub/samba/stable
+PKG_SOURCE_URL:=https://download.samba.org/pub/samba \
+		https://download.samba.org/pub/samba/stable
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=8f2c8a7f2bd89b0dfd228ed917815852f7c625b2bc0936304ac3ed63aaf83751
 
@@ -34,7 +34,7 @@ define Package/samba36-server
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Samba 3.6 SMB/CIFS server
-  URL:=http://www.samba.org/
+  URL:=https://www.samba.org/
   DEPENDS:=+USE_GLIBC:librt $(ICONV_DEPENDS)
 endef
 
@@ -42,7 +42,7 @@ define Package/samba36-client
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Samba 3.6 SMB/CIFS client
-  URL:=http://www.samba.org/
+  URL:=https://www.samba.org/
   DEPENDS:=+libreadline +libncurses
 endef
 

--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -11,7 +11,8 @@ PKG_NAME:=ccache
 PKG_VERSION:=3.3.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://samba.org/ftp/ccache/
+PKG_SOURCE_URL:=https://download.samba.org/pub/ccache/ \
+		https://samba.org/ftp/ccache/
 PKG_HASH:=907685cb23d8f82074b8d1a9b4ebabb36914d151ac7b96a840c68c08d1a14530
 
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
samba.org has started to enforce https and currently plain http downloads with curl/wget fail, although the same links from browser redirect to https.

So, convert samba.org download links to use https.
Modernise download links at the same time.

Also convert samba.org links in URL fields to have https, although that is merely documentation isssue.

I already fixed the same thing on the packages repo a few days ago with https://github.com/openwrt/packages/commit/eb0f2f0021e471f8b19a77a80080ca60d9ce5ed0 , but then I noticed a few minutes ago from the failing Openwrt buildbot that this samba.org change also affects the ccache tool & samba36 package in the main repo.