### PR TITLE
dnsmasq: rfc6303 address exclusion

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.77test1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq/test-releases
@@ -152,6 +152,8 @@ define Package/dnsmasq/install
 	$(INSTALL_BIN) ./files/dnsmasq.init $(1)/etc/init.d/dnsmasq
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/ntp
 	$(INSTALL_DATA) ./files/dnsmasqsec.hotplug $(1)/etc/hotplug.d/ntp/25-dnsmasqsec
+	$(INSTALL_DIR) $(1)/usr/share/dnsmasq
+	$(INSTALL_DATA) ./files/rfc6303.conf $(1)/usr/share/dnsmasq
 endef
 
 Package/dnsmasq-dhcpv6/install = $(Package/dnsmasq/install)

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -17,6 +17,7 @@ BASETIMESTAMPFILE="/etc/dnsmasq.time"
 TRUSTANCHORSFILE="/usr/share/dnsmasq/trust-anchors.conf"
 TIMEVALIDFILE="/var/state/dnsmasqsec"
 BASEDHCPSTAMPFILE="/var/run/dnsmasq"
+RFC6303FILE="/usr/share/dnsmasq/rfc6303.conf"
 
 DNSMASQ_DHCP_VER=4
 
@@ -739,7 +740,6 @@ dnsmasq_start()
 	append_bool "$cfg" nonwildcard "--bind-dynamic"
 	append_bool "$cfg" fqdn "--dhcp-fqdn"
 	append_bool "$cfg" proxydnssec "--proxy-dnssec"
-	append_bool "$cfg" localservice "--local-service"
 	append_bool "$cfg" logdhcp "--log-dhcp"
 	append_bool "$cfg" quietdhcp "--quiet-dhcp"
 	append_bool "$cfg" sequential_ip "--dhcp-sequential-ip"
@@ -886,6 +886,11 @@ dnsmasq_start()
 	config_foreach filter_dnsmasq mxhost dhcp_mx_add "$cfg"
 	echo >> $CONFIGFILE_TMP
 
+	config_get_bool localservice "$cfg" localservice 0
+	[ "$localservice" -gt 0 ] && {
+		xappend "--local-service"
+		[ -r "$RFC6303FILE" ] && xappend "--conf-file=$RFC6303FILE"
+	}
 
 	if [ "$DNSMASQ_DHCP_VER" -gt 4 ] ; then
 		# Enable RA feature for when/if it is constructed,
@@ -930,7 +935,7 @@ dnsmasq_start()
 	fi
 
 	procd_add_jail dnsmasq ubus log
-	procd_add_jail_mount $CONFIGFILE $TRUSTANCHORSFILE $HOSTFILE /etc/passwd /etc/group /etc/TZ /dev/null /dev/urandom $dnsmasqconffile $dnsmasqconfdir $resolvfile $dhcpscript /etc/hosts /etc/ethers $EXTRA_MOUNT
+	procd_add_jail_mount $CONFIGFILE $TRUSTANCHORSFILE $HOSTFILE $RFC6303FILE /etc/passwd /etc/group /etc/TZ /dev/null /dev/urandom $dnsmasqconffile $dnsmasqconfdir $resolvfile $dhcpscript /etc/hosts /etc/ethers $EXTRA_MOUNT
 	procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
 
 	procd_close_instance

--- a/package/network/services/dnsmasq/files/rfc6303.conf
+++ b/package/network/services/dnsmasq/files/rfc6303.conf
@@ -1,0 +1,49 @@
+# RFC6303 included configuration file for dnsmasq
+#
+# includes a list of domains that should not be forwarded to Internet name servers
+# to reduce burden on them, asking questions that they won't know the answer to.
+
+server=/bind/
+server=/example/
+server=/invalid/
+server=/local/
+server=/localhost/
+server=/onion/
+server=/test/
+server=/d.f.ip6.arpa/
+server=/8.e.f.ip6.arpa/
+server=/9.e.f.ip6.arpa/
+server=/a.e.f.ip6.arpa/
+server=/b.e.f.ip6.arpa/
+server=/8.b.d.0.1.0.0.2.ip6.arpa/
+server=/0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa/
+server=/1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa/
+
+# These are already known to dnsmasq, implemented as part of '--local-server'
+# but are included here for completeness
+#
+#server=/0.in-addr.arpa/
+#server=/10.in-addr.arpa/
+#server=/127.in-addr.arpa/
+#server=/16.172.in-addr.arpa/
+#server=/17.172.in-addr.arpa/
+#server=/18.172.in-addr.arpa/
+#server=/19.172.in-addr.arpa/
+#server=/20.172.in-addr.arpa/
+#server=/21.172.in-addr.arpa/
+#server=/22.172.in-addr.arpa/
+#server=/23.172.in-addr.arpa/
+#server=/24.172.in-addr.arpa/
+#server=/25.172.in-addr.arpa/
+#server=/26.172.in-addr.arpa/
+#server=/27.172.in-addr.arpa/
+#server=/28.172.in-addr.arpa/
+#server=/29.172.in-addr.arpa/
+#server=/30.172.in-addr.arpa/
+#server=/31.172.in-addr.arpa/
+#server=/168.192.in-addr.arpa/
+#server=/254.169.in-addr.arpa/
+#server=/2.0.192.in-addr.arpa/
+#server=/100.51.198.in-addr.arpa/
+#server=/113.0.203.in-addr.arpa/
+#server=/255.255.255.255.in-addr.arpa/


### PR DESCRIPTION
The essence of this has been lurking in my local tree for a long time as a simple modification to /etc/config/dhcp.  My coding and git knowledge has come along a little and I now offer this as a more flexible way of doing the same thing.  Fundamentally the idea is to make LEDE a good netizen by default but allow configuration flexibility should it be needed.


RFC6303 defines a number of arpa zones that should not be forwarded to
the wider internet and thus burden root DNS servers.  dnsmasq covers the
IPv4 zones itself by use of the '--localservice' option.  At the present
time it does not exclude IPv6 zones.

Similarly some top level domains should never be forwarded. e.g. example.

This change adds a list of domains that will be blocked when
'localservice' is used and augments that which is already blocked by
dnsmasq's notion of 'local service'.

To make this configurable rather than hard coded in dnsmasq's init
script, the new option of "list rfc6303 '/block_domain/'" in
/etc/config/dhcp, along with a default list that matches the RFC6303
recommendation.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>