### PR TITLE
hostapd: Default disable b rates, add legacy_rates

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -64,6 +64,7 @@ hostapd_common_add_device_config() {
 	config_add_string country
 	config_add_boolean country_ie doth
 	config_add_string require_mode
+	config_add_boolean legacy_rates
 
 	hostapd_add_log_config
 }
@@ -75,12 +76,13 @@ hostapd_prepare_device_config() {
 	local base="${config%%.conf}"
 	local base_cfg=
 
-	json_get_vars country country_ie beacon_int doth require_mode
+	json_get_vars country country_ie beacon_int doth require_mode legacy_rates
 
 	hostapd_set_log_options base_cfg
 
 	set_default country_ie 1
 	set_default doth 1
+	set_default legacy_rates 0
 
 	[ -n "$country" ] && {
 		append base_cfg "country_code=$country" "$N"
@@ -88,23 +90,68 @@ hostapd_prepare_device_config() {
 		[ "$country_ie" -gt 0 ] && append base_cfg "ieee80211d=1" "$N"
 		[ "$hwmode" = "a" -a "$doth" -gt 0 ] && append base_cfg "ieee80211h=1" "$N"
 	}
-	[ -n "$hwmode" ] && append base_cfg "hw_mode=$hwmode" "$N"
 
 	local brlist= br
 	json_get_values basic_rate_list basic_rate
-	for br in $basic_rate_list; do
-		hostapd_add_rate brlist "$br"
-	done
-	case "$require_mode" in
-		g) brlist="60 120 240" ;;
-		n) append base_cfg "require_ht=1" "$N";;
-		ac) append base_cfg "require_vht=1" "$N";;
-	esac
-
 	local rlist= r
 	json_get_values rate_list supported_rates
+
+	[ -n "$hwmode" ] && {
+		append base_cfg "hw_mode=$hwmode" "$N"
+
+		[ "$hwmode" = "g" ] && {
+			[ -z "$rate_list" -a "$legacy_rates" -eq 0 ] && {
+				rate_list="6000 9000 12000 18000 24000 36000 48000 54000"
+			}
+
+			[ -z "$basic_rate_list" -a \( -n "$require_mode" -o "$legacy_rates" -eq 0 \) ] && {
+				basic_rate_list="6000 12000 24000"
+			}
+		}
+
+		[ "$hwmode" = "g" -o "$hwmode" = "a" ] && {
+			case "$require_mode" in
+				n)
+					append base_cfg "require_ht=1" "$N"
+				;;
+				ac)
+					append base_cfg "require_vht=1" "$N"
+				;;
+			esac
+		}
+	}
+
 	for r in $rate_list; do
+		if [ "$legacy_rates" -eq 0 ]; then
+			case "$r" in
+				1000|2000|5500|11000)
+					continue
+				;;
+			esac
+		fi
+
 		hostapd_add_rate rlist "$r"
+	done
+
+	for br in $basic_rate_list; do
+		if [ -n "$require_mode" -o "$legacy_rates" -eq 0 ]; then
+			case "$br" in
+				1000|2000|5500|11000)
+					continue
+				;;
+			esac
+		fi
+
+		if [ -z "$rate_list" ]; then
+			hostapd_add_rate brlist "$br"
+		else
+			for r in $rate_list; do
+				if [ "$br" = "$r" ]; then
+					hostapd_add_rate brlist "$br"
+					break
+				fi
+			done
+		fi
 	done
 
 	[ -n "$rlist" ] && append base_cfg "supported_rates=$rlist" "$N"


### PR DESCRIPTION
The require_mode option can currently be configured to a value of g or n for 2.4 GHz BSSes or n or ac for 5 GHz BSSes to set the minimum mode that connecting clients need to support to be able to connect.

This patch introduces a new require_mode of b and defaults to a require_mode of g where this is unspecified.

The rationale for this, which is stronger now than in 2014, can be found in:

https://mentor.ieee.org/802.11/dcn/14/11-14-0099-00-000m-renewing-2-4ghz-band.pptx

The balance of equities between compatibility with b clients and the detriment to the 2.4 GHz ecosystem as a whole in 2017 strongly favors disabling b support by default.

Issues previously in the hostapd.sh shell script for 2.4 GHz BSSes for the require_mode were:

1) Where a require_mode of g was configured, the supported rates still included b rates yet the basic rates would not include b rates.

2) Where a require_mode of g was configured, the basic rates would be set to 60 120 240 that would override the configuration of the basic_rate option rather than filtering to exclude b rates.

3) Where a require_mode of n was configured, the b rates were still used as basic rates which is not airtime efficient. The g require_mode achieved better airtime efficiency for broadcast/multicast traffic. Only where the require_mode was set to g would the basic rates be set to not include b rates.

Now:

1) Where a require_mode is not configured to b and the supported_rates option has not been configured, this will be changed to OFDM rates only:

60 90 120 180 240 360 480 540

2) Where a require_mode is not configured to b and the supported_rates option has been configured, this will be filtered to include OFDM rates only.

3) Where a require_mode is not configured to b and the basic_rate option has not been configured, this will be changed to OFDM rates only:

60 120 240

4) Where a require_mode is not configured to b and the basic_rate option has been configured, this will now be filtered to include OFDM rates only.

Signed-off-by: Nick Lowe <nick.lowe@gmail.com>
