### PR TITLE
kirkwood: fix include in etc/board.d/02_network

### DIFF
--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -4,6 +4,7 @@
 #
 
 . /lib/functions/uci-defaults.sh
+. /lib/functions/system.sh
 . /lib/kirkwood.sh
 
 board_config_update


### PR DESCRIPTION
the mtd_get_mac_ascii function called within this script requires the inclusion of /lib/functions/system.sh

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>