### PR TITLE
ramips: add support for Netgear R6220

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -291,6 +291,11 @@ px-4885)
 	set_wifi_led "$board:orange:wifi"
 	set_usb_led "$board:blue:storage"
 	;;
+r6220)
+	ucidef_set_led_netdev "wan" "wan" "$board:green:wan" eth0.2
+	set_wifi_led "$board:green:wifi"
+	set_usb_led "$board:green:usb"
+	;;
 re6500)
 	ucidef_set_led_default "power" "power" "$board:white:power" "1"
 	ucidef_set_led_default "wifi" "wifi" "$board:orange:wifi" "1"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -95,6 +95,7 @@ ramips_setup_interfaces()
 	pbr-m1|\
 	psg1208|\
 	psg1218|\
+	r6220|\
 	sap-g3200u3|\
 	sk-wb8|\
 	vr500|\
@@ -393,6 +394,10 @@ ramips_setup_macs()
 	oy-0001)
 		lan_mac=$(mtd_get_mac_binary factory 40)
 		wan_mac=$(mtd_get_mac_binary factory 46)
+		;;
+	r6220)
+		wan_mac=$(mtd_get_mac_binary factory 4)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
 	rt-n56u)
 		lan_mac=$(cat /sys/class/net/eth0/address)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -33,6 +33,7 @@ get_status_led() {
 	nbg-419n|\
 	nbg-419n2|\
 	pwh2004|\
+	r6220|\
 	vr500|\
 	wnce2001|\
 	wndr3700v5|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -412,6 +412,9 @@ ramips_board_detect() {
 	*"Q7")
 		name="zte-q7"
 		;;
+	*"R6220")
+		name="r6220"
+		;;
 	*"RB750Gr3")
 		name="rb750gr3"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -233,6 +233,7 @@ platform_check_image() {
 		# these boards use metadata images
 		return 0
 		;;
+	r6220|\
 	ubnt-erx)
 		nand_do_platform_check "$board" "$1"
 		return $?;
@@ -266,6 +267,7 @@ platform_pre_upgrade() {
 
 	case "$board" in
 	hc5962|\
+	r6220|\
     	ubnt-erx)
 		nand_do_upgrade "$ARGV"
 		;;

--- a/target/linux/ramips/dts/R6220.dts
+++ b/target/linux/ramips/dts/R6220.dts
@@ -1,0 +1,156 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Netgear R6220";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "r6220:green:power";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "r6220:green:usb";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "r6220:green:wan";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "r6220:green:wifi";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "r6220:green:wps";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partition@0 {
+		label = "u-boot";
+		reg = <0x0 0x100000>;
+		read-only;
+	};
+
+	partition@100000 {
+		label = "SC PID";
+		reg = <0x100000 0x100000>;
+		read-only;
+	};
+
+	partition@200000 {
+		label = "kernel";
+		reg = <0x200000 0x400000>;
+	};
+
+	partition@600000 {
+		label = "ubi";
+		reg = <0x600000 0x1c00000>;
+	};
+
+	factory: partition@2e00000 {
+		label = "factory";
+		reg = <0x2e00000 0x100000>;
+		read-only;
+	};
+
+	partition@4200000 {
+		label = "reserved";
+		reg = <0x4200000 0x3c00000>;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+		};
+	};
+
+	pcie1 {
+		mt76@1,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+			ieee80211-freq-limit = <2400000 2500000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x00000004>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart3", "jtag";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -118,6 +118,24 @@ define Device/pbr-m1
 endef
 TARGET_DEVICES += pbr-m1
 
+define Device/r6220
+  DTS := R6220
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4194304
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  IMAGE_SIZE := 33554432
+  UBINIZE_OPTS := -E 5
+  IMAGES := sysupgrade.tar kernel.bin rootfs.bin factory.bin
+  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
+  IMAGE/kernel.bin := append-kernel
+  IMAGE/rootfs.bin := append-ubi
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | append-metadata | check-size $$$$(IMAGE_SIZE)
+  DEVICE_TITLE := Netgear R6220
+  DEVICE_PACKAGES := kmod-usb2 kmod-mt76
+endef
+TARGET_DEVICES += r6220
+
 define Device/rb750gr3
   DTS := RB750Gr3
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
This patch adds support for the Netgear R6220, aka Netgear AC1200 and R6220-100NAS.

Specification:
- SoC: MediaTek MT7621ST (880 MHz)
- Falsh: 128 MiB (Macronix MX30LF1G08AA-TI)
- RAM: 128 MiB (Nanya NT5CB64M16FP-DH)
- Wireless: MediaTek MT7603EN b/g/n , MediaTek MT7612EN an+ac
- LAN speed: 10/100/1000
- LAN ports: 4
- WAN speed: 10/100/1000
- WAN ports: 1
- Serial baud rate of Bootloader : 57600

Installation through telnet:
- Copy kernel.bin and rootfs.bin to a USB flash disk, plug to usb port on the router.
- Enable telnet with link: http://192.168.1.1/setup.cgi?todo=debug (login if required, default: admin password)
- You will see "Debug Enabled!"
- Telnet 192.168.1.1 and login with "root"
- ls /mnt/shares/ to find out path of your USB disk. 'myUdisk' for example.
- cd /mnt/shares/myUdisk
- mtd_write write rootfs.bin Rootfs
- mtd_write write kernel.bin Kernel
- reboot

Signed-off-by: Hanqing Wong < hquu@outlook.com >