### PR TITLE
kernel: add ip_vs kernel modules configuration to enable load balancer

### DIFF
--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -77,6 +77,17 @@ endef
 $(eval $(call KernelPackage,nf-conntrack))
 
 
+define KernelPackage/nf-conntrack-ftp
+  SUBMENU:=$(NF_MENU)
+  TITLE:=FTP connection tracking
+  KCONFIG:=CONFIG_NF_CONNTRACK_FTP
+  DEPENDS:=kmod-nf-conntrack
+  FILES:=$(LINUX_DIR)/net/netfilter/nf_conntrack_ftp.ko
+endef
+
+$(eval $(call KernelPackage,nf-conntrack-ftp))
+
+
 define KernelPackage/nf-conntrack6
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter IPv6 connection tracking
@@ -270,6 +281,84 @@ define KernelPackage/ipt-ipset
   AUTOLOAD:=$(call AutoLoad,49,$(notdir $(IPSET_MODULES)))
 endef
 $(eval $(call KernelPackage,ipt-ipset))
+
+IPVS_MODULES:= \
+    ipvs/ip_vs \
+    ipvs/ip_vs_lc \
+    ipvs/ip_vs_wlc \
+    ipvs/ip_vs_rr \
+    ipvs/ip_vs_wrr \
+    ipvs/ip_vs_lblc \
+    ipvs/ip_vs_lblcr \
+    ipvs/ip_vs_dh \
+    ipvs/ip_vs_sh \
+    ipvs/ip_vs_fo \
+    ipvs/ip_vs_ovf \
+    ipvs/ip_vs_nq \
+    ipvs/ip_vs_sed \
+    xt_ipvs
+
+define KernelPackage/nf-ipvs
+  SUBMENU:=Netfilter Extensions
+  TITLE:=IP Virtual Server modules
+  DEPENDS:=@IPV6 +kmod-lib-crc32c +kmod-ipt-conntrack +kmod-nf-conntrack
+  KCONFIG:= \
+    CONFIG_IP_VS \
+    CONFIG_IP_VS_IPV6=y \
+    CONFIG_IP_VS_DEBUG=n \
+    CONFIG_IP_VS_PROTO_TCP=y \
+    CONFIG_IP_VS_PROTO_UDP=y \
+    CONFIG_IP_VS_PROTO_AH_ESP=y \
+    CONFIG_IP_VS_PROTO_ESP=y \
+    CONFIG_IP_VS_PROTO_AH=y \
+    CONFIG_IP_VS_PROTO_SCTP=y \
+    CONFIG_IP_VS_TAB_BITS=12 \
+    CONFIG_IP_VS_RR \
+    CONFIG_IP_VS_WRR \
+    CONFIG_IP_VS_LC \
+    CONFIG_IP_VS_WLC \
+    CONFIG_IP_VS_FO \
+    CONFIG_IP_VS_OVF \
+    CONFIG_IP_VS_LBLC \
+    CONFIG_IP_VS_LBLCR \
+    CONFIG_IP_VS_DH \
+    CONFIG_IP_VS_SH \
+    CONFIG_IP_VS_SED \
+    CONFIG_IP_VS_NQ \
+    CONFIG_IP_VS_SH_TAB_BITS=8 \
+    CONFIG_IP_VS_NFCT=y \
+    CONFIG_NETFILTER_XT_MATCH_IPVS
+
+  FILES:=$(foreach mod,$(IPVS_MODULES),$(LINUX_DIR)/net/netfilter/$(mod).ko)
+  $(call AddDepends/ipt,+kmod-ipt-conntrack,+kmod-nf-conntrack)
+endef
+$(eval $(call KernelPackage,nf-ipvs))
+
+define KernelPackage/nf-ipvs/description
+ IPVS (IP Virtual Server) implements transport-layer load balancing inside the Linux kernel
+ so called Layer-4 switching.
+endef
+
+define KernelPackage/nf-ipvs-ftp
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Virtual Server FTP protocol support
+  KCONFIG:=CONFIG_IP_VS_FTP
+  DEPENDS:=kmod-nf-ipvs +kmod-nf-nat +kmod-nf-conntrack-ftp
+  FILES:=$(LINUX_DIR)/net/netfilter/ipvs/ip_vs_ftp.ko
+endef
+
+$(eval $(call KernelPackage,nf-ipvs-ftp))
+
+
+define KernelPackage/nf-ipvs-sip
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Virtual Server SIP protocol support
+  KCONFIG:=CONFIG_IP_VS_PE_SIP
+  DEPENDS:=kmod-nf-ipvs +kmod-nf-nathelper-extra
+  FILES:=$(LINUX_DIR)/net/netfilter/ipvs/ip_vs_pe_sip.ko
+endef
+
+$(eval $(call KernelPackage,nf-ipvs-sip))
 
 
 define KernelPackage/ipt-nat


### PR DESCRIPTION
IPVS (IP Virtual Server) implements transport-layer load balancing inside the Linux kernel, so called Layer-4 switching. IPVS running on a host acts as a load balancer at the front of a cluster of real servers, it can direct requests for TCP/UDP based services to the real servers, and makes services of the real servers to appear as a virtual service on a single IP address.

This change adds kmod-nf-ipvs and kmod-nf-conntrack-ftp kernel modules options to LEDE kernel netfilter

Signed-off-by: Mauro Mozzarelli <mauro@ezplanet.org>