### PR TITLE
dnsmasq: remove check for existing dhcp server

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.77test4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq/test-releases

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -58,30 +58,6 @@ dhcp_calc() {
 	echo "$res"
 }
 
-dhcp_check() {
-	local ifname="$1"
-	local stamp="${BASEDHCPSTAMPFILE_CFG}.${ifname}.dhcp"
-	local rv=0
-
-	[ -s "$stamp" ] && return $(cat "$stamp")
-
-	# If there's no carrier yet, skip this interface.
-	# The init script will be called again once the link is up
-	case "$(devstatus "$ifname" | jsonfilter -e @.carrier)" in
-		false) return 1;;
-	esac
-
-	udhcpc -n -q -s /bin/true -t 1 -i "$ifname" >&- && rv=1 || rv=0
-
-	[ $rv -eq 1 ] && \
-		logger -t dnsmasq \
-			"found already running DHCP-server on interface '$ifname'" \
-			"refusing to start, use 'option force 1' to override"
-
-	echo $rv > "$stamp"
-	return $rv
-}
-
 log_once() {
 	pidof dnsmasq >/dev/null || \
 		logger -t dnsmasq "$@"
@@ -448,10 +424,6 @@ dhcp_add() {
 
 	# Override interface netmask with dhcp config if applicable
 	config_get netmask "$cfg" netmask "${subnet##*/}"
-
-	#check for an already active dhcp server on the interface, unless 'force' is set
-	config_get_bool force "$cfg" force 0
-	[ $force -gt 0 ] || dhcp_check "$ifname" || return 0
 
 	config_get start "$cfg" start 100
 	config_get limit "$cfg" limit 150


### PR DESCRIPTION
Remove check for existing dhcp server on interface.  This check could
already be overridden by using 'force' parameter so this change
forces 'force'.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>