### PR TITLE
libevent2:  version update to 2.1.8-stable

### DIFF
--- a/package/libs/libevent2/Makefile
+++ b/package/libs/libevent2/Makefile
@@ -8,13 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevent2
-PKG_VERSION:=2.0.22
-PKG_RELEASE:=1
+PKG_VERSION:=2.1.8
+PKG_RELEASE:=2
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/libevent-$(PKG_VERSION)-stable
+PKG_SOURCE_PROTO:=git
+PKG_BUILD_DIR:=$(BUILD_DIR)/libevent-$(PKG_VERSION)
 PKG_SOURCE:=libevent-$(PKG_VERSION)-stable.tar.gz
-PKG_SOURCE_URL:=@SF/levent
-PKG_HASH:=71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3
+PKG_SOURCE_SUBDIR:=libevent-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/libevent/libevent.git
+PKG_SOURCE_VERSION:=release-$(PKG_VERSION)-stable
+PKG_MIRROR_HASH:=7227b9ae556f22f9d9815c6ba2630b614510f3cb0ac44c3775fe55c5cae720bb
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=BSD-3-Clause
 
@@ -45,7 +48,7 @@ endef
 
 define Package/libevent2
   $(call Package/libevent2/Default)
-  TITLE+= library (version 2.0)
+  TITLE+= library (version 2.1)
 endef
 
 define Package/libevent2/description
@@ -57,7 +60,7 @@ endef
 
 define Package/libevent2-core
   $(call Package/libevent2/Default)
-  TITLE+= core library (version 2.0)
+  TITLE+= core library (version 2.1)
 endef
 
 define Package/libevent2-core/description
@@ -69,7 +72,7 @@ endef
 
 define Package/libevent2-extra
   $(call Package/libevent2/Default)
-  TITLE+= extra library (version 2.0)
+  TITLE+= extra library (version 2.1)
 endef
 
 define Package/libevent2-extra/description
@@ -81,7 +84,7 @@ endef
 
 define Package/libevent2-openssl
   $(call Package/libevent2/Default)
-  TITLE+= OpenSSL library (version 2.0)
+  TITLE+= OpenSSL library (version 2.1)
   DEPENDS+=+libopenssl
 endef
 
@@ -94,7 +97,7 @@ endef
 
 define Package/libevent2-pthreads
   $(call Package/libevent2/Default)
-  TITLE+= Pthreads library (version 2.0)
+  TITLE+= Pthreads library (version 2.1)
   DEPENDS+=+libpthread
 endef
 
@@ -120,34 +123,34 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent*.{la,a,so} $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent*-2.0.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent*-2.1.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libevent*.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libevent2/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-core/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_core-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_core-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-extra/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_extra-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_extra-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-openssl/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_openssl-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_openssl-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-pthreads/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_pthreads-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_pthreads-2.1.so.* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libevent2))

--- a/package/libs/libevent2/patches/001-fix_openssl_all_depends.patch
+++ b/package/libs/libevent2/patches/001-fix_openssl_all_depends.patch
@@ -1,0 +1,22 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -114,7 +114,7 @@ AC_ARG_ENABLE([libevent-regress],
+ 	[], [enable_libevent_regress=yes])
+ AC_ARG_ENABLE([samples],
+      AS_HELP_STRING([--disable-samples, skip building of sample programs]),
+-	[], [enable_samples=yes])
++	[], [enable_samples=no])
+ AC_ARG_ENABLE([function-sections],
+      AS_HELP_STRING([--enable-function-sections, make static library allow smaller binaries with --gc-sections]),
+ 	[], [enable_function_sections=no])
+@@ -791,10 +791,6 @@ fi
+ 
+ # check if we have and should use openssl
+ AM_CONDITIONAL(OPENSSL, [test "$enable_openssl" != "no" && test "$have_openssl" = "yes"])
+-if test "x$enable_openssl" = "xyes"; then
+-	AC_SEARCH_LIBS([ERR_remove_thread_state], [crypto eay32],
+-		[AC_DEFINE(HAVE_ERR_REMOVE_THREAD_STATE, 1, [Define to 1 if you have ERR_remove_thread_stat().])])
+-fi
+ 
+ # Add some more warnings which we use in development but not in the
+ # released versions.  (Some relevant gcc versions can't handle these.)


### PR DESCRIPTION
Compile tested: ar71xx & ramips & ipq806x  OpenWRT Chaos Calmer & LEDE 17.01 RC1
Compile run:  ar71xx & ramips & ipq806x  OpenWRT Chaos Calmer & LEDE 17.01 RC1

update libevent2 from version 2.0.22 to 2.1.8
add patch to fix bug of needing to add depends on libopenssl in all libevent library, according to communicate with  @azat who is a member of libevent2, this bug will be fixed in version 2.1.9. here is issue
https://github.com/libevent/libevent/issues/462


Signed-off-by: Dengfeng Liu <liudengfeng@kunteng.org>