### PR TITLE
ath10k-firmware: update qca9984 firmware

### DIFF
--- a/package/firmware/ath10k-firmware/Makefile
+++ b/package/firmware/ath10k-firmware/Makefile
@@ -207,8 +207,8 @@ $(eval $(call Download,qca99x0-board))
 QCA9984_BOARD_REV:=719c0127e52bd70559e71b85ab0331790e1bf66c
 QCA9984_BOARD_FILE:=board-2.bin
 QCA9984_BOARD_FILE_DL:=$(QCA9984_BOARD_FILE).$(QCA9984_BOARD_REV)
-QCA9984_FIRMWARE_REV:=d697906c66ccfbf9dfd77071b154394006e3371a
-QCA9984_FIRMWARE_FILE:=firmware-5.bin_10.4-3.4-00068
+QCA9984_FIRMWARE_REV:=d43cb1188154037506e94abf3aa456cc934c6861
+QCA9984_FIRMWARE_FILE:=firmware-5.bin_10.4-3.4-00072
 QCA9984_FIRMWARE_FILE_DL:=$(QCA9984_FIRMWARE_FILE).$(QCA9984_FIRMWARE_REV)
 
 define Download/ath10k-qca9984-board
@@ -223,7 +223,7 @@ define Download/ath10k-qca9984-firmware
   URL:=https://source.codeaurora.org/quic/qsdk/oss/firmware/ath10k-firmware/plain/ath10k/QCA9984/hw1.0/
   URL_FILE:=$(QCA9984_FIRMWARE_FILE)?id=$(QCA9984_FIRMWARE_REV)
   FILE:=$(QCA9984_FIRMWARE_FILE_DL)
-  HASH:=47616657bbfda217b82aacde51076f768f0aa38493decadd7f339d2d040c53fc
+  HASH:=28d5834e8c4ca8fcef9ea033cd8b9b0f9ee84ecf30dbde84c9c64bf8dd9912bc
 endef
 $(eval $(call Download,ath10k-qca9984-firmware))
 


### PR DESCRIPTION
Bump qca9984 firmware.

Haven't noticed any changes in my setup.

Has been testing for a 3-4 days on Netgear R7800 without issues.