### PR TITLE
ath9k: Fix OTP offsets for AR934x

### DIFF
--- a/package/kernel/mac80211/patches/325-ath9k-fix-ar934x-OTP-offsets.patch
+++ b/package/kernel/mac80211/patches/325-ath9k-fix-ar934x-OTP-offsets.patch
@@ -1,0 +1,42 @@
+From: Christian Lamparter <chunkeey@googlemail.com>
+Date: Tue, 14 Feb 2017 20:10:30 +0100
+Subject: ath9k: use correct OTP register offsets for the AR9340 and AR9550
+
+This patch fixes the OTP register definitions for the AR934x and AR9550
+WMAC SoC.
+
+Previously, the ath9k driver was unable to initialize the integrated
+WMAC on an Aerohive AP121:
+
+| ath: phy0: timeout (1000 us) on reg 0x30018: 0xbadc0ffe & 0x00000007 != 0x00000004
+| ath: phy0: timeout (1000 us) on reg 0x30018: 0xbadc0ffe & 0x00000007 != 0x00000004
+| ath: phy0: Unable to initialize hardware; initialization status: -5
+| ath9k ar934x_wmac: failed to initialize device
+| ath9k: probe of ar934x_wmac failed with error -5
+
+It turns out that the AR9300_OTP_STATUS and AR9300_OTP_DATA
+definitions contain a typo.
+
+Fixes: add295a4afbdf5852d0 "ath9k: use correct OTP register offsets for AR9550"
+Signed-off-by: Christian Lamparter <chunkeey@googlemail.com>
+Signed-off-by: Chris Blake <chrisrblake93@gmail.com>
+---
+
+--- a/drivers/net/wireless/ath/ath9k/ar9003_eeprom.h
++++ b/drivers/net/wireless/ath/ath9k/ar9003_eeprom.h
+@@ -75,13 +75,13 @@
+ #define AR9300_OTP_BASE \
+ 		((AR_SREV_9340(ah) || AR_SREV_9550(ah)) ? 0x30000 : 0x14000)
+ #define AR9300_OTP_STATUS \
+-		((AR_SREV_9340(ah) || AR_SREV_9550(ah)) ? 0x30018 : 0x15f18)
++		((AR_SREV_9340(ah) || AR_SREV_9550(ah)) ? 0x31018 : 0x15f18)
+ #define AR9300_OTP_STATUS_TYPE		0x7
+ #define AR9300_OTP_STATUS_VALID		0x4
+ #define AR9300_OTP_STATUS_ACCESS_BUSY	0x2
+ #define AR9300_OTP_STATUS_SM_BUSY	0x1
+ #define AR9300_OTP_READ_DATA \
+-		((AR_SREV_9340(ah) || AR_SREV_9550(ah)) ? 0x3001c : 0x15f1c)
++		((AR_SREV_9340(ah) || AR_SREV_9550(ah)) ? 0x3101c : 0x15f1c)
+
+ enum targetPowerHTRates {
+ 	HT_TARGET_RATE_0_8_16,

--- a/target/linux/ar71xx/patches-4.4/641-MIPS-ath79-fix-AR934x-OTP-offsets.patch
+++ b/target/linux/ar71xx/patches-4.4/641-MIPS-ath79-fix-AR934x-OTP-offsets.patch
@@ -1,0 +1,66 @@
+--- a/arch/mips/ath79/dev-wmac.c	2017-02-12 19:49:21.158142253 +0100
++++ b/arch/mips/ath79/dev-wmac.c	2017-02-12 21:01:51.206198122 +0100
+@@ -232,15 +274,27 @@ static void qca956x_wmac_setup(void)
+ 	ath79_wmac_data.get_mac_revision = ar93xx_get_soc_revision;
+ }
+
++#define AR93XX_WMAC_SIZE \
++	(soc_is_ar934x() ? AR934X_WMAC_SIZE : AR933X_WMAC_SIZE)
++#define AR93XX_WMAC_BASE \
++	(soc_is_ar934x() ? AR934X_WMAC_BASE : AR933X_WMAC_BASE)
++
++#define AR93XX_OTP_BASE \
++	(soc_is_ar934x() ? AR934X_OTP_BASE : AR9300_OTP_BASE)
++#define AR93XX_OTP_STATUS \
++	(soc_is_ar934x() ? AR934X_OTP_STATUS : AR9300_OTP_STATUS)
++#define AR93XX_OTP_READ_DATA \
++	(soc_is_ar934x() ? AR934X_OTP_READ_DATA : AR9300_OTP_READ_DATA)
++
+ static bool __init
+ ar93xx_wmac_otp_read_word(void __iomem *base, int addr, u32 *data)
+ {
+ 	int timeout = 1000;
+ 	u32 val;
+
+-	__raw_readl(base + AR9300_OTP_BASE + (4 * addr));
++	__raw_readl(base + AR93XX_OTP_BASE + (4 * addr));
+ 	while (timeout--) {
+-		val = __raw_readl(base + AR9300_OTP_STATUS);
++		val = __raw_readl(base + AR93XX_OTP_STATUS);
+ 		if ((val & AR9300_OTP_STATUS_TYPE) == AR9300_OTP_STATUS_VALID)
+ 			break;
+
+@@ -250,7 +304,7 @@ ar93xx_wmac_otp_read_word(void __iomem *
+ 	if (!timeout)
+ 		return false;
+
+-	*data = __raw_readl(base + AR9300_OTP_READ_DATA);
++	*data = __raw_readl(base + AR93XX_OTP_READ_DATA);
+ 	return true;
+ }
+
+@@ -326,7 +380,7 @@ bool __init ar93xx_wmac_read_mac_address
+ 	int mac_start = 2, mac_end = 8;
+
+ 	BUG_ON(!soc_is_ar933x() && !soc_is_ar934x());
+-	base = ioremap_nocache(AR933X_WMAC_BASE, AR933X_WMAC_SIZE);
++	base = ioremap_nocache(AR93XX_WMAC_BASE, AR93XX_WMAC_SIZE);
+ 	while (addr > sizeof(hdr)) {
+ 		if (!ar93xx_wmac_otp_read(base, addr, hdr, sizeof(hdr)))
+ 			break;
+--- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h	2017-02-12 20:22:32.185209249 +0100
++++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h	2017-02-12 20:42:21.037382287 +0100
+@@ -172,6 +172,13 @@
+ #define AR9300_OTP_STATUS_SM_BUSY	0x1
+ #define AR9300_OTP_READ_DATA	0x15f1c
+
++#define AR934X_OTP_BASE					0x30000
++#define AR934X_OTP_STATUS				0x31018
++#define AR934X_OTP_READ_DATA				0x3101c
++#define AR934X_OTP_INTF2_ADDRESS			0x31008
++#define AR934X_OTP_INTF3_ADDRESS			0x3100c
++#define AR934X_OTP_PGENB_SETUP_HOLD_TIME_ADDRESS	0x31034
++
+ /*
+  * Hidden Registers
+  */


### PR DESCRIPTION
The following patches fix reading the OTP from AR934x devices, such as the Aerohive AP-121.

Signed-off-by: Chris Blake <chrisrblake93@gmail.com>