### PR TITLE
ramips: add support for Netgear EX3700

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -49,7 +49,7 @@ define Build/netgear-chk
 		-o $@.new \
 		-k $@ \
 		-b $(NETGEAR_BOARD_ID) \
-		-r $(NETGEAR_REGION)
+		$(if $(NETGEAR_REGION),-r $(NETGEAR_REGION),)
 	mv $@.new $@
 endef
 

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -165,6 +165,10 @@ wn3000rpv3)
 	ucidef_set_led_default "power_r" "POWER (red)" "$board:red:power" "0"
 	set_wifi_led "$board:green:router"
 	;;
+ex3700)
+	ucidef_set_led_netdev "wlan5g" "ROUTER (green)" "$board:green:router" "wlan0"
+	ucidef_set_led_netdev "wlan2g" "DEVICE (green)" "$board:green:device" "wlan1"
+	;;
 f5d8235-v1)
 	ucidef_set_led_default "lan" "lan" "$board:blue:wired" "0"
 	set_usb_led "$board:blue:storage"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -189,6 +189,7 @@ ramips_setup_interfaces()
 	d105|\
 	dch-m225|\
 	ex2700|\
+	ex3700|\
 	hpm|\
 	mzk-ex300np|\
 	mzk-ex750np|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -23,6 +23,7 @@ get_status_led() {
 	dch-m225|\
 	dir-860l-b1|\
 	e1700|\
+	ex3700|\
 	fonera20n|\
 	kn_rc|\
 	kn_rf|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -190,6 +190,9 @@ ramips_board_detect() {
 	*"EX2700")
 		name="ex2700";
 		;;
+	*"EX3700")
+		name="ex3700"
+		;;
 	*"F5D8235 v1")
 		name="f5d8235-v1"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -55,6 +55,7 @@ platform_check_image() {
 	esr-9753|\
 	ew1200|\
 	ex2700|\
+	ex3700|\
 	f7c027|\
 	firewrt|\
 	fonera20n|\

--- a/target/linux/ramips/dts/EX3700.dts
+++ b/target/linux/ramips/dts/EX3700.dts
@@ -1,0 +1,162 @@
+/* This file is released into the public domain */
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7620a.dtsi"
+
+/ {
+	compatible = "ralink,mt7620a-soc";
+	model = "Netgear EX3700";
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power_g {
+			label = "ex3700:green:power";
+			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		power_a {
+			label = "ex3700:amber:power";
+			gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		router_g {
+			label = "ex3700:green:router";
+			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
+		};
+
+		router_r {
+			label = "ex3700:red:router";
+			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+		};
+
+		device_g {
+			label = "ex3700:green:device";
+			gpios = <&gpio2 20 GPIO_ACTIVE_LOW>;
+		};
+
+		device_r {
+			label = "ex3700:red:device";
+			gpios = <&gpio2 21 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "ex3700:green:wps";
+			gpios = <&gpio2 27 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio2 26 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "config";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x790000>;
+		};
+
+		partition@7e0000 {
+			label = "board_data";
+			reg = <0x7e0000 0x10000>;
+			read-only;
+		};
+
+		partition@7f0000 {
+			label = "nvram";
+			reg = <0x7f0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie-bridge {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0 >;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "i2c", "rgmii2", "spi refclk";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -79,6 +79,18 @@ define Device/wn3000rpv3
 endef
 TARGET_DEVICES += wn3000rpv3
 
+define Device/ex3700
+  NETGEAR_BOARD_ID := U12H319T00_NETGEAR
+  DTS := EX3700
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7744k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | netgear-chk
+  DEVICE_PACKAGES := -kmod-mt76 kmod-mt76x2
+  DEVICE_TITLE := Netgear EX3700
+endef
+TARGET_DEVICES += ex3700
+
 define Device/wt3020-4M
   DTS := WT3020-4M
   BLOCKSIZE := 4k


### PR DESCRIPTION
Specifications:
* SoC: MT7620A
* RAM: 64 MB DDR
* Flash: 8MB NOR SPI flash
* WiFi: MT7612E (5Ghz) and builtin MT7620A (2.4GHz)
* LAN: 1x100M

This patch would not have been possible without the help and input of
Paul Oranje (@poranje).