### PR TITLE
base-files: add submission service port

### DIFF
--- a/package/base-files/files/etc/services
+++ b/package/base-files/files/etc/services
@@ -76,6 +76,8 @@ afpovertcp	548/tcp
 afpovertcp	548/udp
 nntps		563/tcp		snntp
 nntps		563/udp		snntp
+submission	587/tcp
+submission	587/udp
 ldaps		636/tcp
 ldaps		636/udp
 tinc		655/tcp


### PR DESCRIPTION
prevent postfix start failure fatal: 0.0.0.0:submission: Unrecognized service

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>