### PR TITLE
ar71xx: add support for RB LHG 5nD

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -259,6 +259,15 @@ rb-2011uias-2hnd)
 	ucidef_set_led_switch "eth9" "ETH9" "rb:green:eth9" "switch1" "0x04"
 	ucidef_set_led_switch "eth10" "ETH10" "rb:green:eth10" "switch1" "0x02"
 	;;
+rb-lhg-5nd)
+	ucidef_set_led_netdev "lan" "LAN" "rb:green:eth" "eth0"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "rb:green:rssi0" "wlan0" "1" "100" "0" "13"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "rb:green:rssi1" "wlan0" "20" "100" "-19" "13"
+	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "rb:green:rssi2" "wlan0" "40" "100" "-39" "13"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "rb:green:rssi3" "wlan0" "60" "100" "-59" "13"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "rb:green:rssi4" "wlan0" "80" "100" "-79" "13"
+	;;
 rb-mapl-2nd)
 	ucidef_set_led_default "power" "POWER" "rb:green:power" "1"
 	ucidef_set_led_netdev "lan" "LAN" "rb:green:eth" "eth0"

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -90,6 +90,7 @@ ar71xx_setup_interfaces()
 	rb-911g-5hpnd|\
 	rb-912uag-2hpnd|\
 	rb-912uag-5hpnd|\
+	rb-lhg-5nd|\
 	rb-mapl-2nd|\
 	rb-sxt2n|\
 	rb-sxt5n|\

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -306,6 +306,7 @@ get_status_led() {
 	rb-912uag-5hpnd|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
+	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		status_led="rb:green:user"
 		;;

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -905,6 +905,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD 951Ui-2nD")
 		name="rb-951ui-2nd"
 		;;
+	*"RouterBOARD LHG 5nD")
+		name="rb-lhg-5nd"
+		;;
 	*"RouterBOARD mAP L-2nD")
 		name="rb-mapl-2nd"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -638,6 +638,7 @@ platform_check_image() {
 	rb-750up-r2|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
+	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		return 0
 		;;
@@ -689,6 +690,7 @@ platform_pre_upgrade() {
 	rb-750up-r2|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
+	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		# erase firmware if booted from initramfs
 		[ -z "$(rootfs_type)" ] && mtd erase firmware

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -928,6 +928,7 @@ config ATH79_MACH_RB2011
 
 config ATH79_MACH_RBSPI
 	bool "MikroTik RouterBOARD SPI-NOR support"
+	select SOC_AR934X
 	select SOC_QCA953X
 	select ATH79_DEV_ETH
 	select ATH79_DEV_GPIO_BUTTONS
@@ -943,6 +944,7 @@ config ATH79_MACH_RBSPI
 	  MikroTik RouterBOARD hAP
 	  MikroTik RouterBOARD hEX PoE lite
 	  MikroTik RouterBOARD hEX lite
+	  MikroTik RouterBOARD LHG 5
 	  MikroTik RouterBOARD cAP (EXPERIMENTAL)
 	  MikroTik RouterBOARD mAP (EXPERIMENTAL)
 	  MikroTik RouterBOARD wAP (EXPERIMENTAL)

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -437,20 +437,32 @@ void __init rbspi_wlan_init(u16 id, int wmac_offset)
 	kfree(art_buf);
 }
 
+#define RBSPI_MACH_BUFLEN	64
 /* 
  * Common platform init routine for all SPI NOR devices.
  */
 static int __init rbspi_platform_setup(void)
 {
 	const struct rb_info *info;
-	char buf[64];
+	char buf[RBSPI_MACH_BUFLEN] = "MikroTik ";
+	char *str;
+	int len = RBSPI_MACH_BUFLEN - strlen(buf) - 1;
 
 	info = rb_init_info((void *)(KSEG1ADDR(AR71XX_SPI_BASE)), 0x20000);
 	if (!info)
 		return -ENODEV;
 
-	scnprintf(buf, sizeof(buf), "MikroTik %s",
-		(info->board_name) ? info->board_name : "");
+	if (info->board_name) {
+		str = "RouterBOARD ";
+		if (strncmp(info->board_name, str, strlen(str))) {
+			strncat(buf, str, len);
+			len -= strlen(str);
+		}
+		strncat(buf, info->board_name, len);
+	}
+	else
+		strncat(buf, "UNKNOWN", len);
+
 	mips_set_machine_name(buf);
 
 	/* fix partitions based on flash parsing */

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -178,6 +178,7 @@ enum ath79_mach_type {
 	ATH79_MACH_RB_951U,			/* Mikrotik RouterBOARD 951Ui-2HnD */
 	ATH79_MACH_RB_952,			/* MikroTik RouterBOARD 951Ui-2nD */
 	ATH79_MACH_RB_CAP,			/* Mikrotik RouterBOARD cAP2nD */
+	ATH79_MACH_RB_LHG5,			/* Mikrotik RouterBOARD LHG5 */
 	ATH79_MACH_RB_MAP,			/* Mikrotik RouterBOARD mAP2nD */
 	ATH79_MACH_RB_MAPL,			/* Mikrotik RouterBOARD mAP L-2nD */
 	ATH79_MACH_RB_WAP,			/* Mikrotik RouterBOARD wAP2nD */

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -26,12 +26,12 @@ TARGET_DEVICES += nand-64m nand-large
 
 define Device/rb-nor-flash-16M
   DEVICE_TITLE := MikroTik RouterBoard with 16 MB SPI NOR flash
-  DEVICE_PACKAGES := rbcfg
+  DEVICE_PACKAGES := rbcfg rssileds
   IMAGE_SIZE := 16000k
   LOADER_TYPE := elf
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin | lzma | loader-kernel
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-941-2nd rb-951ui-2nd rb-mapl-2nd
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-941-2nd rb-951ui-2nd rb-lhg-5nd rb-mapl-2nd
   IMAGE/sysupgrade.bin = append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef

--- a/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,25 @@ void __init prom_init(void)
+@@ -136,6 +136,26 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -17,6 +17,7 @@
 +	    strstr(arcs_cmdline, "board=H951L") ||
 +	    strstr(arcs_cmdline, "board=952-hb") ||
 +	    strstr(arcs_cmdline, "board=953gs") ||
++	    strstr(arcs_cmdline, "board=lhg") ||
 +	    strstr(arcs_cmdline, "board=map-hb") ||
 +	    strstr(arcs_cmdline, "board=2011L") ||
 +	    strstr(arcs_cmdline, "board=2011r") ||


### PR DESCRIPTION
This patch adds support for the MikroTik RouterBOARD LHG 5
https://routerboard.com/RBLHG-5nD

Specifications:
- SoC: Atheros AR9344 (600MHz)
- RAM: 64MB
- Storage: 16MB NOR SPI flash
- Wireless: builtin AR9344 5GHz, 2x2:2
- Ethernet: 1x100M

Leveraged the existing SPI NOR code. Tested on actual hardware. Sysupgrade works.