### PR TITLE
mvebu: Enable eSATA on Linksys WRT-devices

### DIFF
--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -100,6 +100,7 @@ define Device/linksys-wrt1200ac
   $(call Device/linksys,WRT1200AC (Caiman))
   $(Device/armada-385-linksys)
   DEVICE_DTS := armada-385-linksys-caiman
+  DEVICE_PACKAGES += kmod-ata-core kmod-ata-ahci kmod-ata-ahci-platform
 endef
 TARGET_DEVICES += linksys-wrt1200ac
 
@@ -107,6 +108,7 @@ define Device/linksys-wrt1900acv2
   $(call Device/linksys,WRT1900ACv2 (Cobra))
   $(Device/armada-385-linksys)
   DEVICE_DTS := armada-385-linksys-cobra
+  DEVICE_PACKAGES += kmod-ata-core kmod-ata-ahci kmod-ata-ahci-platform
 endef
 TARGET_DEVICES += linksys-wrt1900acv2
 
@@ -114,7 +116,7 @@ define Device/linksys-wrt3200acm
   $(call Device/linksys,WRT3200ACM (Rango))
   $(Device/armada-385-linksys)
   DEVICE_DTS := armada-385-linksys-rango
-  DEVICE_PACKAGES += kmod-mwifiex-sdio
+  DEVICE_PACKAGES += kmod-mwifiex-sdio kmod-ata-core kmod-ata-ahci kmod-ata-ahci-platform
 endef
 TARGET_DEVICES += linksys-wrt3200acm
 
@@ -122,12 +124,14 @@ define Device/linksys-wrt1900acs
   $(call Device/linksys,WRT1900ACS (Shelby))
   $(Device/armada-385-linksys)
   DEVICE_DTS := armada-385-linksys-shelby
+  DEVICE_PACKAGES += kmod-ata-core kmod-ata-ahci kmod-ata-ahci-platform
 endef
 TARGET_DEVICES += linksys-wrt1900acs
 
 define Device/linksys-wrt1900ac
   $(call Device/linksys,WRT1900AC (Mamba))
   DEVICE_DTS := armada-xp-linksys-mamba
+  DEVICE_PACKAGES += kmod-ata-core kmod-ata-ahci kmod-ata-ahci-platform
   $(Device/NAND-128K)
   $(Device/UBI-factory)
   KERNEL_SIZE := 3072k


### PR DESCRIPTION
Enable eSATA port on WRT1200AC, WRT1900AC, WRT1900ACv2, WRT3200ACM
and WRT1900ACS by default.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>