### PR TITLE
modules: Add kmod-igbvf kernel module for Intel(R) 82576 Virtual Function Ethernet adapters

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -522,6 +522,24 @@ endef
 $(eval $(call KernelPackage,igb))
 
 
+define KernelPackage/igbvf
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Intel(R) 82576 Virtual Function Ethernet support
+  DEPENDS:=@PCI_SUPPORT +kmod-i2c-core +kmod-i2c-algo-bit +kmod-ptp
+  KCONFIG:=CONFIG_IGBVF \
+    CONFIG_IGB_HWMON=n \
+    CONFIG_IGB_DCA=n
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/igbvf/igbvf.ko
+  AUTOLOAD:=$(call AutoLoad,35,igbvf)
+endef
+
+define KernelPackage/igbvf/description
+ Kernel modules for Intel(R) 82576 Virtual Function Ethernet adapters.
+endef
+
+$(eval $(call KernelPackage,igbvf))
+
+
 define KernelPackage/b44
   TITLE:=Broadcom 44xx driver
   KCONFIG:=CONFIG_B44


### PR DESCRIPTION
Intel(R) 82576 is an adapter which supports SR-IOV. Thus the host can
assign Virtual Functions (VFs) to different VMs by the PCI-E Passthrough
(e.g. VFIO for KVM), to gain different advantages (performance, VF to VF
communications, host kernel offload, etc.).

The driver of the passthroughed VFs is the igbvf (igb is NOT compatible).

This is essential for VM guests, to enable them to utilize this feature.

(This patch is already merged to the original openwrt tree, thus I resubmit it for LEDE.) 