### PR TITLE
netifd: remove _6 suffix from 6rd interface names

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/dhcp.script
+++ b/package/network/config/netifd/files/lib/netifd/dhcp.script
@@ -61,7 +61,7 @@ setup_interface () {
 		local ip6rdbr="${ip6rd%% *}"
 
 		[ -n "$ZONE" ] || ZONE=$(fw3 -q network $INTERFACE)
-		[ -z "$IFACE6RD" -o "$IFACE6RD" = 1 ] && IFACE6RD=${INTERFACE}_6
+		[ -z "$IFACE6RD" -o "$IFACE6RD" = 1 ] && IFACE6RD=${INTERFACE}
 
 		json_init
 		json_add_string name "$IFACE6RD"


### PR DESCRIPTION
This suffix is redundant, 6rd interfaces already use "6rd-" prefix.
Given the maximum length of 15 characters Linux ifnames supports, it
would be best not to waste this limited space with redundancies.

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>