### PR TITLE
build: Pass -iremap gcc option as a single argument

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -140,7 +140,7 @@ else
 endif
 
 ifeq ($(or $(CONFIG_EXTERNAL_TOOLCHAIN),$(CONFIG_GCC_VERSION_4_8),$(CONFIG_TARGET_uml)),)
-  iremap = -iremap $(1):$(2)
+  iremap = -iremap$(1):$(2)
 endif
 
 PACKAGE_DIR:=$(BIN_DIR)/packages


### PR DESCRIPTION
Passing -iremap argument separately causes problems with projects that
use scons and its ParseFlags function. Consider this SConscript
example:

    env = Environment()
    d = env.ParseFlags("-iremap one:two")

ParseFlags will interpret one:two as a file name and the returned dict
d will contain only "-iremap". When the -iremap is passed to the
compiler without an argument, compilation obviously fails.

Signed-off-by: Michal Sojka <sojkam1@fel.cvut.cz>