### PR TITLE
uclibc++: patch bugfix erase() on derived __base_associative

### DIFF
--- a/package/libs/uclibc++/patches/050-Bugfix-erase-on-derived-__base_associative.patch
+++ b/package/libs/uclibc++/patches/050-Bugfix-erase-on-derived-__base_associative.patch
@@ -1,0 +1,40 @@
+From 946b29e62927eadfc4e87f27b8d30e5974b78c4c Mon Sep 17 00:00:00 2001
+From: Ben Kelly <ben@benjii.net>
+Date: Mon, 6 Feb 2017 13:08:25 +0200
+Subject: [PATCH] Bugfix erase() on derived __base_associative
+
+When calling erase() on a containers derived from __base_associative
+(e.g. multimap) and providing a pair of iterators a segfault will
+occur.
+
+Example code to reproduce:
+
+	typedef std::multimap<int, int> testmap;
+	testmap t;
+	t.insert(std::pair<int, int>(1, 1));
+	t.insert(std::pair<int, int>(2, 1));
+	t.insert(std::pair<int, int>(3, 1));
+	t.erase(t.begin(), t.end());
+
+Signed-off-by: Ben Kelly <ben@benjii.net>
+---
+ include/associative_base | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/include/associative_base b/include/associative_base
+index 27ae0ef..be8b27f 100644
+--- a/include/associative_base
++++ b/include/associative_base
+@@ -200,8 +200,7 @@ public:
+ 	}
+ 	void erase(iterator first, iterator last){
+ 		while(first != last){
+-			backing.erase(first.base_iterator());
+-			++first;
++			first = backing.erase(first.base_iterator());
+ 		}
+ 	}
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
This patch has also been sent upstream to uClibc++ maintainer.

Signed-off-by: Ben Kelly <ben@benjii.net>