### PR TITLE
ar71xx: mikrotik: erase firmware partition on SPI NOR devices in pre_upgrade()

### DIFF
--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -684,6 +684,14 @@ platform_pre_upgrade() {
 	wndr4300)
 		nand_do_upgrade "$1"
 		;;
+	rb-750-r2|\
+	rb-750up-r2|\
+	rb-941-2nd|\
+	rb-951ui-2nd|\
+	rb-mapl-2nd)
+		# erase firmware if booted from initramfs
+		[ -z "$(rootfs_type)" ] && mtd erase firmware
+		;;
 	mr18|\
 	z1)
 		merakinand_do_upgrade "$1"


### PR DESCRIPTION
On Mikrotik SPI NOR devices, the firmware partition must be erased when flashing
from stock firmware, otherwise leftover bits (in particular a kernel signature)
can trigger a boot loop.

When booted from initramfs (the only way to flash LEDE on these devices),
this patch unconditionally erases the firmware partition in the pre_upgrade()
stage for all supported SPI NOR devices.