### PR TITLE
ramips: fix PWM pin mux conflict in dtsi

### DIFF
--- a/target/linux/ramips/dts/OMEGA2.dtsi
+++ b/target/linux/ramips/dts/OMEGA2.dtsi
@@ -152,10 +152,6 @@
 	status = "okay";
 };
 
-&pwm {
-	status = "okay";
-};
-
 &ethernet {
 	mtd-mac-address = <&factory 0x28>;
 };


### PR DESCRIPTION
GPIO18 and GPIO19 on OMEGA2(+) should be GPIO mode, enable PWM lead to a conflict

[    0.290633] rt2880-pinmux pinctrl: pin io18 already requested by pinctrl; cannot claim for 10005000.pwm
[    0.299722] rt2880-pinmux pinctrl: pin-18 (10005000.pwm) status -22
[    0.305729] rt2880-pinmux pinctrl: could not request pin 18 (io18) from group pwm0  on device rt2880-pinmux
[    0.315131] mtk-pwm 10005000.pwm: Error applying setting, reverse things back

Keep PWM disabled.

Signed-off-by: Furong Xu <xfr@outlook.com>