### PR TITLE
bcm53xx: Add basic support for Linksys EA9500

### DIFF
--- a/target/linux/bcm53xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm53xx/base-files/etc/board.d/01_leds
@@ -11,6 +11,14 @@ netgear,r8000)
 	ucidef_set_led_usbport "usb2" "USB 2.0" "bcm53xx:white:usb2" "usb1-port2" "usb2-port2"
 	ucidef_set_led_usbport "usb3" "USB 3.0" "bcm53xx:white:usb3" "usb1-port1" "usb2-port1" "usb4-port1"
 	;;
+
+linksys,ea9500)
+	ucidef_set_led_usbport "usb2" "USB 2.0" "bcm53xx:green:usb2" "usb1-port2" "usb2-port2"
+	ucidef_set_led_usbport "usb3" "USB 3.0" "bcm53xx:green:usb3" "usb1-port1" "usb2-port1" "usb4-port1"
+	ucidef_set_led_netdev "wireless" "Wireless5G1" "bcm53xx:white:wireless" "wlan0" "link"
+	ucidef_set_led_default "power" "Power" "bcm53xx:white:power" "1"
+	;;
+
 esac
 
 board_config_flush

--- a/target/linux/bcm53xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm53xx/base-files/etc/board.d/02_network
@@ -35,7 +35,8 @@ asus,rt-ac87u)
 dlink,dir-885l | \
 netgear,r7900 | \
 netgear,r8000 | \
-netgear,r8500)
+netgear,r8500 | \
+linksys,ea9500)
 	ifname=eth2
 	etXmacaddr=$(nvram get et2macaddr)
 	;;
@@ -53,7 +54,8 @@ case "$board" in
 dlink,dir-885l | \
 netgear,r7900 | \
 netgear,r8000 | \
-netgear,r8500)
+netgear,r8500 | \
+linksys,ea9500)
 	ifname=eth0
 	ucidef_add_switch "switch0" \
 		"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "5t@$ifname"

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -206,6 +206,14 @@ endef
 # Disabled due to problems with 2 TRX partitions
 # TARGET_DEVICES += linksys-ea6300-v1
 
+define Device/linksys-ea9500
+  DEVICE_TITLE := Linksys EA9500
+  #Add BRCMFMAC_4366C firmware package when available
+  DEVICE_PACKAGES := kmod-brcmfmac $(USB3_PACKAGES)
+endef
+# Disabled due to problems with 2 TRX partitions
+# TARGET_DEVICES += linksys-ea9500
+
 define Device/netgear
   IMAGES := chk
   IMAGE/chk := append-ubi | trx-nand | netgear-chk

--- a/target/linux/bcm53xx/patches-4.4/046-0012-ARM-dts-BCM5301X-Add-basic-DT-for-Linksys-EA9500.patch
+++ b/target/linux/bcm53xx/patches-4.4/046-0012-ARM-dts-BCM5301X-Add-basic-DT-for-Linksys-EA9500.patch
@@ -1,0 +1,162 @@
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -84,6 +84,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm4709-netgear-r8000.dtb \
+ 	bcm4709-tplink-archer-c9-v1.dtb \
+ 	bcm47094-dlink-dir-885l.dtb \
++        bcm47094-linksys-ea9500.dtb \
+ 	bcm47094-luxul-xwr-3100.dtb \
+ 	bcm47094-netgear-r8500.dtb \
+ 	bcm94708.dtb \
+--- /dev/null
++++ b/arch/arm/boot/dts/bcm47094-linksys-ea9500.dts
+@@ -0,0 +1,149 @@
++/*
++ * Broadcom BCM47094 / BCM5301X ARM platform code.
++ * Basic DTS for Linksys EA9500
++ *
++ *
++ * Licensed under the GNU/GPL. See COPYING for details.
++ */
++
++/dts-v1/;
++
++#include "bcm47094.dtsi"
++#include "bcm5301x-nand-cs0-bch1.dtsi"
++
++/ {
++   compatible = "linksys,ea9500", "brcm,bcm47094", "brcm,bcm4708";
++   model = "Linksys EA9500";
++
++   chosen {
++       bootargs = "console=ttyS0,115200 earlyprintk";
++   };
++
++   memory {
++	reg = <0x00000000 0x08000000
++			0x88000000 0x08000000>;
++	};
++
++   leds {
++       compatible = "gpio-leds";
++
++       wps {
++           label = "bcm53xx:white:wps";
++           gpios = <&chipcommon 22 GPIO_ACTIVE_LOW>;
++           linux,default-trigger = "default-off";
++       };
++
++       usb2 {
++           label = "bcm53xx:green:usb2";
++           gpios = <&chipcommon 1 GPIO_ACTIVE_LOW>;
++           linux,default-trigger = "default-off";
++       };
++
++       usb3 {
++           label = "bcm53xx:green:usb3";
++           gpios = <&chipcommon 2 GPIO_ACTIVE_LOW>;
++           linux,default-trigger = "default-off";
++       };
++
++       power {
++           label = "bcm53xx:white:power";
++           gpios = <&chipcommon 4 GPIO_ACTIVE_HIGH>;
++           linux,default-trigger = "default-on";
++       };
++
++       wifibtn {
++           label = "bcm53xx:amber:wifibtn";
++           gpios = <&chipcommon 0 GPIO_ACTIVE_LOW>;
++           linux,default-trigger = "default-off";
++       };
++
++       wireless {
++           label = "bcm53xx:white:wireless";
++           gpios = <&chipcommon 5 GPIO_ACTIVE_HIGH>;
++           linux,default-trigger = "default-off";
++       };
++
++       bluebar1 {
++           label = "bcm53xx:white:bluebar1";
++           gpios = <&chipcommon 11 GPIO_ACTIVE_HIGH>;
++           linux,default-trigger = "default-off";
++       };
++
++       bluebar2 {
++           label = "bcm53xx:white:bluebar2";
++           gpios = <&chipcommon 12 GPIO_ACTIVE_HIGH>;
++           linux,default-trigger = "default-off";
++       };
++
++       bluebar3 {
++           label = "bcm53xx:white:bluebar3";
++           gpios = <&chipcommon 15 GPIO_ACTIVE_LOW>;	//actHigh -> actLow
++           linux,default-trigger = "default-off";
++       };
++
++       bluebar4 {
++           label = "bcm53xx:white:bluebar4";
++           gpios = <&chipcommon 18 GPIO_ACTIVE_HIGH>;
++           linux,default-trigger = "default-off";
++       };
++
++       bluebar5 {
++           label = "bcm53xx:white:bluebar5";
++           gpios = <&chipcommon 19 GPIO_ACTIVE_HIGH>;
++           linux,default-trigger = "default-off";
++       };
++
++       bluebar6 {
++           label = "bcm53xx:white:bluebar6";
++           gpios = <&chipcommon 20 GPIO_ACTIVE_HIGH>;
++           linux,default-trigger = "default-off";
++       };
++
++       bluebar7 {
++           label = "bcm53xx:white:bluebar7";
++           gpios = <&chipcommon 21 GPIO_ACTIVE_HIGH>;
++           linux,default-trigger = "default-off";
++       };
++
++       bluebar8 {
++           label = "bcm53xx:white:bluebar8";
++           gpios = <&chipcommon 8 GPIO_ACTIVE_HIGH>;
++           linux,default-trigger = "default-off";
++       };
++
++
++   };
++
++   gpio-keys {
++       compatible = "gpio-keys";
++       #address-cells = <1>;
++       #size-cells = <0>;
++
++       rfkill {
++           label = "WiFi";
++           linux,code = <KEY_RFKILL>;
++           gpios = <&chipcommon 16 GPIO_ACTIVE_LOW>;
++       };
++
++       wps {
++           label = "WPS";
++           linux,code = <KEY_WPS_BUTTON>;
++           gpios = <&chipcommon 3 GPIO_ACTIVE_LOW>;
++       };
++
++       reset {
++           label = "Reset";
++           linux,code = <KEY_RESTART>;
++           gpios = <&chipcommon 17 GPIO_ACTIVE_LOW>;
++       };
++
++   };
++};
++
++&usb2 {
++	vcc-gpio = <&chipcommon 13 GPIO_ACTIVE_HIGH>;
++};
++
++&usb3 {
++	vcc-gpio = <&chipcommon 14 GPIO_ACTIVE_HIGH>;
++};

--- a/target/linux/bcm53xx/patches-4.4/710-b53-add-hacky-CPU-port-fixes-for-devices-not-using-p.patch
+++ b/target/linux/bcm53xx/patches-4.4/710-b53-add-hacky-CPU-port-fixes-for-devices-not-using-p.patch
@@ -21,7 +21,7 @@ Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
  
  #include "b53_regs.h"
  #include "b53_priv.h"
-@@ -1383,6 +1384,28 @@ static int b53_switch_init(struct b53_de
+@@ -1383,6 +1384,29 @@ static int b53_switch_init(struct b53_de
  			sw_dev->cpu_port = 5;
  	}
  
@@ -44,7 +44,8 @@ Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 +	 * For some reason it doesn't work (no packets on eth2).
 +	 */
 +	if (of_machine_is_compatible("netgear,r7900") ||
-+	    of_machine_is_compatible("netgear,r8000"))
++	    of_machine_is_compatible("netgear,r8000") ||
++	    of_machine_is_compatible("linksys,ea9500"))
 +		sw_dev->cpu_port = 5;
 +
  	dev->enabled_ports |= BIT(sw_dev->cpu_port);


### PR DESCRIPTION
This patch adds basic support for Linksys EA9500 router

- Broadcom 4366c0 wireless chip is used and it's firmware package doesn't
  exist yet. I was able to test it with firmware that came buried in the
  router's dhd.ko
- It has two switches in order to support 8 lan ports. Internal switch is
  BCM53012 and it's port 5 is connected to CPU. The external switch 
  BCM53125 currently works as "dumb switch"
- Using 8 bit ECC gives errors, switching to 1 bit ECC solved the issue
- It uses dual trx images for failsafe purposes. Image generation has 
  been disabled until solution is available.

**Hardware Info**

|Component         |Description                                       |
|:-----------------|:-------------------------------------------------|
|CPU               |Broadcom BCM4709C0KFEBG dual-core @ 1.4 GHz       |
|Switch            |One in BCM4709C0KFEBG & external BCM53125         |
|RAM               |256 MB DDR3                                       |
|Flash             |128 MB (Toshiba TC58BVG0S3HTA00)                  |
|2.4 GHz Radio     |BCM4366 4×4 2.4/5G single chip 802.11ac SoC       |
|                  |Skyworks SE2623L 2.4 GHz power amp (x4)           |
|5 GHz radio x 2   |BCM4366 4×4 2.4/5G single chip 802.11ac SoC       |
|                  |PLX Technology PEX8603 3-lane, 3-port PCIe switch |
|Ports             |8 Ports, 1 WAN Ports                              |
|Antennas          |8 Antennas                                        |
|Serial Port       |GND,RX,TX                                         |

**Installation**

Linksys has started to sign their firmwares for this router, hence it is
not possible to install using Factory UI.

That being said, tftp method works .
1. Uploading the .trx to the router from your PC using  tftp client
2. If you have a serial cable setup to this router, interrupt the boot 
   process by Ctrl+C to enter CFE prompt
   From there execute:
        `flash -noheader 192.168.1.10:/lede.trx nflash0.trx`
   where 192.168.1.10 is where your tftp server is running. 
   You may want to reset partial boots using 
        `nvram set partialboot=0 && nvram commit' while at CFE prompt`.

**TODO**
- Add BCM53125 to dts connected to MDIO bus so that it can be configured
- Add robo_reset gpio (pin # 10 active low) to dts

Signed-off-by: Vivek Unune <npcomplete13@gmail.com>