### PR TITLE
dnsmasq: workaround jail/procd/sysntp hotplug SIGHUP issue

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.77test1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq/test-releases

--- a/package/network/services/dnsmasq/files/dnsmasqsec.hotplug
+++ b/package/network/services/dnsmasq/files/dnsmasqsec.hotplug
@@ -1,14 +1,14 @@
 #!/bin/sh
 
-. /lib/functions/procd.sh
+[ "$ACTION" = "stratum" ] || exit 0
 
 TIMEVALIDFILE="/var/state/dnsmasqsec"
-
-[ "$ACTION" = stratum ] || exit 0
 
 [ -f "$TIMEVALIDFILE" ] || {
 	echo "ntpd says time is valid" >$TIMEVALIDFILE
 	/etc/init.d/dnsmasq enabled && {
-		procd_send_signal dnsmasq
+		for pid in $(pidof dnsmasq); do
+			[ "$(readlink /proc/$pid/exe)" = "/usr/sbin/dnsmasq" ] && kill -SIGHUP $pid
+		done
 	}
 }


### PR DESCRIPTION
Commit c914fa04 used ubus/procd signalling to issue a SIGHUP to dnsmasq
when ntp regarded time as valid.  This has highlighted an issue with
procd in a jailed environment in that procd signals the jailing 'helper'
process rather than the 'jailed' process.

The jailer dies, whilst the jailed (dnsmasq) process keeps running.
Procd in response to the jailer dieing respawns dnsmasq processes which
cannot startup properly because ports are already in use. This produces
log spam until procd gives up.  Whilst the original dnsmasq is still
running, it still hasn't received the SIGHUP letting it know time is
valid and hence should check DNSSEC timestamps which is a security
issue.

As a workaround, the ntp hotplug script now uses 'pidof dnsmasq' to
identify and SIGHUP dnsmasq processes.

Fixes FX#464

Tested on Archer C7 v2 in jailed & non jailed environments.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>