### PR TITLE
ar71xx: add support for MikroTik hAP ac

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -249,6 +249,9 @@ rb-952ui-5ac2nd)
 	ucidef_set_led_switch "port5" "port5" "rb:green:port5" "switch0" "0x02"
 	ucidef_set_led_wlan "wlan" "WLAN" "rb:blue:wlan" "phy0tpt"
 	;;
+rb-962uigs-5hact2hnt)
+	ucidef_set_led_timer "user" "USER/SFP" "rb:green:user" "1000" "1000"
+	;;
 rb-2011l|\
 rb-2011uas|\
 rb-2011uias|\

--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -239,7 +239,8 @@ rb-750up-r2)
 rb-941-2nd)
 	ucidef_set_led_timer "user" "USR/ACT" "rb:green:user" "1000" "1000"
 	;;
-rb-951ui-2nd)
+rb-951ui-2nd|\
+rb-952ui-5ac2nd)
 	ucidef_set_led_timer "user" "USER" "rb:green:user" "1000" "1000"
 	ucidef_set_led_netdev "port1" "port1" "rb:green:port1" "eth0"
 	ucidef_set_led_switch "port2" "port2" "rb:green:port2" "switch0" "0x10"

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -142,6 +142,7 @@ ar71xx_setup_interfaces()
 	rb-750up-r2|\
 	rb-951ui-2hnd|\
 	rb-951ui-2nd|\
+	rb-952ui-5ac2nd|\
 	routerstation|\
 	tl-wr710n|\
 	tl-wr720n-v3|\

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -171,6 +171,7 @@ ar71xx_setup_interfaces()
 	rb-750gl|\
 	rb-751g|\
 	rb-951g-2hnd|\
+	rb-962uigs-5hact2hnt|\
 	wlr8100|\
 	wzr-hp-g450h)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ar71xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ar71xx/base-files/etc/board.d/03_gpio_switches
@@ -28,7 +28,8 @@ rb-912uag-5hpnd)
 	ucidef_add_gpio_switch "usb_power_switch" "USB Power Switch" "52" "1"
 	;;
 rb-750up-r2|\
-rb-951ui-2nd)
+rb-951ui-2nd|\
+rb-952ui-5ac2nd)
 	ucidef_add_gpio_switch "usb_power_switch" "USB Power Switch" "45" "1"
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "14"
 	;;

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -307,6 +307,7 @@ get_status_led() {
 	rb-941-2nd|\
 	rb-951ui-2nd|\
 	rb-952ui-5ac2nd|\
+	rb-962uigs-5hact2hnt|\
 	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		status_led="rb:green:user"

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -306,6 +306,7 @@ get_status_led() {
 	rb-912uag-5hpnd|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
+	rb-952ui-5ac2nd|\
 	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		status_led="rb:green:user"

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -106,6 +106,9 @@ case "$FIRMWARE" in
 	unifiac-pro)
 		ath10kcal_extract "EEPROM" 20480 2116
 		;;
+	rb-952ui-5ac2nd)
+		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
+		;;
 	esac
 	;;
 "ath10k/cal-pci-0000:01:00.0.bin")

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -127,7 +127,8 @@ case "$FIRMWARE" in
 		ath10kcal_extract "ART" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
-	rb-911g-5hpacd)
+	rb-911g-5hpacd | \
+	rb-962uigs-5hact2hnt)
 		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
 		;;
 	esac

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -905,6 +905,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD 951Ui-2nD")
 		name="rb-951ui-2nd"
 		;;
+	*"RouterBOARD 952Ui-5ac2nD")
+		name="rb-952ui-5ac2nd"
+		;;
 	*"RouterBOARD LHG 5nD")
 		name="rb-lhg-5nd"
 		;;

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -908,6 +908,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD 952Ui-5ac2nD")
 		name="rb-952ui-5ac2nd"
 		;;
+	*"RouterBOARD 962UiGS-5HacT2HnT")
+		name="rb-962uigs-5hact2hnt"
+		;;
 	*"RouterBOARD LHG 5nD")
 		name="rb-lhg-5nd"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -639,6 +639,7 @@ platform_check_image() {
 	rb-941-2nd|\
 	rb-951ui-2nd|\
 	rb-952ui-5ac2nd|\
+	rb-962uigs-5hact2hnt|\
 	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		return 0
@@ -692,6 +693,7 @@ platform_pre_upgrade() {
 	rb-941-2nd|\
 	rb-951ui-2nd|\
 	rb-952ui-5ac2nd|\
+	rb-962uigs-5hact2hnt|\
 	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		# erase firmware if booted from initramfs

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -638,6 +638,7 @@ platform_check_image() {
 	rb-750up-r2|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
+	rb-952ui-5ac2nd|\
 	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		return 0
@@ -690,6 +691,7 @@ platform_pre_upgrade() {
 	rb-750up-r2|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
+	rb-952ui-5ac2nd|\
 	rb-lhg-5nd|\
 	rb-mapl-2nd)
 		# erase firmware if booted from initramfs

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -942,6 +942,7 @@ config ATH79_MACH_RBSPI
 	  MikroTik RouterBOARD mAP lite
 	  MikroTik RouterBOARD hAP lite
 	  MikroTik RouterBOARD hAP
+	  MikroTik RouterBOARD hAP ac lite
 	  MikroTik RouterBOARD hEX PoE lite
 	  MikroTik RouterBOARD hEX lite
 	  MikroTik RouterBOARD LHG 5

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -930,6 +930,7 @@ config ATH79_MACH_RBSPI
 	bool "MikroTik RouterBOARD SPI-NOR support"
 	select SOC_AR934X
 	select SOC_QCA953X
+	select SOC_QCA955X
 	select ATH79_DEV_ETH
 	select ATH79_DEV_GPIO_BUTTONS
 	select ATH79_DEV_LEDS_GPIO
@@ -942,6 +943,7 @@ config ATH79_MACH_RBSPI
 	  MikroTik RouterBOARD mAP lite
 	  MikroTik RouterBOARD hAP lite
 	  MikroTik RouterBOARD hAP
+	  MikroTik RouterBOARD hAP ac
 	  MikroTik RouterBOARD hAP ac lite
 	  MikroTik RouterBOARD hEX PoE lite
 	  MikroTik RouterBOARD hEX lite

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -5,6 +5,7 @@
  *  - MikroTik RouterBOARD 941L-2nD
  *  - MikroTik RouterBOARD 951Ui-2nD
  *  - MikroTik RouterBOARD 952Ui-5ac2nD
+ *  - MikroTik RouterBOARD 962UiGS-5HacT2HnT
  *  - MikroTik RouterBOARD 750UP r2
  *  - MikroTik RouterBOARD 750 r2
  *  - MikroTik RouterBOARD LHG 5nD
@@ -18,6 +19,8 @@
  *  identifier.
  *
  *  Copyright (C) 2017 Thibaut VARENE <varenet@parisc-linux.org>
+ *  Copyright (C) 2016 David Hutchison <dhutchison@bluemesh.net>
+ *  Copyright (C) 2017 Ryan Mounce <ryan@mounce.com.au>
  *
  *  This program is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License version 2 as published
@@ -35,6 +38,8 @@
 
 #include <linux/mtd/mtd.h>
 #include <linux/mtd/partitions.h>
+
+#include <linux/ar8216_platform.h>
 
 #include <asm/prom.h>
 #include <asm/mach-ath79/ar71xx_regs.h>
@@ -130,6 +135,7 @@ static struct flash_platform_data rbspi_spi_flash_data = {
 
 /* Several boards only have a single reset button wired to GPIO 16 */
 #define RBSPI_GPIO_BTN_RESET16	16
+#define RBSPI_GPIO_BTN_RESET20	20
 
 static struct gpio_keys_button rbspi_gpio_keys_reset16[] __initdata = {
 	{
@@ -138,6 +144,17 @@ static struct gpio_keys_button rbspi_gpio_keys_reset16[] __initdata = {
 		.code = KEY_RESTART,
 		.debounce_interval = RBSPI_KEYS_DEBOUNCE_INTERVAL,
 		.gpio = RBSPI_GPIO_BTN_RESET16,
+		.active_low = 1,
+	},
+};
+
+static struct gpio_keys_button rbspi_gpio_keys_reset20[] __initdata = {
+	{
+		.desc = "Reset button",
+		.type = EV_KEY,
+		.code = KEY_RESTART,
+		.debounce_interval = RBSPI_KEYS_DEBOUNCE_INTERVAL,
+		.gpio = RBSPI_GPIO_BTN_RESET20,
 		.active_low = 1,
 	},
 };
@@ -233,6 +250,83 @@ static struct gpio_led rb952_leds[] __initdata = {
 		.gpio = RB952_GPIO_LED_LAN5,
 		.active_low = 1,
 	},
+};
+
+
+/* RB 962UiGS-5HacT2HnT gpios */
+#define RB962_GPIO_POE_STATUS	2
+#define RB962_GPIO_POE_POWER	3
+#define RB962_GPIO_LED_USER	12
+#define RB962_GPIO_USB_POWER	13
+
+static struct gpio_led rb962_leds_gpio[] __initdata = {
+	{
+		.name		= "rb:green:user",
+		.gpio		= RB962_GPIO_LED_USER,
+		.active_low	= 1,
+	},
+};
+
+static const struct ar8327_led_info rb962_leds_ar8327[] __initconst = {
+		AR8327_LED_INFO(PHY0_0, HW, "rb:green:port1"),
+		AR8327_LED_INFO(PHY1_0, HW, "rb:green:port2"),
+		AR8327_LED_INFO(PHY2_0, HW, "rb:green:port3"),
+		AR8327_LED_INFO(PHY3_0, HW, "rb:green:port4"),
+		AR8327_LED_INFO(PHY4_0, HW, "rb:green:port5"),
+};
+
+static struct ar8327_pad_cfg rb962_ar8327_pad0_cfg = {
+		.mode = AR8327_PAD_MAC_RGMII,
+		.txclk_delay_en = true,
+		.rxclk_delay_en = true,
+		.txclk_delay_sel = AR8327_CLK_DELAY_SEL1,
+		.rxclk_delay_sel = AR8327_CLK_DELAY_SEL2,
+		.mac06_exchange_dis = true,
+};
+
+static struct ar8327_pad_cfg rb962_ar8327_pad6_cfg = {
+		/* Use SGMII interface for GMAC6 of the AR8337 switch */
+		.mode = AR8327_PAD_MAC_SGMII,
+		.rxclk_delay_en = true,
+		.rxclk_delay_sel = AR8327_CLK_DELAY_SEL0,
+};
+
+static struct ar8327_led_cfg rb962_ar8327_led_cfg = {
+		.led_ctrl0 = 0xc737c737,
+		.led_ctrl1 = 0x00000000,
+		.led_ctrl2 = 0x00000000,
+		.led_ctrl3 = 0x0030c300,
+		.open_drain = false,
+};
+
+static struct ar8327_platform_data rb962_ar8327_data = {
+		.pad0_cfg = &rb962_ar8327_pad0_cfg,
+		.pad6_cfg = &rb962_ar8327_pad6_cfg,
+		.port0_cfg = {
+				.force_link = 1,
+				.speed = AR8327_PORT_SPEED_1000,
+				.duplex = 1,
+				.txpause = 1,
+				.rxpause = 1,
+		},
+		.port6_cfg = {
+				.force_link = 1,
+				.speed = AR8327_PORT_SPEED_1000,
+				.duplex = 1,
+				.txpause = 1,
+				.rxpause = 1,
+		},
+		.led_cfg = &rb962_ar8327_led_cfg,
+		.num_leds = ARRAY_SIZE(rb962_leds_ar8327),
+		.leds = rb962_leds_ar8327,
+};
+
+static struct mdio_board_info rb962_mdio0_info[] = {
+		{
+				.bus_id = "ag71xx-mdio.0",
+				.phy_addr = 0,
+				.platform_data = &rb962_ar8327_data,
+		},
 };
 
 /* RB wAP-2nD gpios */
@@ -686,6 +780,68 @@ static void __init rb750upr2_setup(void)
 }
 
 /*
+ * Init the hAP ac / 962UiGS-5HacT2HnT hardware (QCA9558).
+ * The hAP ac has 5 ethernet ports provided by an AR8337 switch. Port 1 is
+ * assigned to WAN, ports 2-5 are assigned to LAN. Port 0 is connected to the
+ * SoC, ports 1-5 of the switch are connected to physical ports 1-5 in order.
+ * The SFP cage is not assigned by default on RouterOS. Extra work is required
+ * to support this interface as it is directly connected to the SoC (eth1).
+ * Wireless is provided by a 2.4GHz radio on the SoC (WLAN1) and a 5GHz radio
+ * attached via PCI (QCA9880). Red and green WLAN LEDs are populated however
+ * they are not attached to GPIOs, extra work is required to support these.
+ * PoE and USB output power control is supported.
+ */
+static void __init rb962_setup(void)
+{
+	u32 flags = RBSPI_HAS_USB | RBSPI_HAS_POE | RBSPI_HAS_PCI;
+
+	if (rbspi_platform_setup())
+		return;
+
+	rbspi_peripherals_setup(flags);
+
+	/* Do not call rbspi_network_setup as we have a discrete switch chip */
+	ath79_eth0_pll_data.pll_1000 = 0xae000000;
+	ath79_eth0_pll_data.pll_100 = 0xa0000101;
+	ath79_eth0_pll_data.pll_10 = 0xa0001313;
+
+	ath79_register_mdio(0, 0x0);
+	mdiobus_register_board_info(rb962_mdio0_info,
+					ARRAY_SIZE(rb962_mdio0_info));
+
+	ath79_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN);
+
+	ath79_init_mac(ath79_eth0_data.mac_addr, ath79_mac_base, 0);
+	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;
+	ath79_eth0_data.phy_mask = BIT(0);
+	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
+	ath79_register_eth(0);
+
+	/* WLAN1 MAC is HW MAC + 7 */
+	rbspi_wlan_init(1, 7);
+
+	if (flags & RBSPI_HAS_USB)
+		gpio_request_one(RB962_GPIO_USB_POWER,
+				GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
+				"USB power");
+
+	/* PoE output GPIO is inverted, set GPIOF_ACTIVE_LOW for consistency */
+	if (flags & RBSPI_HAS_POE)
+		gpio_request_one(RB962_GPIO_POE_POWER,
+				GPIOF_OUT_INIT_HIGH | GPIOF_ACTIVE_LOW |
+					GPIOF_EXPORT_DIR_FIXED,
+				"POE power");
+
+	ath79_register_leds_gpio(-1, ARRAY_SIZE(rb962_leds_gpio),
+				rb962_leds_gpio);
+	
+	/* This device has a single reset button as gpio 20 */
+	ath79_register_gpio_keys_polled(-1, RBSPI_KEYS_POLL_INTERVAL,
+					ARRAY_SIZE(rbspi_gpio_keys_reset20),
+					rbspi_gpio_keys_reset20);
+}
+
+/*
  * Init the LHG hardware (AR9344).
  * The LHG 5nD has a single ethernet port connected to PHY0.
  * Wireless is provided via 5GHz WLAN1.
@@ -781,6 +937,7 @@ static void __init rbmap_setup(void)
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_MAPL, "map-hb", rbmapl_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_941, "H951L", rbhapl_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_952, "952-hb", rb952_setup);
+MIPS_MACHINE_NONAME(ATH79_MACH_RB_962, "962", rb962_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_750UPR2, "750-hb", rb750upr2_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_LHG5, "lhg", rblhg_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_WAP, "wap-hb", rbwap_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -176,7 +176,7 @@ enum ath79_mach_type {
 	ATH79_MACH_RB_941,			/* MikroTik RouterBOARD 941-2nD */
 	ATH79_MACH_RB_951G,			/* Mikrotik RouterBOARD 951G */
 	ATH79_MACH_RB_951U,			/* Mikrotik RouterBOARD 951Ui-2HnD */
-	ATH79_MACH_RB_952,			/* MikroTik RouterBOARD 951Ui-2nD */
+	ATH79_MACH_RB_952,			/* MikroTik RouterBOARD 951Ui-2nD / 952Ui-5ac2nD */
 	ATH79_MACH_RB_CAP,			/* Mikrotik RouterBOARD cAP2nD */
 	ATH79_MACH_RB_LHG5,			/* Mikrotik RouterBOARD LHG5 */
 	ATH79_MACH_RB_MAP,			/* Mikrotik RouterBOARD mAP2nD */

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -177,6 +177,7 @@ enum ath79_mach_type {
 	ATH79_MACH_RB_951G,			/* Mikrotik RouterBOARD 951G */
 	ATH79_MACH_RB_951U,			/* Mikrotik RouterBOARD 951Ui-2HnD */
 	ATH79_MACH_RB_952,			/* MikroTik RouterBOARD 951Ui-2nD / 952Ui-5ac2nD */
+	ATH79_MACH_RB_962,			/* MikroTik RouterBOARD 962UiGS-5HacT2HnT */
 	ATH79_MACH_RB_CAP,			/* Mikrotik RouterBOARD cAP2nD */
 	ATH79_MACH_RB_LHG5,			/* Mikrotik RouterBOARD LHG5 */
 	ATH79_MACH_RB_MAP,			/* Mikrotik RouterBOARD mAP2nD */

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -31,7 +31,7 @@ define Device/rb-nor-flash-16M
   LOADER_TYPE := elf
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin | lzma | loader-kernel
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-lhg-5nd rb-mapl-2nd
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-mapl-2nd
   IMAGE/sysupgrade.bin = append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -31,9 +31,15 @@ define Device/rb-nor-flash-16M
   LOADER_TYPE := elf
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin | lzma | loader-kernel
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-941-2nd rb-951ui-2nd rb-lhg-5nd rb-mapl-2nd
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-lhg-5nd rb-mapl-2nd
   IMAGE/sysupgrade.bin = append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
 
-TARGET_DEVICES += rb-nor-flash-16M
+define Device/rb-nor-flash-16M-ac
+  $(Device/rb-nor-flash-16M)
+  DEVICE_TITLE := MikroTik RouterBoard with 16 MB SPI NOR flash and ac
+  DEVICE_PACKAGES += kmod-ath10k ath10k-firmware-qca988x ath10k-firmware-qca9887
+endef
+
+TARGET_DEVICES += rb-nor-flash-16M rb-nor-flash-16M-ac

--- a/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,26 @@ void __init prom_init(void)
+@@ -136,6 +136,27 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -17,6 +17,7 @@
 +	    strstr(arcs_cmdline, "board=H951L") ||
 +	    strstr(arcs_cmdline, "board=952-hb") ||
 +	    strstr(arcs_cmdline, "board=953gs") ||
++	    strstr(arcs_cmdline, "board=962") ||
 +	    strstr(arcs_cmdline, "board=lhg") ||
 +	    strstr(arcs_cmdline, "board=map-hb") ||
 +	    strstr(arcs_cmdline, "board=2011L") ||


### PR DESCRIPTION
This patch adds initial support for the MikroTik RouterBOARD hAP ac (RB962UiGS-5HacT2HnT).

All functions are supported except:
-SFP cage (eth1) is not working
-WLAN LEDs are not working

My branch currently includes #931 in order to avoid a merge conflict in the near future as this PR is already closed and in @pepe2k's staging tree.