### PR TITLE
ar71xx: fix CPU hangs on QCA956x when WAN port gets link up

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
@@ -1096,7 +1096,7 @@ void __init ath79_register_eth(unsigned int id)
 			if (pdata->phy_if_mode == PHY_INTERFACE_MODE_SGMII)
 				pdata->set_speed = qca956x_set_speed_sgmii;
 			else
-				pdata->set_speed = ath79_set_speed_ge0;
+				pdata->set_speed = ath79_set_speed_dummy;
 		} else {
 			pdata->reset_bit = QCA955X_RESET_GE1_MAC |
 					   QCA955X_RESET_GE1_MDIO;


### PR DESCRIPTION
On QCA956x, if GMAC0, i.e. WAN, in MII mode, we cannot change the PLL
configuration parameters when autonegotiation is done. Or CPU will hangs and then
the watchdog kicks us off to reset.

This issue is observed on TL-WDR6500 v2, now works like a charm.

Signed-off-by: Furong Xu <xfr@outlook.com>