### PR TITLE
dnsmasq: make bind-dynamic 'non-wildcard' interfaces default

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.77test4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq/test-releases

--- a/package/network/services/dnsmasq/files/dhcp.conf
+++ b/package/network/services/dnsmasq/files/dhcp.conf
@@ -15,7 +15,7 @@ config dnsmasq
 	option leasefile	'/tmp/dhcp.leases'
 	option resolvfile	'/tmp/resolv.conf.auto'
 	#list server		'/mycompany.local/1.2.3.4'
-	#option nonwildcard	1
+	option binddynamic	1 # bind to & keep track of interfaces
 	#list interface		br-lan
 	#list notinterface	lo
 	#list bogusnxdomain     '64.94.110.11'

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -91,8 +91,10 @@ append_bool() {
 	local section="$1"
 	local option="$2"
 	local value="$3"
+	local default="$4"
 	local _loctmp
-	config_get_bool _loctmp "$section" "$option" 0
+	[ -z "$default" ] && default="0"
+	config_get_bool _loctmp "$section" "$option" "$default"
 	[ $_loctmp -gt 0 ] && xappend "$value"
 }
 
@@ -736,7 +738,7 @@ dnsmasq_start()
 	config_get tftp_root "$cfg" "tftp_root"
 	[ -d "$tftp_root" ] && append_bool "$cfg" enable_tftp "--enable-tftp"
 	append_bool "$cfg" tftp_no_fail "--tftp-no-fail"
-	append_bool "$cfg" nonwildcard "--bind-dynamic"
+	append_bool "$cfg" binddynamic "--bind-dynamic" 1
 	append_bool "$cfg" fqdn "--dhcp-fqdn"
 	append_bool "$cfg" proxydnssec "--proxy-dnssec"
 	append_bool "$cfg" localservice "--local-service"


### PR DESCRIPTION
'non-wildcard' interfaces enables dnsmasq's '--bind-dynamic' mode.  This
binds to interfaces rather than wildcard addresses *and* keeps track of
interface comings/goings via a unique Linux api.

Quoting dnsmasq's author "bind-dynamic (bind individual addresses, keep
up with changes in interface config) ... On linux, there's actually no
sane reason not to use --bind-dynamic, and it's only not the default for
historical reasons."

Rename the 'nonwildcard' option to 'binddynamic' as this is more
descriptive of what dnsmasq is doing underneath.

Let's change history, well on LEDE at least, and change the default!

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>

Companion luci PR https://github.com/openwrt/luci/pull/1040

The advantages of doing this is that multiple dnsmasq instances are easier
to implement if required and interface labels are carried through for the various
tagging options that may be used.