### PR TITLE
 DWR-512: IRQ signal and led polarity added to devicetree

### DIFF
--- a/target/linux/ramips/dts/DWR-512-B.dts
+++ b/target/linux/ramips/dts/DWR-512-B.dts
@@ -33,7 +33,7 @@
 
 		sms {
 			label = "dwr-512-b:green:sms";
-			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 		};
 		status {
 			label = "dwr-512-b:green:status";
@@ -111,6 +111,10 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "siliconlabs,si3210";
+
+		interrupt-parent = <&gpio0>;
+		interrupts = <1 8>;
+		irq-gpio = <&gpio0 1 8>;
 
 		reg = <0>;
 		spi-max-frequency = <1000000>;

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -296,6 +296,7 @@ TARGET_DEVICES += dir-620-d1
 
 define Device/dwr-512-b
   DTS := DWR-512-B
+  IMAGE_SIZE := 7700k
   DEVICE_TITLE := D-Link DWR-512 B
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-i2c-core kmod-i2c-ralink kmod-spi-dev \
 			kmod-usb-serial kmod-usb-serial-option kmod-usb-serial-wwan comgt


### PR DESCRIPTION
Update to properly set the sms led active hi and to map the active
low IRQ generated by the si3210.

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>