### PR TITLE
ar71xx: archer C7: change reset button to reset function

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7.c
@@ -107,9 +107,9 @@ static struct gpio_led archer_c7_leds_gpio[] __initdata = {
 
 static struct gpio_keys_button archer_c7_gpio_keys[] __initdata = {
 	{
-		.desc		= "Reset button",
+		.desc		= "Reset/WPS button",
 		.type		= EV_KEY,
-		.code		= KEY_WPS_BUTTON,
+		.code		= KEY_RESTART,
 		.debounce_interval = ARCHER_C7_KEYS_DEBOUNCE_INTERVAL,
 		.gpio		= ARCHER_C7_GPIO_BTN_RESET,
 		.active_low	= 1,
@@ -125,9 +125,9 @@ static struct gpio_keys_button archer_c7_gpio_keys[] __initdata = {
 
 static struct gpio_keys_button archer_c7_v2_gpio_keys[] __initdata = {
 	{
-		.desc		= "Reset button",
+		.desc		= "Reset/WPS button",
 		.type		= EV_KEY,
-		.code		= KEY_WPS_BUTTON,
+		.code		= KEY_RESTART,
 		.debounce_interval = ARCHER_C7_KEYS_DEBOUNCE_INTERVAL,
 		.gpio		= ARCHER_C7_GPIO_BTN_RESET,
 		.active_low	= 1,

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wdr3500.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wdr3500.c
@@ -86,9 +86,9 @@ static struct gpio_led wdr3500_leds_gpio[] __initdata = {
 
 static struct gpio_keys_button wdr3500_gpio_keys[] __initdata = {
 	{
-		.desc		= "QSS button",
+		.desc		= "Reset/WPS button",
 		.type		= EV_KEY,
-		.code		= KEY_WPS_BUTTON,
+		.code		= KEY_RESTART,
 		.debounce_interval = WDR3500_KEYS_DEBOUNCE_INTERVAL,
 		.gpio		= WDR3500_GPIO_BTN_WPS,
 		.active_low	= 1,

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wdr4300.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wdr4300.c
@@ -90,9 +90,9 @@ static struct gpio_led wdr4300_leds_gpio[] __initdata = {
 
 static struct gpio_keys_button wdr4300_gpio_keys[] __initdata = {
 	{
-		.desc		= "QSS button",
+		.desc		= "Reset/WPS button",
 		.type		= EV_KEY,
-		.code		= KEY_WPS_BUTTON,
+		.code		= KEY_RESTART,
 		.debounce_interval = WDR4300_KEYS_DEBOUNCE_INTERVAL,
 		.gpio		= WDR4300_GPIO_BTN_WPS,
 		.active_low	= 1,


### PR DESCRIPTION
Changed button description.
This router have only one button named Reset/WPS.
Reset/restart function is more important as WPS.

Signed-off-by: Henryk Heisig <hyniu@o2.pl>