### PR TITLE
lantiq: vr9 fxs support: fixed check of SMP state within vpe-mt.c

### DIFF
--- a/target/linux/lantiq/patches-4.9/0155-lantiq-VPE-nosmp.patch
+++ b/target/linux/lantiq/patches-4.9/0155-lantiq-VPE-nosmp.patch
@@ -1,0 +1,14 @@
+--- a/arch/mips/kernel/vpe-mt.c
++++ b/arch/mips/kernel/vpe-mt.c
+@@ -132,7 +132,10 @@ int vpe_run(struct vpe *v)
+ 	 * kernels need to turn it on, even if that wasn't the pre-dvpe() state.
+ 	 */
+ #ifdef CONFIG_SMP
+-	evpe(vpeflags);
++	if (!setup_max_cpus) /* nosmp is set */
++		evpe(EVPE_ENABLE);
++	else
++		evpe(vpeflags);
+ #else
+ 	evpe(EVPE_ENABLE);
+ #endif


### PR DESCRIPTION
SMP state is generally affected by
- CONFIG_SMP build-time kernel configuration option and
- 'nosmp' runtime kernel commandline option

The SMP state within vpe-mt.c is determined by CONFIG_SMP option.
A runtime check is needed if VPE functionality
should be used with a kernel image that supports SMP.

This fix introduces a check for 'nosmp' command line option
if CONFIG_SMP kernel configuration option is enabled.

Note: This patch is needed to use lantiq FXS if CONFIG_MIPS_MT_SMP
(that activates CONFIG_SMP) is enabled within kernel configuration
and the 'nosmp' command line argument is given to disable SMP at runtime.

Without this patch CONFIG_MIPS_MT_SMP must be disabled before using FXS.
With this patch setting the 'nosmp' parameter is enough.

In general, concurrent usage of FXS and SMP
is incompatible and will cause kernel panics.

Signed-off-by: Stefan Koch <stefan.koch10@gmail.com>

Thanks for your contribution to the LEDE project!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
