### PR TITLE
nvram: add nvram init for new created nvram partition

### DIFF
--- a/package/utils/nvram/src/cli.c
+++ b/package/utils/nvram/src/cli.c
@@ -27,13 +27,17 @@
 
 static nvram_handle_t * nvram_open_rdonly(void)
 {
-	const char *file = nvram_find_staging();
+	char *file = nvram_find_staging();
 
 	if( file == NULL )
 		file = nvram_find_mtd();
 
-	if( file != NULL )
-		return nvram_open(file, NVRAM_RO);
+	if( file != NULL ) {
+		nvram_handle_t *h = nvram_open(file, NVRAM_RO);
+		if( strcmp(file, NVRAM_STAGING) )
+			free(file);
+		return h;
+	}
 
 	return NULL;
 }

--- a/package/utils/nvram/src/cli.c
+++ b/package/utils/nvram/src/cli.c
@@ -151,15 +151,16 @@ int main( int argc, const char *argv[] )
 	int done = 0;
 	int i;
 
+	if( argc < 2 ) {
+		usage();
+		return 1;
+	}
+
 	/* Ugly... iterate over arguments to see whether we can expect a write */
-	for( i = 1; i < argc; i++ )
-		if( ( !strcmp(argv[i], "set")   && ++i < argc ) ||
-			( !strcmp(argv[i], "unset") && ++i < argc ) ||
-			!strcmp(argv[i], "commit") )
-		{
-			write = 1;
-			break;
-		}
+	if( ( !strcmp(argv[1], "set")  && 2 < argc ) ||
+		( !strcmp(argv[1], "unset") && 2 < argc ) ||
+		!strcmp(argv[1], "commit") )
+		write = 1;
 
 
 	nvram = write ? nvram_open_staging() : nvram_open_rdonly();

--- a/package/utils/nvram/src/cli.c
+++ b/package/utils/nvram/src/cli.c
@@ -129,6 +129,18 @@ static int do_info(nvram_handle_t *nvram)
 	return 0;
 }
 
+static void usage(void)
+{
+	fprintf(stderr,
+		"Usage:\n"
+		"	nvram show\n"
+		"	nvram info\n"
+		"	nvram get variable\n"
+		"	nvram set variable=value [set ...]\n"
+		"	nvram unset variable [unset ...]\n"
+		"	nvram commit\n"
+	);
+}
 
 int main( int argc, const char *argv[] )
 {
@@ -229,16 +241,7 @@ int main( int argc, const char *argv[] )
 	}
 	else if( !done )
 	{
-		fprintf(stderr,
-			"Usage:\n"
-			"	nvram show\n"
-			"	nvram info\n"
-			"	nvram get variable\n"
-			"	nvram set variable=value [set ...]\n"
-			"	nvram unset variable [unset ...]\n"
-			"	nvram commit\n"
-		);
-
+		usage();
 		stat = 1;
 	}
 

--- a/package/utils/nvram/src/cli.c
+++ b/package/utils/nvram/src/cli.c
@@ -235,6 +235,7 @@ int main( int argc, const char *argv[] )
 			"	- Insufficient permissions to open mtd device\n"
 			"	- Insufficient memory to complete operation\n"
 			"	- Memory mapping failed or not supported\n"
+			"	- Nvram magic not found\n"
 		);
 
 		stat = 1;

--- a/package/utils/nvram/src/nvram.c
+++ b/package/utils/nvram/src/nvram.c
@@ -380,7 +380,9 @@ nvram_handle_t * nvram_open(const char *file, int rdonly)
 
 			if( offset < 0 )
 			{
+				munmap(mmap_area, nvram_part_size);
 				free(mtd);
+				close(fd);
 				return NULL;
 			}
 			else if( (h = malloc(sizeof(nvram_handle_t))) != NULL )
@@ -410,6 +412,7 @@ nvram_handle_t * nvram_open(const char *file, int rdonly)
 	}
 
 	free(mtd);
+	close(fd);
 	return NULL;
 }
 


### PR DESCRIPTION
Since the original nvram work based on header with NVRAM_MAGIC,
this command(nvram init) initialize the mtd partition that
new created and named 'nvram'.

Moreover, adding the 'nvram init' command can make the nvram support
on any other platform.

Signed-off-by: BangLang Huang <banglang.huang@foxmail.com>