### PR TITLE
ar71xx: add support for MikroTik hAP ac lite

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -239,7 +239,8 @@ rb-750up-r2)
 rb-941-2nd)
 	ucidef_set_led_timer "user" "USR/ACT" "rb:green:user" "1000" "1000"
 	;;
-rb-951ui-2nd)
+rb-951ui-2nd|\
+rb-952ui-5ac2nd)
 	ucidef_set_led_timer "user" "USER" "rb:green:user" "1000" "1000"
 	ucidef_set_led_netdev "port1" "port1" "rb:green:port1" "eth0"
 	ucidef_set_led_switch "port2" "port2" "rb:green:port2" "switch0" "0x10"

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -142,6 +142,7 @@ ar71xx_setup_interfaces()
 	rb-750up-r2|\
 	rb-951ui-2hnd|\
 	rb-951ui-2nd|\
+	rb-952ui-5ac2nd|\
 	routerstation|\
 	tl-wr710n|\
 	tl-wr720n-v3|\

--- a/target/linux/ar71xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ar71xx/base-files/etc/board.d/03_gpio_switches
@@ -28,7 +28,8 @@ rb-912uag-5hpnd)
 	ucidef_add_gpio_switch "usb_power_switch" "USB Power Switch" "52" "1"
 	;;
 rb-750up-r2|\
-rb-951ui-2nd)
+rb-951ui-2nd|\
+rb-952ui-5ac2nd)
 	ucidef_add_gpio_switch "usb_power_switch" "USB Power Switch" "45" "1"
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "14"
 	;;

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -306,6 +306,7 @@ get_status_led() {
 	rb-912uag-5hpnd|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
+	rb-952ui-5ac2nd|\
 	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		status_led="rb:green:user"

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -106,6 +106,9 @@ case "$FIRMWARE" in
 	unifiac-pro)
 		ath10kcal_extract "EEPROM" 20480 2116
 		;;
+	rb-952ui-5ac2nd)
+		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
+		;;
 	esac
 	;;
 "ath10k/cal-pci-0000:01:00.0.bin")

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -905,6 +905,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD 951Ui-2nD")
 		name="rb-951ui-2nd"
 		;;
+	*"RouterBOARD 952Ui-5ac2nD")
+		name="rb-952ui-5ac2nd"
+		;;
 	*"RouterBOARD LHG 5nD")
 		name="rb-lhg-5nd"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -638,6 +638,7 @@ platform_check_image() {
 	rb-750up-r2|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
+	rb-952ui-5ac2nd|\
 	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		return 0
@@ -690,6 +691,7 @@ platform_pre_upgrade() {
 	rb-750up-r2|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
+	rb-952ui-5ac2nd|\
 	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		# erase firmware if booted from initramfs

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -942,6 +942,7 @@ config ATH79_MACH_RBSPI
 	  MikroTik RouterBOARD mAP lite
 	  MikroTik RouterBOARD hAP lite
 	  MikroTik RouterBOARD hAP
+	  MikroTik RouterBOARD hAP ac lite
 	  MikroTik RouterBOARD hEX PoE lite
 	  MikroTik RouterBOARD hEX lite
 	  MikroTik RouterBOARD LHG 5

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -176,7 +176,7 @@ enum ath79_mach_type {
 	ATH79_MACH_RB_941,			/* MikroTik RouterBOARD 941-2nD */
 	ATH79_MACH_RB_951G,			/* Mikrotik RouterBOARD 951G */
 	ATH79_MACH_RB_951U,			/* Mikrotik RouterBOARD 951Ui-2HnD */
-	ATH79_MACH_RB_952,			/* MikroTik RouterBOARD 951Ui-2nD */
+	ATH79_MACH_RB_952,			/* MikroTik RouterBOARD 951Ui-2nD / 952Ui-5ac2nD */
 	ATH79_MACH_RB_CAP,			/* Mikrotik RouterBOARD cAP2nD */
 	ATH79_MACH_RB_LHG5,			/* Mikrotik RouterBOARD LHG5 */
 	ATH79_MACH_RB_MAP,			/* Mikrotik RouterBOARD mAP2nD */

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -31,9 +31,15 @@ define Device/rb-nor-flash-16M
   LOADER_TYPE := elf
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin | lzma | loader-kernel
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-941-2nd rb-951ui-2nd rb-lhg-5nd rb-mapl-2nd
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-lhg-5nd rb-mapl-2nd
   IMAGE/sysupgrade.bin = append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
 
-TARGET_DEVICES += rb-nor-flash-16M
+define Device/rb-nor-flash-16M-ac
+  $(Device/rb-nor-flash-16M)
+  DEVICE_TITLE := MikroTik RouterBoard with 16 MB SPI NOR flash and ac
+  DEVICE_PACKAGES += kmod-ath10k ath10k-firmware-qca988x ath10k-firmware-qca9887
+endef
+
+TARGET_DEVICES += rb-nor-flash-16M rb-nor-flash-16M-ac


### PR DESCRIPTION
This patch adds support for the MikroTik RouterBOARD hAP ac lite (RB952Ui-5ac2nD). The hAP ac lite is nearly identical to the hAP, with an added QCA9887 5GHz radio.

The 2.4GHz radio ID is also changed in the hAP ac lite. Handling for this case has been added in #925 upon which this patch is based, so this PR depends upon #925.

There has also been some discussion in #925 regarding different target profiles for SPI NOR based RouterBOARDs. As the hAP ac lite also depends upon ath10k and firmware for the QCA9887 it probably deserves its own profile.