### PR TITLE
ramips: Add support for HiWiFi HC5962

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -80,6 +80,7 @@ ramips_setup_interfaces()
 	dir-615-h1|\
 	firewrt|\
 	hc5661a|\
+	hc5962|\
 	hlk-rm04|\
 	mac1200rv2|\
 	miwifi-mini|\
@@ -345,7 +346,8 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii config WAN_MAC_ADDR)
 		;;
 	hc5*61|\
-	hc5661a)
+	hc5661a|\
+	hc5962)
 		lan_mac=`mtd_get_mac_ascii bdinfo "Vfac_mac "`
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -147,6 +147,9 @@ get_status_led() {
 	mlwg2)
 		status_led="$board:blue:system"
 		;;
+	hc5962)
+		status_led="$board:white:status"
+		;;
 	linkits7688| \
 	linkits7688d)
 		[ "$1" = "upgrade" ] && status_led="mediatek:orange:wifi"

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -226,6 +226,9 @@ ramips_board_detect() {
 	*"HC5861")
 		name="hc5861"
 		;;
+	*"HC5962")
+		name="hc5962"
+		;;
 	*"HG255D")
 		name="hg255d"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -228,6 +228,10 @@ platform_check_image() {
 		}
 		return 0
 		;;
+	hc5962)
+		# these boards use metadata images
+		return 0
+		;;
 	ubnt-erx)
 		nand_do_platform_check "$board" "$1"
 		return $?;
@@ -260,6 +264,7 @@ platform_pre_upgrade() {
 	local board=$(ramips_board_name)
 
 	case "$board" in
+    	hc5962|\
     	ubnt-erx)
 		nand_do_upgrade "$ARGV"
 		;;

--- a/target/linux/ramips/dts/HC5962.dts
+++ b/target/linux/ramips/dts/HC5962.dts
@@ -1,0 +1,147 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "HiWiFi HC5962";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		status {
+			label = "hc5962:white:status";
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+		};	
+		
+		system {
+			label = "hc5962:red:system";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partition@0 {
+		label = "u-boot";
+		reg = <0x0 0x80000>;
+		read-only;
+	};
+
+	partition@80000 {
+		label = "debug";
+		reg = <0x80000 0x80000>;
+		read-only;
+	};
+
+	factory: partition@100000 {
+		label = "factory";
+		reg = <0x100000 0x40000>;
+		read-only;
+	};
+
+	partition@140000 {
+		label = "kernel";
+		reg = <0x140000 0x200000>;
+	};
+
+	partition@340000 {
+		label = "ubi";
+		reg = <0x340000 0x1E00000>;
+	};
+
+	partition@2140000 {
+		label = "hw_panic";
+		reg = <0x2140000 0x80000>;
+		read-only;
+	};
+
+	partition@21c0000 {
+		label = "bdinfo";
+		reg = <0x21c0000 0x80000>;
+		read-only;
+	};
+
+	partition@2240000 {
+		label = "backup";
+		reg = <0x2240000 0x80000>;
+		read-only;
+	};
+
+	partition@22c0000 {
+		label = "overly";
+		reg = <0x22c0000 0x1000000>;
+	};
+
+	partition@32c0000 {
+		label = "firmware_backup";
+		reg = <0x32c0000 0x2000000>;
+	};
+
+	partition@52c0000 {
+		label = "oem";
+		reg = <0x52c0000 0x200000>;
+	};
+
+	partition@54c0000 {
+		label = "opt";
+		reg = <0x54c0000 0x2ac0000>;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+			ieee80211-freq-limit = <2400000 2500000>;
+		};
+	};
+
+	pcie1 {
+		mt76@1,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart3", "jtag";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -71,6 +71,21 @@ define Device/firewrt
 endef
 TARGET_DEVICES += firewrt
 
+define Device/hc5962
+  DTS := HC5962
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 2097152
+  UBINIZE_OPTS := -E 5
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | check-size $$$$(IMAGE_SIZE)
+  DEVICE_TITLE := HiWiFi HC5962
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt76
+endef
+TARGET_DEVICES += hc5962
+
 define Device/mt7621
   DTS := MT7621
   BLOCKSIZE := 64k


### PR DESCRIPTION
This patch adds supports for the HiWiFi HC5962(gee4) http://www.hiwifi.com

Short specification:
- MT7621AT + MT7612EN + 7603EN
- 256MB DDR3 RAM
- 128MB NAND flash
- 1+3 x 1000M Ethernet
- 1x USB 2.0 port. 1x USB 3.0 port
- UART pad on PCB (JP3: TX, RX, GND, 3.3V)

Flash instruction:

1. Download lede-ramips-mt7621-hc5962-squashfs-factory.bin
2. Login as root via SSH on 192.168.199.1 and then copy factory.bin(using wget or nc or...) to /tmp/
3. use the following commands:
   $ mtd write /tmp/lede-ramips-mt7621-hc5962-squashfs-factory.bin firmware
   $ mtd erase firmware_backup && reboot
After reboot you should be able to login as root via SSH on 192.168.1.1

Signed-off-by: ZengFei Zhang <zhangzengfei@kunteng.org>