### PR TITLE
x86: Add Geos profile for Geode subtarget

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -201,7 +201,6 @@ menu "Target Images"
 		int "Serial port baud rate"
 		depends on GRUB_IMAGES
 		default 38400 if TARGET_x86_generic
-		default 38400 if TARGET_x86_geode
 		default 115200
 
 	config GRUB_BOOTOPTS

--- a/target/linux/x86/geode/profiles/000-Generic.mk
+++ b/target/linux/x86/geode/profiles/000-Generic.mk
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2006-2009 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Profile/Generic
+  NAME:=Generic
+  PACKAGES:= \
+		soloscli linux-atm br2684ctl ppp-mod-pppoa pppdump pppstats \
+		hwclock flashrom tc kmod-pppoa kmod-8139cp kmod-mppe \
+		kmod-usb-ohci-pci kmod-hwmon-lm90 \
+		kmod-via-rhine
+endef
+
+define Profile/Generic/Description
+	Generic Profile for all Geode boards.
+endef
+$(eval $(call Profile,Generic))

--- a/target/linux/x86/geode/profiles/100-Geos.mk
+++ b/target/linux/x86/geode/profiles/100-Geos.mk
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2006-2009 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Profile/Geos
+  NAME:=Geos
+  PACKAGES:= \
+		soloscli linux-atm br2684ctl ppp-mod-pppoa pppdump pppstats \
+		hwclock flashrom tc kmod-pppoa kmod-8139cp kmod-mppe \
+		kmod-usb-ohci-pci kmod-hwmon-lm90
+endef
+
+define Profile/Geos/Description
+	Traverse Technologies Geos ADSL router
+endef
+$(eval $(call Profile,Geos))

--- a/target/linux/x86/geode/target.mk
+++ b/target/linux/x86/geode/target.mk
@@ -6,6 +6,11 @@ DEFAULT_PACKAGES += \
 			kmod-button-hotplug \
 			kmod-ledtrig-heartbeat kmod-ledtrig-gpio \
 			kmod-ledtrig-netdev hwclock wpad-mini
+# Geos
+DEFAULT_PACKAGES += \
+		soloscli linux-atm br2684ctl ppp-mod-pppoa pppdump pppstats \
+		hwclock flashrom tc kmod-pppoa kmod-8139cp kmod-mppe \
+		kmod-usb-ohci-pci kmod-hwmon-lm90
 
 define Target/Description
 	Build firmware images for AMD Geode GX/LX based systems (net5501, alix, geos)


### PR DESCRIPTION
This makes the Geode images actually useful again. The Geos profile
should include the relevant hardware for that board, and the Default
profile adds the via-rhine adapter which seems to have been present in
the net5501 and alix targets killed in commit 9e0759ea265 ("x86: merge
all geode based subtargets into one").

Signed-off-by: David Woodhouse <dwmw2@infradead.org>
