### PR TITLE
ar8216: flush ARL table during reset after init_globals

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/ar8216.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8216.c
@@ -1194,6 +1194,7 @@ ar8xxx_sw_reset_switch(struct switch_dev *dev)
 	priv->arl_age_time = AR8XXX_DEFAULT_ARL_AGE_TIME;
 
 	chip->init_globals(priv);
+	chip->atu_flush(priv);
 
 	mutex_unlock(&priv->reg_mutex);
 


### PR DESCRIPTION
Hi

in commit ec1a695daa7390a6c24e3b28d3956f194cba2cb5 ar8327_get_arl_entry() function is disabled due to lockups on some devices when swconfig dev <dev> get_arl_table (or show) is executed.

We had similar lockups when arl table was read shortly after a reboot where a device was reset by the hardware watchdog. Waiting some minutes after reboot before executing this command we couldn't trigger this lockup anymore.

I think I've found the cause for this issue (FS#384):

commit 33b72b8e0faf7a39faabece584fd6da61cd8f8df
"ar8216: adjust ATU flushing in case of link changes"
introduced portwise flushing on link down events. Now the ARL table could
be in a chaotic state after boot where ar8xxx_sw_get_arl_table looped
forever (depending on the entries collected while booting).

Signed-off-by: Günther Kelleter <guenther.kelleter@devolo.de>


If this fixes it commit ec1a695daa7390a6c24e3b28d3956f194cba2cb5 should be reverted!