### PR TITLE
dnsmasq: do not forward rfc6761 excluded domains

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -152,6 +152,8 @@ define Package/dnsmasq/install
 	$(INSTALL_BIN) ./files/dnsmasq.init $(1)/etc/init.d/dnsmasq
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/ntp
 	$(INSTALL_DATA) ./files/dnsmasqsec.hotplug $(1)/etc/hotplug.d/ntp/25-dnsmasqsec
+	$(INSTALL_DIR) $(1)/usr/share/dnsmasq
+	$(INSTALL_DATA) ./files/rfc6761.conf $(1)/usr/share/dnsmasq/
 endef
 
 Package/dnsmasq-dhcpv6/install = $(Package/dnsmasq/install)

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -17,6 +17,7 @@ BASETIMESTAMPFILE="/etc/dnsmasq.time"
 TRUSTANCHORSFILE="/usr/share/dnsmasq/trust-anchors.conf"
 TIMEVALIDFILE="/var/state/dnsmasqsec"
 BASEDHCPSTAMPFILE="/var/run/dnsmasq"
+RFC6761FILE="/usr/share/dnsmasq/rfc6761.conf"
 
 DNSMASQ_DHCP_VER=4
 
@@ -731,7 +732,6 @@ dnsmasq_start()
 	append_bool "$cfg" localise_queries "--localise-queries"
 	append_bool "$cfg" readethers "--read-ethers"
 	append_bool "$cfg" dbus "--enable-dbus"
-	append_bool "$cfg" boguspriv "--bogus-priv"
 	append_bool "$cfg" expandhosts "--expand-hosts"
 	config_get tftp_root "$cfg" "tftp_root"
 	[ -d "$tftp_root" ] && append_bool "$cfg" enable_tftp "--enable-tftp"
@@ -886,6 +886,11 @@ dnsmasq_start()
 	config_foreach filter_dnsmasq mxhost dhcp_mx_add "$cfg"
 	echo >> $CONFIGFILE_TMP
 
+	config_get_bool boguspriv "$cfg" boguspriv 1
+	[ "$boguspriv" -gt 0 ] && {
+		xappend "--bogus-priv"
+		[ -r "$RFC6761FILE" ] && xappend "--conf-file=$RFC6761FILE"
+	}
 
 	if [ "$DNSMASQ_DHCP_VER" -gt 4 ] ; then
 		# Enable RA feature for when/if it is constructed,
@@ -930,7 +935,7 @@ dnsmasq_start()
 	fi
 
 	procd_add_jail dnsmasq ubus log
-	procd_add_jail_mount $CONFIGFILE $TRUSTANCHORSFILE $HOSTFILE /etc/passwd /etc/group /etc/TZ /dev/null /dev/urandom $dnsmasqconffile $dnsmasqconfdir $resolvfile $dhcpscript /etc/hosts /etc/ethers $EXTRA_MOUNT
+	procd_add_jail_mount $CONFIGFILE $TRUSTANCHORSFILE $HOSTFILE $RFC6761FILE /etc/passwd /etc/group /etc/TZ /dev/null /dev/urandom $dnsmasqconffile $dnsmasqconfdir $resolvfile $dhcpscript /etc/hosts /etc/ethers $EXTRA_MOUNT
 	procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
 
 	procd_close_instance

--- a/package/network/services/dnsmasq/files/rfc6761.conf
+++ b/package/network/services/dnsmasq/files/rfc6761.conf
@@ -1,0 +1,15 @@
+# RFC6761 included configuration file for dnsmasq
+#
+# includes a list of domains that should not be forwarded to Internet name servers
+# to reduce burden on them, asking questions that they won't know the answer to.
+
+server=/bind/
+server=/example/
+server=/example.com/
+server=/example.org/
+server=/example.net/
+server=/invalid/
+server=/local/
+server=/localhost/
+server=/onion/
+server=/test/


### PR DESCRIPTION
RFC 6761 defines a number of top level domains should not be forwarded
to the Internet's domain servers since they are not responsible for
those domains.

This change adds a list of domains that will be blocked when 'boguspriv'
is used and augments that which is already blocked by dnsmasq's notion
of 'local service' using '--bogus-priv' i.e. RFC 1918 private addresses
and IPv6 prefixes as defined in RFC 6303.

To make this configurable rather than hard coded in dnsmasq's init
script, a new file /usr/share/dnsmasq/rfc6761.conf is conditionally
included.

The default file matches the RFC 6761 recommendation along with a few
other top level domains that should not be forwarded to the Internet.

Compile & run tested Archer C7 v2

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>