### PR TITLE
utils/e2fsprogs: Update to 1.43.4

### DIFF
--- a/package/utils/e2fsprogs/Makefile
+++ b/package/utils/e2fsprogs/Makefile
@@ -8,12 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=e2fsprogs
-PKG_VERSION:=1.43.3
-PKG_HASH:=ce8ef1bbb0d4730f170167284fda156ac9d6bf18db2750eb94af619a81b19927
-PKG_RELEASE:=2
+PKG_VERSION:=1.43.4
+PKG_HASH:=54b3f21123a531a6a536b9cdcc21344b0122a72790dbe4dacc98e64db25e4a24
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/e2fsprogs
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://mirror.as35701.net/pub/linux/kernel/people/tytso/e2fsprogs/v$(PKG_VERSION)/ \
+		https://ftp.yandex.ru/pub/linux/kernel/people/tytso/e2fsprogs/v$(PKG_VERSION)/ \
+		http://www.ring.gr.jp/archives/linux/kernel.org/kernel/people/tytso/e2fsprogs/v$(PKG_VERSION)/ \
+		https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v$(PKG_VERSION)/
 
 PKG_BUILD_DEPENDS:=util-linux
 PKG_INSTALL:=1


### PR DESCRIPTION
* Update to 1.43.4
* Use xz tarball which saves about 2Mbyte in size

Changelog: http://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.43.4

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>