### PR TITLE
ramips: remove kmod-mt76* from EX2700 images

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -61,7 +61,7 @@ define Device/ex2700
   KERNEL := $(KERNEL_DTB) | uImage lzma | pad-offset 64k 64 | append-uImage-fakeroot-hdr
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	netgear-dni
-  DEVICE_PACKAGES := -kmod-mt76 kmod-mt76-core
+  DEVICE_PACKAGES := -kmod-mt76
   DEVICE_TITLE := Netgear EX2700
 endef
 TARGET_DEVICES += ex2700


### PR DESCRIPTION
These modules are not needed by the EX2700, since it does not have an external wifi chip (MT7620A is covered by rt2x00).

Signed-off-by: Joseph C. Lehner <joseph.c.lehner@gmail.com>