### PR TITLE
ar71xx: Add more boards to the routerboard serial detection patch

### DIFF
--- a/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,22 @@ void __init prom_init(void)
+@@ -136,6 +136,24 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -10,11 +10,13 @@
 +	    strstr(arcs_cmdline, "board=750-hb") ||
 +	    strstr(arcs_cmdline, "board=411") ||
 +	    strstr(arcs_cmdline, "board=433") ||
++	    strstr(arcs_cmdline, "board=435") ||
 +	    strstr(arcs_cmdline, "board=450") ||
 +	    strstr(arcs_cmdline, "board=493") ||
 +	    strstr(arcs_cmdline, "board=951G") ||
 +	    strstr(arcs_cmdline, "board=H951L") ||
 +	    strstr(arcs_cmdline, "board=952-hb") ||
++	    strstr(arcs_cmdline, "board=953gs") ||
 +	    strstr(arcs_cmdline, "board=map-hb") ||
 +	    strstr(arcs_cmdline, "board=2011L") ||
 +	    strstr(arcs_cmdline, "board=711Gr100") ||


### PR DESCRIPTION
This patch enables serial console on the 435 series and the 953gs.

953gs requested here: http://lists.infradead.org/pipermail/lede-dev/2017-January/005197.html
435 requested by @djbuldog