### PR TITLE
ramips: export slic IRQ line in dwr-512

### DIFF
--- a/target/linux/ramips/dts/DWR-512-B.dts
+++ b/target/linux/ramips/dts/DWR-512-B.dts
@@ -61,6 +61,10 @@
 		compatible = "gpio-export";
 		#size-cells = <0>;
 
+		slic_int {
+			gpio-export,name = "slic_int";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+		};
 		modem3g_enable {
 			gpio-export,name = "modem3g_enable";
 			gpio-export,output = <1>;


### PR DESCRIPTION
The DWR-512 embeds the hw slic device si3210.
This device have the IRQ line attached to the gpio1.
This patch export the gpio1 with proper name and parameters to the
sysfs.

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>