### PR TITLE
layerscape: fix adjust_link for 10G & 2.5G

### DIFF
--- a/target/linux/layerscape/patches-4.4/7226-dpaa_eth-fix-adjust_link-for-10G-2.5G.patch
+++ b/target/linux/layerscape/patches-4.4/7226-dpaa_eth-fix-adjust_link-for-10G-2.5G.patch
@@ -1,0 +1,48 @@
+From 09a3bd3bb7e59703bfa5fa580436b4a85b15cfb0 Mon Sep 17 00:00:00 2001
+From: Shaohui Xie <Shaohui.Xie@nxp.com>
+Date: Fri, 22 Apr 2016 11:26:14 +0800
+Subject: [PATCH] dpaa_eth: fix adjust_link for 10G & 2.5G
+
+We don't support adjust link for 10G & 2.5G.
+
+Signed-off-by: Shaohui Xie <Shaohui.Xie@nxp.com>
+---
+ drivers/net/ethernet/freescale/sdk_dpaa/mac-api.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/freescale/sdk_dpaa/mac-api.c b/drivers/net/ethernet/freescale/sdk_dpaa/mac-api.c
+index aaedaae..c092afb 100644
+--- a/drivers/net/ethernet/freescale/sdk_dpaa/mac-api.c
++++ b/drivers/net/ethernet/freescale/sdk_dpaa/mac-api.c
+@@ -409,6 +409,10 @@ void get_pause_cfg(struct mac_device *mac_dev, bool *rx_pause, bool *tx_pause)
+ }
+ EXPORT_SYMBOL(get_pause_cfg);
+ 
++static void adjust_link_void(struct net_device *net_dev)
++{
++}
++
+ static void adjust_link(struct net_device *net_dev)
+ {
+ 	struct dpa_priv_s *priv = netdev_priv(net_dev);
+@@ -473,7 +477,7 @@ static int xgmac_init_phy(struct net_device *net_dev,
+ 				     mac_dev->phy_if);
+ 	else
+ 		phy_dev = of_phy_connect(net_dev, mac_dev->phy_node,
+-					 &adjust_link, 0, mac_dev->phy_if);
++					 &adjust_link_void, 0, mac_dev->phy_if);
+ 	if (unlikely(phy_dev == NULL) || IS_ERR(phy_dev)) {
+ 		netdev_err(net_dev, "Could not attach to PHY %s\n",
+ 				mac_dev->phy_node ?
+@@ -506,7 +510,7 @@ static int memac_init_phy(struct net_device *net_dev,
+ 			return 0;
+ 		} else
+ 			phy_dev = of_phy_connect(net_dev, mac_dev->phy_node,
+-						 &adjust_link, 0,
++						 &adjust_link_void, 0,
+ 						 mac_dev->phy_if);
+ 	} else {
+ 		if (!mac_dev->phy_node)
+-- 
+2.1.0.27.g96db324
+


### PR DESCRIPTION
Added a linux-4.4 patch to fix adjust_link for 10G & 2.5G.

Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>