### PR TITLE
lantiq: vr9 fxs support: bugfix for usage of VPE with nosmp

### DIFF
--- a/target/linux/lantiq/patches-4.4/0155-lantiq-VPE-nosmp.patch
+++ b/target/linux/lantiq/patches-4.4/0155-lantiq-VPE-nosmp.patch
@@ -1,0 +1,14 @@
+--- a/arch/mips/kernel/vpe-mt.c
++++ b/arch/mips/kernel/vpe-mt.c
+@@ -132,7 +132,10 @@ int vpe_run(struct vpe *v)
+ 	 * kernels need to turn it on, even if that wasn't the pre-dvpe() state.
+ 	 */
+ #ifdef CONFIG_SMP
+-	evpe(vpeflags);
++	if (!setup_max_cpus) /* nosmp is set */
++		evpe(EVPE_ENABLE);
++	else
++		evpe(vpeflags);
+ #else
+ 	evpe(EVPE_ENABLE);
+ #endif


### PR DESCRIPTION
This patch is needed to use FXS if CONFIG_MIPS_MT_SMP
is enabled within kernel configuration and the 'nosmp'
command line argument is given to disable SMP at runtime.

Without this patch CONFIG_MIPS_MT_SMP must be disabled before using FXS.
With this patch setting the 'nosmp' parameter is enough.

In general, concurrent usage of FXS and SMP
is incompatible and will cause kernel panics.

Signed-off-by: Stefan Koch <stefan.koch10@gmail.com>