### PR TITLE
wireless-tools: Change download url to github

### DIFF
--- a/package/network/utils/wireless-tools/Makefile
+++ b/package/network/utils/wireless-tools/Makefile
@@ -13,7 +13,7 @@ PKG_MINOR:=
 PKG_RELEASE:=5
 
 PKG_SOURCE:=wireless_tools.$(PKG_VERSION)$(PKG_MINOR).tar.gz
-PKG_SOURCE_URL:=http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux
+PKG_SOURCE_URL:=https://hewlettpackard.github.io/wireless-tools
 PKG_HASH:=6fb80935fe208538131ce2c4178221bab1078a1656306bce8909c19887e2e5a1
 TAR_OPTIONS += || true
 


### PR DESCRIPTION
The original url is unreachable.
Signed-off-by: Hsing-Wang Liao <kuoruan@gmail.com>