### PR TITLE
ugps: fix typo

### DIFF
--- a/package/utils/ugps/Makefile
+++ b/package/utils/ugps/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ugps
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL=$(LEDE_GIT)/project/ugps.git
 PKG_SOURCE_PROTO:=git

--- a/package/utils/ugps/files/gps.config
+++ b/package/utils/ugps/files/gps.config
@@ -1,3 +1,3 @@
 config gps
 	option	'tty'	'ttyACM0'
-	option	'adjust_time '	'1'
+	option	'adjust_time'	'1'


### PR DESCRIPTION
Removing redundant spaces from the name of the option. Without fix:

```
root@LEDE:~# opkg install ugps
Installing ugps (2016-10-24-32a6b2b7-1) to root...
Downloading http://downloads.lede-project.org/releases/17.01-SNAPSHOT/packages/mips_24kc/base/ugps_2016-10-24-32a6b2b7-1_mips_24kc.ipk
Configuring ugps.
uci: Parse error (invalid character in name field) at line 3, byte 23
uci: Parse error (invalid character in name field) at line 3, byte 23
sh: out of range
root@LEDE:~# uci show gps
uci: Parse error (invalid character in name field) at line 3, byte 23
```

With this fix:

```
root@LEDE:~# uci show gps
gps.@gps[0]=gps
gps.@gps[0].tty='ttyACM0'
gps.@gps[0].adjust_time='1'
```

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>