### PR TITLE
ramips: include only kmod-mt76-core in EX2700 image

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -61,6 +61,7 @@ define Device/ex2700
   KERNEL := $(KERNEL_DTB) | uImage lzma | pad-offset 64k 64 | append-uImage-fakeroot-hdr
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	netgear-dni
+  DEVICE_PACKAGES := -kmod-mt76 kmod-mt76-core
   DEVICE_TITLE := Netgear EX2700
 endef
 TARGET_DEVICES += ex2700


### PR DESCRIPTION
This patch frees up flash space on the EX2700, by
removing unused mt76 drivers and firmware.

Signed-off-by: Joseph C. Lehner <joseph.c.lehner@gmail.com>