### PR TITLE
procd: fix default timeout for reload trigger actions

### DIFF
--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -251,9 +251,8 @@ _procd_add_interface_trigger() {
 	json_close_array
 
 	json_close_array
-	json_close_array
-
 	_procd_add_timeout
+	json_close_array
 }
 
 _procd_add_reload_interface_trigger() {
@@ -283,10 +282,8 @@ _procd_add_config_trigger() {
 	json_close_array
 
 	json_close_array
-
-	json_close_array
-
 	_procd_add_timeout
+	json_close_array
 }
 
 _procd_add_raw_trigger() {


### PR DESCRIPTION
Default trigger action timeout was added to procd.sh in commit f88e3a4c0
(procd: add default timeout for reload trigger actions)
However, the timeout value was not placed under the correct JSON-script
array nesting level and thus did not apply.

To fix this and make the timeout actually apply to the reload triggers,
we place it in the correct scope, that is the per-trigger array.

Fixes: f88e3a4c0abb60bb76a7678dd30dfdc8a808a2f1
Signed-off-by: Denis Osvald <denis.osvald@sartura.hr>