### PR TITLE
gpio-button-hotplug: leave platform_device.dev.platform_data untouched

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -474,7 +474,6 @@ static int gpio_keys_button_probe(struct platform_device *pdev,
 			dev_err(dev, "missing platform data\n");
 			return -EINVAL;
 		}
-		pdev->dev.platform_data = pdata;
 	}
 
 	if (polled && !pdata->poll_interval) {
@@ -559,7 +558,7 @@ static int gpio_keys_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
-	pdata = pdev->dev.platform_data;
+	pdata = bdev->pdata;
 	for (i = 0; i < pdata->nbuttons; i++) {
 		struct gpio_keys_button *button = &pdata->buttons[i];
 		struct gpio_keys_button_data *bdata = &bdev->data[i];


### PR DESCRIPTION
get platform_data from gpio_keys_button_dev.pdata, and fix a illegal pointer
dereference like this:

[   51.143776] gpio-keys-polled gpio-keys-polled: missing poll_interval value
[   51.150852] gpio-keys-polled: probe of gpio-keys-polled failed with error -22
[  828.159993] gpio-keys-polled gpio-keys-polled: no memory for button data
[  828.166821] gpio-keys-polled: probe of gpio-keys-polled failed with error -12

Signed-off-by: Furong Xu <xfr@outlook.com>