### PR TITLE
ramips: Clean duplicated status property for Omega2 WMAC in dtsi

### DIFF
--- a/target/linux/ramips/dts/OMEGA2.dtsi
+++ b/target/linux/ramips/dts/OMEGA2.dtsi
@@ -94,10 +94,6 @@
 	status = "okay";
 };
 
-&wmac {
-	status = "okay";
-};
-
 &spi0 {
 	status = "okay";
 


### PR DESCRIPTION
At the tail of dtsi, wmac is enabled twice, clean the first one

Signed-off-by: Furong Xu <xfr@outlook.com>