### PR TITLE
ipq806x: scm firmware fixes

### DIFF
--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064.dtsi
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064.dtsi
@@ -206,10 +206,7 @@
 
 	firmware {
 		scm {
-			compatible = "qcom,scm-apq8064";
-
-			clocks = <&rpmcc RPM_DAYTONA_FABRIC_CLK>;
-			clock-names = "core";
+			compatible = "qcom,scm-ipq806x";
 		};
 	};
 

--- a/target/linux/ipq806x/patches-4.9/0072-ipq-scm-TZ-don-t-need-clock-to-be-enabled-disabled-for-ipq.patch
+++ b/target/linux/ipq806x/patches-4.9/0072-ipq-scm-TZ-don-t-need-clock-to-be-enabled-disabled-for-ipq.patch
@@ -1,0 +1,166 @@
+From 0fb08a02baf5114fd3bdbc5aa92d6a6cd6d5ef3f Mon Sep 17 00:00:00 2001
+From: Manoharan Vijaya Raghavan <mraghava@codeaurora.org>
+Date: Tue, 24 Jan 2017 20:58:46 +0530
+Subject: ipq: scm: TZ don't need clock to be enabled/disabled for ipq
+
+When SCM was made as a platform driver, clock management was
+addedfor firmware calls. This is not required for IPQ.
+
+Change-Id: I3d29fafe0266e51f708f2718bab03907078b0f4d
+Signed-off-by: Manoharan Vijaya Raghavan <mraghava@codeaurora.org>
+---
+ drivers/firmware/qcom_scm.c | 87 +++++++++++++++++++++++++++++----------------
+ 1 file changed, 57 insertions(+), 30 deletions(-)
+
+(limited to 'drivers/firmware/qcom_scm.c')
+
+--- a/drivers/firmware/qcom_scm.c
++++ b/drivers/firmware/qcom_scm.c
+@@ -28,12 +28,15 @@
+ 
+ #include "qcom_scm.h"
+ 
++#define SCM_NOCLK 1
++
+ struct qcom_scm {
+ 	struct device *dev;
+ 	struct clk *core_clk;
+ 	struct clk *iface_clk;
+ 	struct clk *bus_clk;
+ 	struct reset_controller_dev reset;
++	int is_clkdisabled;
+ };
+ 
+ static struct qcom_scm *__scm;
+@@ -42,6 +45,9 @@ static int qcom_scm_clk_enable(void)
+ {
+ 	int ret;
+ 
++	if (__scm->is_clkdisabled)
++		return 0;
++
+ 	ret = clk_prepare_enable(__scm->core_clk);
+ 	if (ret)
+ 		goto bail;
+@@ -66,6 +72,9 @@ bail:
+ 
+ static void qcom_scm_clk_disable(void)
+ {
++	if (__scm->is_clkdisabled)
++		return;
++
+ 	clk_disable_unprepare(__scm->core_clk);
+ 	clk_disable_unprepare(__scm->iface_clk);
+ 	clk_disable_unprepare(__scm->bus_clk);
+@@ -320,37 +329,61 @@ bool qcom_scm_is_available(void)
+ }
+ EXPORT_SYMBOL(qcom_scm_is_available);
+ 
++static const struct of_device_id qcom_scm_dt_match[] = {
++	{ .compatible = "qcom,scm-apq8064",},
++	{ .compatible = "qcom,scm-msm8660",},
++	{ .compatible = "qcom,scm-msm8960",},
++	{ .compatible = "qcom,scm-ipq807x", .data = (void *)SCM_NOCLK },
++	{ .compatible = "qcom,scm-ipq806x", .data = (void *)SCM_NOCLK },
++	{ .compatible = "qcom,scm-ipq40xx", .data = (void *)SCM_NOCLK },
++	{ .compatible = "qcom,scm-msm8960",},
++	{ .compatible = "qcom,scm-msm8960",},
++	{ .compatible = "qcom,scm",},
++	{}
++};
++
+ static int qcom_scm_probe(struct platform_device *pdev)
+ {
+ 	struct qcom_scm *scm;
++	const struct of_device_id *id;
+ 	int ret;
+ 
+ 	scm = devm_kzalloc(&pdev->dev, sizeof(*scm), GFP_KERNEL);
+ 	if (!scm)
+ 		return -ENOMEM;
+ 
+-	scm->core_clk = devm_clk_get(&pdev->dev, "core");
+-	if (IS_ERR(scm->core_clk)) {
+-		if (PTR_ERR(scm->core_clk) == -EPROBE_DEFER)
+-			return PTR_ERR(scm->core_clk);
++	id = of_match_device(qcom_scm_dt_match, &pdev->dev);
++	if (id)
++		scm->is_clkdisabled = (unsigned int)id->data;
++	else
++		scm->is_clkdisabled = 0;
++
++	if (!(scm->is_clkdisabled)) {
++
++		scm->core_clk = devm_clk_get(&pdev->dev, "core");
++		if (IS_ERR(scm->core_clk)) {
++			if (PTR_ERR(scm->core_clk) == -EPROBE_DEFER)
++				return PTR_ERR(scm->core_clk);
+ 
+-		scm->core_clk = NULL;
+-	}
+-
+-	if (of_device_is_compatible(pdev->dev.of_node, "qcom,scm")) {
+-		scm->iface_clk = devm_clk_get(&pdev->dev, "iface");
+-		if (IS_ERR(scm->iface_clk)) {
+-			if (PTR_ERR(scm->iface_clk) != -EPROBE_DEFER)
+-				dev_err(&pdev->dev, "failed to acquire iface clk\n");
+-			return PTR_ERR(scm->iface_clk);
++			scm->core_clk = NULL;
+ 		}
+ 
+-		scm->bus_clk = devm_clk_get(&pdev->dev, "bus");
+-		if (IS_ERR(scm->bus_clk)) {
+-			if (PTR_ERR(scm->bus_clk) != -EPROBE_DEFER)
+-				dev_err(&pdev->dev, "failed to acquire bus clk\n");
+-			return PTR_ERR(scm->bus_clk);
++		if (of_device_is_compatible(pdev->dev.of_node, "qcom,scm")) {
++			scm->iface_clk = devm_clk_get(&pdev->dev, "iface");
++			if (IS_ERR(scm->iface_clk)) {
++				if (PTR_ERR(scm->iface_clk) != -EPROBE_DEFER)
++					dev_err(&pdev->dev, "failed to acquire iface clk\n");
++				return PTR_ERR(scm->iface_clk);
++			}
++
++			scm->bus_clk = devm_clk_get(&pdev->dev, "bus");
++			if (IS_ERR(scm->bus_clk)) {
++				if (PTR_ERR(scm->bus_clk) != -EPROBE_DEFER)
++					dev_err(&pdev->dev, "failed to acquire bus clk\n");
++				return PTR_ERR(scm->bus_clk);
++			}
+ 		}
++
+ 	}
+ 
+ 	scm->reset.ops = &qcom_scm_pas_reset_ops;
+@@ -358,10 +391,12 @@ static int qcom_scm_probe(struct platfor
+ 	scm->reset.of_node = pdev->dev.of_node;
+ 	reset_controller_register(&scm->reset);
+ 
+-	/* vote for max clk rate for highest performance */
+-	ret = clk_set_rate(scm->core_clk, INT_MAX);
+-	if (ret)
+-		return ret;
++	if (!(scm->is_clkdisabled)) {
++		/* vote for max clk rate for highest performance */
++		ret = clk_set_rate(scm->core_clk, INT_MAX);
++		if (ret)
++			return ret;
++	}
+ 
+ 	__scm = scm;
+ 	__scm->dev = &pdev->dev;
+@@ -371,14 +406,6 @@ static int qcom_scm_probe(struct platfor
+ 	return 0;
+ }
+ 
+-static const struct of_device_id qcom_scm_dt_match[] = {
+-	{ .compatible = "qcom,scm-apq8064",},
+-	{ .compatible = "qcom,scm-msm8660",},
+-	{ .compatible = "qcom,scm-msm8960",},
+-	{ .compatible = "qcom,scm",},
+-	{}
+-};
+-
+ static struct platform_driver qcom_scm_driver = {
+ 	.driver = {
+ 		.name	= "qcom_scm",

--- a/target/linux/ipq806x/patches-4.9/0073-pinctrl-qom-use-scm_call-to-route-GPIO-irq-to-Apps.patch
+++ b/target/linux/ipq806x/patches-4.9/0073-pinctrl-qom-use-scm_call-to-route-GPIO-irq-to-Apps.patch
@@ -1,0 +1,166 @@
+From 2034addc7e193dc81d7ca60d8884832751b76758 Mon Sep 17 00:00:00 2001
+From: Ajay Kishore <akisho@codeaurora.org>
+Date: Tue, 24 Jan 2017 14:14:16 +0530
+Subject: pinctrl: qcom: use scm_call to route GPIO irq to Apps
+
+For IPQ806x targets, TZ protects the registers that are used to
+configure the routing of interrupts to a target processor.
+To resolve this, this patch uses scm call to route GPIO interrupts
+to application processor. Also the scm call interface is changed.
+
+Change-Id: Ib6c06829d04bc8c20483c36e63da92e26cdef9ce
+Signed-off-by: Ajay Kishore <akisho@codeaurora.org>
+---
+ drivers/firmware/qcom_scm-32.c     | 17 +++++++++++++++++
+ drivers/firmware/qcom_scm-64.c     |  9 +++++++++
+ drivers/firmware/qcom_scm.c        | 13 +++++++++++++
+ drivers/firmware/qcom_scm.h        |  8 ++++++++
+ drivers/pinctrl/qcom/pinctrl-msm.c | 34 ++++++++++++++++++++++++++++------
+ include/linux/qcom_scm.h           |  3 ++-
+ 6 files changed, 77 insertions(+), 7 deletions(-)
+
+--- a/drivers/firmware/qcom_scm-32.c
++++ b/drivers/firmware/qcom_scm-32.c
+@@ -560,3 +560,21 @@ int __qcom_scm_pas_mss_reset(struct devi
+ 
+ 	return ret ? : le32_to_cpu(out);
+ }
++
++int __qcom_scm_pinmux_read(u32 svc_id, u32 cmd_id, u32 arg1)
++{
++	s32 ret;
++
++	ret = qcom_scm_call_atomic1(svc_id, cmd_id, arg1);
++
++	return ret;
++}
++
++int __qcom_scm_pinmux_write(u32 svc_id, u32 cmd_id, u32 arg1, u32 arg2)
++{
++	s32 ret;
++
++	ret = qcom_scm_call_atomic2(svc_id, cmd_id, arg1, arg2);
++ 
++ return ret;
++ }
+--- a/drivers/firmware/qcom_scm-64.c
++++ b/drivers/firmware/qcom_scm-64.c
+@@ -358,3 +358,12 @@ int __qcom_scm_pas_mss_reset(struct devi
+ 
+ 	return ret ? : res.a1;
+ }
++int __qcom_scm_pinmux_read(u32 svc_id, u32 cmd_id, u32 arg1)
++{
++	return -ENOTSUPP;
++}
++
++int __qcom_scm_pinmux_write(u32 svc_id, u32 cmd_id, u32 arg1, u32 arg2)
++{
++	return -ENOTSUPP;
++}
+--- a/drivers/firmware/qcom_scm.c
++++ b/drivers/firmware/qcom_scm.c
+@@ -443,3 +443,16 @@ static int __init qcom_scm_init(void)
+ 	return platform_driver_register(&qcom_scm_driver);
+ }
+ subsys_initcall(qcom_scm_init);
++
++int qcom_scm_pinmux_read(u32 arg1)
++{
++	return __qcom_scm_pinmux_read(SCM_SVC_IO_ACCESS, SCM_IO_READ, arg1);
++}
++EXPORT_SYMBOL(qcom_scm_pinmux_read);
++
++int qcom_scm_pinmux_write(u32 arg1, u32 arg2)
++{
++	return __qcom_scm_pinmux_write(SCM_SVC_IO_ACCESS, SCM_IO_WRITE,
++					arg1, arg2);
++}
++EXPORT_SYMBOL(qcom_scm_pinmux_write);
+--- a/drivers/firmware/qcom_scm.h
++++ b/drivers/firmware/qcom_scm.h
+@@ -56,6 +56,13 @@ extern int  __qcom_scm_pas_auth_and_rese
+ extern int  __qcom_scm_pas_shutdown(struct device *dev, u32 peripheral);
+ extern int  __qcom_scm_pas_mss_reset(struct device *dev, bool reset);
+ 
++#define SCM_IO_READ	1
++#define SCM_IO_WRITE	2
++#define SCM_SVC_IO_ACCESS	0x5
++
++s32 __qcom_scm_pinmux_read(u32 svc_id, u32 cmd_id, u32 arg1);
++s32 __qcom_scm_pinmux_write(u32 svc_id, u32 cmd_id, u32 arg1, u32 arg2);
++
+ /* common error codes */
+ #define QCOM_SCM_V2_EBUSY	-12
+ #define QCOM_SCM_ENOMEM		-5
+--- a/drivers/pinctrl/qcom/pinctrl-msm.c
++++ b/drivers/pinctrl/qcom/pinctrl-msm.c
+@@ -30,7 +30,8 @@
+ #include <linux/reboot.h>
+ #include <linux/pm.h>
+ #include <linux/log2.h>
+-
++#include <linux/qcom_scm.h>
++#include <linux/io.h>
+ #include "../core.h"
+ #include "../pinconf.h"
+ #include "pinctrl-msm.h"
+@@ -639,6 +640,9 @@ static int msm_gpio_irq_set_type(struct
+ 	const struct msm_pingroup *g;
+ 	unsigned long flags;
+ 	u32 val;
++	u32 addr;
++	int ret;
++	const __be32 *reg;
+ 
+ 	g = &pctrl->soc->groups[d->hwirq];
+ 
+@@ -652,11 +656,30 @@ static int msm_gpio_irq_set_type(struct
+ 	else
+ 		clear_bit(d->hwirq, pctrl->dual_edge_irqs);
+ 
++	ret = of_device_is_compatible(pctrl->dev->of_node,
++					"qcom,ipq8064-pinctrl");
+ 	/* Route interrupts to application cpu */
+-	val = readl(pctrl->regs + g->intr_target_reg);
+-	val &= ~(7 << g->intr_target_bit);
+-	val |= g->intr_target_kpss_val << g->intr_target_bit;
+-	writel(val, pctrl->regs + g->intr_target_reg);
++	if (!ret) {
++		val = readl(pctrl->regs + g->intr_target_reg);
++		val &= ~(7 << g->intr_target_bit);
++		val |= g->intr_target_kpss_val << g->intr_target_bit;
++		writel(val, pctrl->regs + g->intr_target_reg);
++	} else {
++		reg = of_get_property(pctrl->dev->of_node, "reg", NULL);
++		if (reg) {
++			addr = be32_to_cpup(reg) + g->intr_target_reg;
++			val = qcom_scm_pinmux_read(addr);
++			__iormb();
++
++			val &= ~(7 << g->intr_target_bit);
++			val |= g->intr_target_kpss_val << g->intr_target_bit;
++
++			__iowmb();
++			ret = qcom_scm_pinmux_write(addr, val);
++			if (ret)
++				pr_err("\n Routing interrupts to Apps proc failed");
++		}
++	}
+ 
+ 	/* Update configuration for gpio.
+ 	 * RAW_STATUS_EN is left on for all gpio irqs. Due to the
+@@ -930,4 +953,3 @@ int msm_pinctrl_remove(struct platform_d
+ 	return 0;
+ }
+ EXPORT_SYMBOL(msm_pinctrl_remove);
+-
+--- a/include/linux/qcom_scm.h
++++ b/include/linux/qcom_scm.h
+@@ -46,4 +46,6 @@ extern void qcom_scm_cpu_power_down(u32
+ 
+ extern u32 qcom_scm_get_version(void);
+ 
++extern s32 qcom_scm_pinmux_read(u32 arg1);
++extern s32 qcom_scm_pinmux_write(u32 arg1, u32 arg2);
+ #endif


### PR DESCRIPTION
**1. ipq806x: remove scm firmware clocks**
At the moment as a workaround definition for scm firmware in DT is used as if it is apq8064 board. This leads to incomplete scm firmware initialization and as a result cpuidle driver fails to configure.

By design unlike other qcom boards ipq do not use clocks to connect to scm.

Considering this we're removing clocks for ipq boards from DT and scm driver.

As a result cpuidle does not produce errors about failed configuration anymore.

**2. ipq806x: route gpio interrupts to APPS processor through scm firmware**
For IPQ806x targets, TZ protects the registers that are used to configure the routing of interrupts to a target processor.
To resolve this, this patch uses scm call to route GPIO interrupts to application processor. Also the scm call interface is changed.

@hnyman 