### PR TITLE
ramips: add support for Zbtlink ZBT-WE2026

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -385,6 +385,9 @@ zbt-wa05)
 	set_wifi_led "$board:blue:air"
 	set_usb_led "$board:blue:usb"
 	;;
+zbt-we2026)
+	set_wifi_led "$board:green:wlan"
+	;;
 zbt-we826)
 	ucidef_set_led_default "power" "power" "$board:green:power" "1"
 	set_wifi_led "$board:green:wifi"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -107,6 +107,7 @@ ramips_setup_interfaces()
 	y1|\
 	youku-yk1|\
 	zbt-ape522ii|\
+	zbt-we2026|\
 	zbt-we826|\
 	zbt-wg2626|\
 	zbt-wg3526|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -238,7 +238,8 @@ get_status_led() {
 		status_led="$board:amber:power"
 		;;
 	whr-g300n|\
-	wlr-6000)
+	wlr-6000|\
+	zbt-we2026)
 		status_led="$board:red:power"
 		;;
 	wzr-agl300nh)

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -646,6 +646,9 @@ ramips_board_detect() {
 	*"ZBT-WA05")
 		name="zbt-wa05"
 		;;
+	*"ZBT-WE2026")
+		name="zbt-we2026"
+		;;
 	*"ZBT-WE826")
 		name="zbt-we826"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -181,6 +181,7 @@ platform_check_image() {
 	zbt-ape522ii|\
 	zbt-cpe102|\
 	zbt-wa05|\
+	zbt-we2026|\
 	zbt-we826|\
 	zbt-wg2626|\
 	zbt-wg3526|\

--- a/target/linux/ramips/dts/ZBT-WE2026.dts
+++ b/target/linux/ramips/dts/ZBT-WE2026.dts
@@ -1,0 +1,103 @@
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7620n.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-we2026", "ralink,mt7620n-soc";
+	model = "Zbtlink ZBT-WE2026";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "zbt-we2026:red:power";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "zbt-we2026:green:wlan";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	en25q64@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x760000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+	mediatek,portmap = "wllll";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "i2c", "spi refclk", "wled";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -467,6 +467,12 @@ define Device/zbt-wa05
 endef
 TARGET_DEVICES += zbt-wa05
 
+define Device/zbt-we2026
+  DTS := ZBT-WE2026
+  DEVICE_TITLE := Zbtlink ZBT-WE2026
+endef
+TARGET_DEVICES += zbt-we2026
+
 define Device/zbt-we826
   DTS := ZBT-WE826
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
This patch adds support for the Zbtlink ZBT-WE2026.

Specification:
- SoC: MediaTek MT7620N (580MHz)
- RAM: 64 MiB
- Flash: 8 MiB SPI
- LAN: 4x100M
- WAN: 1x100M

Installation through bootloader webserver:
- With the power unplugged press and hold reset button.
- Plug power and hold reset button until LED starts to blink.
- Install sysupgrade image using web interface on 192.168.1.1.

Signed-off-by: Vaclav Svoboda <svoboda@neng.cz>

Thanks for your contribution to the LEDE project!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
