### PR TITLE
Set b rates via require_mode, disable b by default

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -95,16 +95,7 @@ hostapd_prepare_device_config() {
 	for r in $rate_list; do
 		if [ "$require_mode" != "b" ]; then
 			case "$r" in
-				1000)
-					continue
-				;;
-				2000)
-					continue
-				;;
-				5500)
-					continue
-				;;
-				11000)
+				1000|2000|5500|11000)
 					continue
 				;;
 			esac
@@ -118,16 +109,7 @@ hostapd_prepare_device_config() {
 	for br in $basic_rate_list; do
 		if [ "$require_mode" != "b" ]; then
 			case "$br" in
-				1000)
-					continue
-				;;
-				2000)
-					continue
-				;;
-				5500)
-					continue
-				;;
-				11000)
+				1000|2000|5500|11000)
 					continue
 				;;
 			esac


### PR DESCRIPTION
The require_mode option can currently be configured to a value of g or n for 2.4 GHz BSSes or n or ac for 5 GHz BSSes to set the minimum mode that connecting clients need to support to be able to connect.

This patch introduces a new require_mode of b and defaults to a require_mode of g where this is unspecified.

The rationale for this, which is stronger now than in 2014, can be found in:

https://mentor.ieee.org/802.11/dcn/14/11-14-0099-00-000m-renewing-2-4ghz-band.pptx

The balance of equities between compatibility with b clients and the detriment to the 2.4 GHz ecosystem as a whole in 2017 strongly favors disabling b support by default.

Issues previously in the hostapd.sh shell script for 2.4 GHz BSSes for the require_mode were:

1) Where a require_mode of g was configured, the supported rates still included b rates yet the basic rates would not include b rates.

2) Where a require_mode of g was configured, the basic rates would be set to 60 120 240 that would override the configuration of the basic_rate option rather than filtering to exclude b rates.

3) Where a require_mode of n was configured, the b rates were still used as basic rates which is not airtime efficient. The g require_mode achieved better airtime efficiency for broadcast/multicast traffic. Only where the require_mode was set to g would the basic rates be set to not include b rates.

Now:

1) Where a require_mode is not configured to b and the supported_rates option has not been configured, this will be changed to OFDM rates only:

60 90 120 180 240 360 480 540

2) Where a require_mode is not configured to b and the supported_rates option has been configured, this will be filtered to include OFDM rates only.

3) Where a require_mode is not configured to b and the basic_rate option has not been configured, this will be changed to OFDM rates only:

60 120 240

4) Where a require_mode is not configured to b and the basic_rate option has been configured, this will now be filtered to include OFDM rates only.

Signed-off-by: Nick Lowe <nick.lowe@gmail.com>

Thanks for your contribution to the LEDE project!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
