### PR TITLE
dnsmasq: honor quietdhcp option for DHCPv6

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -894,6 +894,7 @@ dnsmasq_start()
 		config_foreach dhcp_add dhcp
 		xappend "--enable-ra"
 		xappend "--quiet-ra"
+		append_bool "$cfg" quietdhcp "--quiet-dhcp6"
 
 	elif [ "$DNSMASQ_DHCP_VER" -gt 0 ] ; then
 		config_foreach dhcp_add dhcp


### PR DESCRIPTION
Do not spam the syslog with lease info if quietdhcp option is given. This already works for DHCPv4, make it work in the same way for DHCPv6.

Signed-off-by: Arjen de Korte build+lede@de-korte.org