### PR TITLE
ramips: WN3000RPv3: do not setup switch

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -58,7 +58,6 @@ ramips_setup_interfaces()
 	timecloud|\
 	w150m|\
 	widora-neo|\
-	wn3000rpv3|\
 	wnce2001|\
 	zbt-cpe102|\
 	zte-q7)
@@ -195,6 +194,7 @@ ramips_setup_interfaces()
 	pbr-d1|\
 	wli-tx4-ag300n|\
 	wmr-300|\
+	wn3000rpv3|\
 	wrh-300cr)
 		ucidef_set_interface_lan "eth0"
 		;;


### PR DESCRIPTION
The WN3000RPv3 is a repeater with a single ethernet port. Setting up the
switch, even to disable it, is unnecessary and possibly confusing.

Configure LAN as eth0 instead.

Signed-off-by: Thibaut VARENE <hacks@slashdirt.org>