### PR TITLE
Added key_direction to append_params.

### DIFF
--- a/package/network/services/openvpn/files/openvpn.init
+++ b/package/network/services/openvpn/files/openvpn.init
@@ -111,8 +111,8 @@ start_instance() {
 		connect_retry connect_timeout connect_retry_max crl_verify dev dev_node dev_type dh \
 		ecdh_curve echo engine explicit_exit_notify fragment group hand_window hash_size http_proxy \
 		http_proxy_option http_proxy_timeout ifconfig ifconfig_pool ifconfig_pool_persist ifconfig_push \
-		inactive ipchange iroute keepalive key key_method keysize learn_address link_mtu lladdr local \
-		log log_append lport management management_log_cache max_clients max_routes_per_client mode \
+		inactive ipchange iroute keepalive key key_direction key_method keysize learn_address link_mtu lladdr \
+		local log log_append lport management management_log_cache max_clients max_routes_per_client mode \
 		mssfix mtu_disc mute ncp_ciphers nice ns_cert_type ping ping_exit ping_restart pkcs12 plugin \
 		port port_share prng proto pull_filter rcvbuf redirect_gateway remap_usr1 remote remote_cert_eku \
 		remote_cert_ku remote_cert_tls reneg_bytes reneg_pkts reneg_sec replay_persist replay_window \


### PR DESCRIPTION
key_direction shows up as an openvpn option in the user-interface but does not end up in the /var/etc/openvpn*.conf file. Adding it to the list here fixed the issue for me.

Signed-off-by: Brandon Koepke <bdkoepke@fastmail.com>