### PR TITLE
ar71xx: fix platform_find_rootfspart()

### DIFF
--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -46,7 +46,7 @@ platform_find_kernelpart() {
 platform_find_rootfspart() {
 	local part
 	for part in "${1%:*}" "${1#*:}"; do
-		[ "$part" != "$2" ] && echo "$part"; break
+		[ "$part" != "$2" ] && echo "$part" && break
 	done
 }
 


### PR DESCRIPTION
platform_find_rootfspart() fails if the kernel partition comes before the
rootfs partition. The proposed patch fixes this while preserving what I
understand was the original idea: stop at first match.

Signed-off-by: Thibaut VARENE <hacks@slashdirt.org>