### PR TITLE
ramips: add support for HiWiFi HC5661A

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -181,7 +181,8 @@ gl-mt300n|\
 gl-mt750)
 	set_wifi_led "$board:wlan"
 	;;
-hc5661)
+hc5661|\
+hc5661a)
 	ucidef_set_led_default "system" "system" "$board:blue:system" "1"
 	ucidef_set_led_netdev "internet" "internet" "$board:blue:internet" "eth0.2"
 	set_wifi_led "$board:blue:wlan2g"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -79,6 +79,7 @@ ramips_setup_interfaces()
 	dir-610-a1|\
 	dir-615-h1|\
 	firewrt|\
+	hc5661a|\
 	hlk-rm04|\
 	mac1200rv2|\
 	miwifi-mini|\
@@ -343,7 +344,8 @@ ramips_setup_macs()
 	e1700)
 		wan_mac=$(mtd_get_mac_ascii config WAN_MAC_ADDR)
 		;;
-	hc5*61)
+	hc5*61|\
+	hc5661a)
 		lan_mac=`mtd_get_mac_ascii bdinfo "Vfac_mac "`
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -140,6 +140,7 @@ get_status_led() {
 		status_led="$board:orange:status"
 		;;
 	hc5*61|\
+	hc5661a|\
 	jhr-n805r|\
 	jhr-n926r|\
 	mlw221|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -217,6 +217,9 @@ ramips_board_detect() {
 	*"HC5661")
 		name="hc5661"
 		;;
+	*"HC5661A")
+		name="hc5661a"
+		;;
 	*"HC5761")
 		name="hc5761"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -62,6 +62,7 @@ platform_check_image() {
 	gl-mt300n|\
 	gl-mt750|\
 	hc5*61|\
+	hc5661a|\
 	hg255d|\
 	hlk-rm04|\
 	hpm|\

--- a/target/linux/ramips/dts/HC5661A.dts
+++ b/target/linux/ramips/dts/HC5661A.dts
@@ -1,0 +1,123 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "HC5661A", "mediatek,mt7628an-soc";
+	model = "HiWiFi HC5661A";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		system {
+			label = "hc5661a:blue:system";
+			gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		};
+		internet {
+			label = "hc5661a:blue:internet";
+			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+		};
+		wlan2g {
+			label = "hc5661a:blue:wlan2g";
+			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "refclk", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80", "w25q128";
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "hw_panic";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xf70000>;
+		};
+
+		partition@fc0000 {
+			label = "oem";
+			reg = <0xfc0000 0x20000>;
+			read-only;
+		};
+
+		bdinfo: partition@fe0000 {
+			label = "bdinfo";
+			reg = <0xfe0000 0x10000>;
+			read-only;
+		};
+
+		partition@ff0000 {
+			label = "backup";
+			reg = <0xff0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+	mediatek,portmap = "wllll";
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7628.mk
+++ b/target/linux/ramips/image/mt7628.mk
@@ -11,6 +11,13 @@ define Device/mt7628
 endef
 TARGET_DEVICES += mt7628
 
+define Device/hc5661a
+  DTS := HC5661A
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := HiWiFi HC5661A
+endef
+TARGET_DEVICES += hc5661a
+
 define Device/miwifi-nano
   DTS := MIWIFI-NANO
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
HC5661A is almost the same as HC5661 but MT7628AN is used instead of MT7620A.

- MT7628AN
- 128 MiB DDR2 RAM (W971GG6KB-25)
- 16 MiB SPI NOR flash (W25Q128)
- SD slot (not work yet)
- 1+4 x 100M Ethernet
- 802.11 b/g/n Wi-Fi
- 3 x LED
- 1 x button
- UART pad on PCB (JP1: TX, RX, GND, 3.3V)

The factory flash layout seems different from HC5661.
"hwf_config" is renamed to "oem" and its size changes to 0x20000.
It is modified accordingly in the dts file.

0x000000000000-0x000000030000 : "u-boot"
0x000000030000-0x000000040000 : "hw_panic"
0x000000040000-0x000000050000 : "Factory"
0x000000050000-0x000000160000 : "kernel"
0x000000160000-0x000000fc0000 : "rootfs"
0x000000bb0000-0x000000fc0000 : "rootfs_data"
0x000000fc0000-0x000000fe0000 : "oem"
0x000000fe0000-0x000000ff0000 : "bdinfo"
0x000000ff0000-0x000001000000 : "backup"
0x000000050000-0x000000fc0000 : "firmware"

To install LEDE, enabled the "developer mode",
which will *void your warranty* and open the SSH server at port 1022.

sysupgrade -n -F lede-ramips-mt7628-hc5661a-squashfs-sysupgrade.bin

SD slot:
- Tried to add modules kmod-sdhci kmod-sdhci-mt7620, and corresponding dts block.
- It will block WAN + 3xLAN ports, only one LAN works.
- I'm not sure why, everything else works fine.

Signed-off-by: Wang JiaWei <buaawjw@gmail.com>