### PR TITLE
ar71xx: Enable RB2011 TTY

### DIFF
--- a/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,24 @@ void __init prom_init(void)
+@@ -136,6 +136,25 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -19,6 +19,7 @@
 +	    strstr(arcs_cmdline, "board=953gs") ||
 +	    strstr(arcs_cmdline, "board=map-hb") ||
 +	    strstr(arcs_cmdline, "board=2011L") ||
++	    strstr(arcs_cmdline, "board=2011r") ||
 +	    strstr(arcs_cmdline, "board=711Gr100") ||
 +	    strstr(arcs_cmdline, "board=922gs"))
 +		ath79_prom_append_cmdline("console", "ttyS0,115200");


### PR DESCRIPTION
Enables TTY on the Mikrotik RouterBoard RB2011UiAS-RM and maybe RB2011iL-RM
