### PR TITLE
17.01: ar71xx: Remove images for rb-941-2nd

### DIFF
--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -42,5 +42,3 @@ $(Device/rb-nor-flash-16M)
   DEVICE_TITLE := hAP lite
   BOARDNAME:= rb-941-2nd
 endef
-
-TARGET_DEVICES += rb-nor-flash-16M rb-941-2nd


### PR DESCRIPTION
The code that generates this image in 17.01-RC is broken in many ways.

The new code currently in master (from #800 and #833) generates images that will not be compatible with the ones in 17.01. To avoid a migration nightmare, this patch removes image generation for this device in 17.01

Signed-off-by: Thibaut VARENE <hacks@slashdirt.org>