### PR TITLE
Fix 433: insert_modules: Ignore modprobe's return code

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -158,7 +158,10 @@ insert_modules() {
 		if [ -f /etc/modules.d/$m ]; then
 			sed 's/^[^#]/insmod &/' /etc/modules.d/$m | ash 2>&- || :
 		else
-			modprobe $m
+			# Since busybox modprobe returns 0 on loading non-existing
+			# and 255 on loading already loaded modules
+			# its return-code is not useful        
+			modprobe $m || true 
 		fi
 	done
 }


### PR DESCRIPTION
Fix for https://bugs.lede-project.org/index.php?do=details&task_id=433
Work-around for https://bugs.busybox.net/show_bug.cgi?id=9676
