### PR TITLE
Afoundry EW-1200 support

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -19,6 +19,7 @@ board_config_update
 case $board in
 11acnas|\
 all0239-3g|\
+ew1200|\
 hw550-3g|\
 mofi3500-3gn|\
 sap-g3200u3|\

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -78,6 +78,7 @@ ramips_setup_interfaces()
 	dir-320-b1|\
 	dir-610-a1|\
 	dir-615-h1|\
+	ew1200|\
 	firewrt|\
 	hc5661a|\
 	hlk-rm04|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -88,6 +88,7 @@ get_status_led() {
 		status_led="$board:blue:wlan"
 		;;
 	atp-52b|\
+	ew1200|\
 	ip2202)
 		status_led="$board:green:run"
 		;;

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -184,6 +184,9 @@ ramips_board_detect() {
 	*"ESR-9753")
 		name="esr-9753"
 		;;
+	*"EW1200")
+		name="ew1200"
+		;;
 	*"EX2700")
 		name="ex2700";
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -53,6 +53,7 @@ platform_check_image() {
 	dwr-512-b|\
 	e1700|\
 	esr-9753|\
+	ew1200|\
 	ex2700|\
 	f7c027|\
 	firewrt|\

--- a/target/linux/ramips/dts/EW1200.dts
+++ b/target/linux/ramips/dts/EW1200.dts
@@ -1,0 +1,127 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "EW1200";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	palmbus: palmbus@1E000000 {
+		i2c@900 {
+			status = "okay";
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 1>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		status {
+			label = "ew1200:green:run";
+			gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb {
+			label = "ew1200:green:usb";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfb0000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+		};
+	};
+
+	pcie1 {
+		mt76@1,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+			ieee80211-freq-limit = <2400000 2500000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt", "rgmii2", "wdt rst", "jtag", "mdio";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -63,6 +63,14 @@ define Device/dir-860l-b1
 endef
 TARGET_DEVICES += dir-860l-b1
 
+define Device/ew1200
+  DTS := EW1200
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := AFOUNDRY EW1200
+  DEVICE_PACKAGES := kmod-usb3 kmod-usb-ledtrig-usbport kmod-ata-core kmod-ata-ahci
+endef
+TARGET_DEVICES += ew1200
+
 define Device/firewrt
   DTS := FIREWRT
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
Signed-off-by: Francois Goudal <francois@goudal.net>

This adds support for the Afoundry EW-1200 router.
I made a PR to OpenWRT few weeks ago but didn't get any response, so I just decided to switch to LEDE and ported my changed to the LEDE tree.
I have tested it on my own device.
Both 2.4 and 5G radios work, USB port works, Reset button works, RUN LED work.
The USB LED worked on my port to OpenWRT but doesn't work on LEDE, most likely due to the transition from usbdev to usbport trigger. I am pushing this anyway as it doesn't prevent router operation, and can be fixed later.
The device also has "2.4G" and "5G" LEDs but those are not GPIOs of the MT7621 chip. They are controlled by the radio chips and the mt76 driver doesn't currently expose them as GPIOs.

The router runs stable and works fine, except for those two LEDs which are not really important.

The stock firmware is in fact based on some openwrt barrier breaker, with a mediatek SDK kernel, and an afoundry custom made web interface (not LuCI based).
Firmware update page on the stock web interface can not accept sysupgrade images.
At this point, the only working solution I found was to connect to the serial console port (available on J4 header) and to use opkg to install dropbear. Then use dropbear to scp the sysupgrade file and run sysupgrade from console without preserving configuration files.