### PR TITLE
uboot-omap: Makefile: Include kernel.mk

### DIFF
--- a/package/boot/uboot-omap/Makefile
+++ b/package/boot/uboot-omap/Makefile
@@ -6,6 +6,7 @@
 #
 
 include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
 
 PKG_VERSION:=2017.01
 PKG_RELEASE:=1


### PR DESCRIPTION
This is needed for the definition of $(LINUX_DIR). This is used in
u-boot.mk to change the device-tree compiler to the dtc used by
linux.

Without this, the build will use the system dtc. This results in a
build failure when a dtc does not exist outside the buildroot.

Signed-off-by: Alexandru Gagniuc <alex.g@adaptrum.com>