### PR TITLE
odhcp6c: check for empty variable before reading

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -167,7 +167,7 @@ setup_interface () {
 		[ -n "$IFACE_DSLITE_DELEGATE" ] && json_add_boolean delegate "$IFACE_DSLITE_DELEGATE"
 		json_close_object
 		ubus call network add_dynamic "$(json_dump)"
-	elif [ "$IFACE_464XLAT" != 0 -a -f /lib/netifd/proto/464xlat.sh ]; then
+	elif [ -n "$IFACE_464XLAT" -a "$IFACE_464XLAT" != 0 -a -f /lib/netifd/proto/464xlat.sh ]; then
 		[ -z "$IFACE_464XLAT" -o "$IFACE_464XLAT" = 1 ] && IFACE_464XLAT=${INTERFACE}_4
 		json_init
 		json_add_string name "$IFACE_464XLAT"


### PR DESCRIPTION
`IFACE_464XLAT` is set by dhcpv6.sh only when
`iface_464xlat` exists. Thus, if 464XLAT support is
installed but interface is not configured to use it,
`$IFACE_464XLAT` will be empty and the `!= 0` check
will be true, causing the script to go along the path
as if 464XLAT is enabled. Adding a check for variable
length before reading solves the issue.

Signed-off-by: Tian Hao <haotia@gmail.com>
