### PR TITLE
dropbear: enable SHA256 HMACs

### DIFF
--- a/package/network/services/dropbear/patches/120-openwrt_options.patch
+++ b/package/network/services/dropbear/patches/120-openwrt_options.patch
@@ -44,10 +44,9 @@
   * which are not the standard form. */
  #define DROPBEAR_SHA1_HMAC
 -#define DROPBEAR_SHA1_96_HMAC
--#define DROPBEAR_SHA2_256_HMAC
--#define DROPBEAR_SHA2_512_HMAC
 +/*#define DROPBEAR_SHA1_96_HMAC*/
-+/*#define DROPBEAR_SHA2_256_HMAC*/
+ #define DROPBEAR_SHA2_256_HMAC
+-#define DROPBEAR_SHA2_512_HMAC
 +/*#define DROPBEAR_SHA2_512_HMAC*/
  #define DROPBEAR_MD5_HMAC
  


### PR DESCRIPTION
The only HMACs currently available use MD5 and SHA1, both of which have known
weaknesses. We already compile in the SHA256 code since we use Curve25519
by default, so there's no significant size penalty to enabling this.

Signed-off-by: Joseph C. Sible <josephcsible@users.noreply.github.com>