### PR TITLE
dnsmasq: decrease the amount of individual sites listed in log

### DIFF
--- a/package/network/services/dnsmasq/patches/200-decrease-server-list-verbosity.patch
+++ b/package/network/services/dnsmasq/patches/200-decrease-server-list-verbosity.patch
@@ -1,0 +1,51 @@
+By default 30 first servers are listed individually to system log, and
+then a count of the remaining items. With e.g. a NXDOMAIN based adblock
+service, dnsmasq lists 30 unnecessary ad sites every time when dnsmasq
+evaluates the list. But the actual nameservers in use are evaluated last
+and are not displayed as they get summed up into the remaining items total.
+
+Handle the "local addresses only" separately and list only a few of them.
+Remove the "local addresses only" from the general count.
+
+--- a/src/config.h
++++ b/src/config.h
+@@ -27,6 +27,7 @@
+ #define FORWARD_TEST 50 /* try all servers every 50 queries */
+ #define FORWARD_TIME 20 /* or 20 seconds */
+ #define SERVERS_LOGGED 30 /* Only log this many servers when logging state */
++#define LOCALS_LOGGED 8 /* Only log this many local addresses when logging state */
+ #define RANDOM_SOCKS 64 /* max simultaneous random ports */
+ #define LEASE_RETRY 60 /* on error, retry writing leasefile after LEASE_RETRY seconds */
+ #define CACHESIZ 150 /* default cache size */
+--- a/src/network.c
++++ b/src/network.c
+@@ -1438,6 +1438,7 @@ void check_servers(void)
+   struct server *serv;
+   struct serverfd *sfd, *tmp, **up;
+   int port = 0, count;
++  int locals = 0;
+ 
+   /* interface may be new since startup */
+   if (!option_bool(OPT_NOWILD))
+@@ -1541,7 +1542,11 @@ void check_servers(void)
+ 		s1 = _("domain"), s2 = serv->domain;
+ 	      
+ 	      if (serv->flags & SERV_NO_ADDR)
+-		my_syslog(LOG_INFO, _("using local addresses only for %s %s"), s1, s2);
++		{
++		  count--;
++		  if (++locals <= LOCALS_LOGGED)
++			my_syslog(LOG_INFO, _("using local addresses only for %s %s"), s1, s2);
++	        }
+ 	      else if (serv->flags & SERV_USE_RESOLV)
+ 		my_syslog(LOG_INFO, _("using standard nameservers for %s %s"), s1, s2);
+ 	      else 
+@@ -1558,6 +1563,8 @@ void check_servers(void)
+ 	}
+     }
+   
++  if (locals > LOCALS_LOGGED)
++    my_syslog(LOG_INFO, _("using %d more local addresses"), locals - LOCALS_LOGGED);
+   if (count - 1 > SERVERS_LOGGED)
+     my_syslog(LOG_INFO, _("using %d more nameservers"), count - SERVERS_LOGGED - 1);
+ 


### PR DESCRIPTION
This PR is related to #638 as it tries to tackle the same challenge, log spam from nxdomain based adblock.

I don't want to push all dnsmasq logging into /dev/null or so, but would like to decrease log spam related to blocked ad sites.

By default the 30 first servers are listed individually to system log, and then a count of the remaining items. With e.g. a NXDOMAIN based adblock service, dnsmasq lists 30 unnecessary ad sites every time when dnsmasq evaluates the list (twice at startup). What is worse, the actual nameservers are evaluated last and get included in the "remaining items" total and their details are not displayed.

* Handle the "local addresses only" separately and list only a few (8) of them. This class includes the blocked ad sites.
* Remove the "local addresses only" from the general count. Now the general nameserver info etc gets properly displayed.

Run-tested with ipq806x/R7800 at r3324-174ce4c56d

Example output at router startup when adblock gets loaded:

```
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain wwww.adleads.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www4.smartadserver.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www3.smartadserver.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www2.smartadserver.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www.smartadserver.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www.pflexads.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www.mmnetwork.m0bi
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www.eltrafiko.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using 21051 more local addresses
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: reading /tmp/resolv.conf.auto
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain wwww.adleads.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www4.smartadserver.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www3.smartadserver.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www2.smartadserver.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www.smartadserver.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www.pflexads.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www.mmnetwork.m0bi
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using local addresses only for domain www.eltrafiko.c0m
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using nameserver 62.241.198.246#53
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using nameserver 62.241.198.245#53
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using nameserver 2001:14b8:1000::1#53
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using nameserver 2001:14b8:1000::2#53
Tue Feb  7 16:57:24 2017 daemon.info dnsmasq[3012]: using 21051 more local addresses
```
