### PR TITLE
netifd: remove _6 suffix from 6rd interface names

### DIFF
--- a/package/network/ipv6/6rd/files/6rd.sh
+++ b/package/network/ipv6/6rd/files/6rd.sh
@@ -12,7 +12,7 @@
 proto_6rd_setup() {
 	local cfg="$1"
 	local iface="$2"
-	local link="6rd-$cfg"
+	local link="6rd-${cfg%_6}"
 
 	local mtu df ttl tos ipaddr peeraddr ip6prefix ip6prefixlen ip4prefixlen tunlink zone
 	json_get_vars mtu df ttl tos ipaddr peeraddr ip6prefix ip6prefixlen ip4prefixlen tunlink zone


### PR DESCRIPTION
This suffix is redundant, 6rd interfaces already use "6rd-" prefix.
Given the maximum length of 15 characters Linux ifnames supports, it
would be best not to waste this limited space with redundancies.

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>