### PR TITLE
openvpn: add extra respawn parameters

### DIFF
--- a/package/network/services/openvpn/files/openvpn.init
+++ b/package/network/services/openvpn/files/openvpn.init
@@ -68,6 +68,9 @@ openvpn_add_instance() {
 		--config "$conf"
 	procd_set_param file "$dir/$conf"
 	procd_set_param respawn
+	procd_append_param respawn 3600
+	procd_append_param respawn 5
+	procd_append_param respawn -1
 	procd_close_instance
 }
 


### PR DESCRIPTION
This change protects the openvpn instances to be marked as "in a crash loop"
and thereby the connection retries will run infinitely.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
