### PR TITLE
patch-kernel.sh: handle broken tarballs w/ 444 mode files

### DIFF
--- a/scripts/patch-kernel.sh
+++ b/scripts/patch-kernel.sh
@@ -36,6 +36,9 @@ for i in ${patchdir}/${patchpattern} ; do
     esac
     [ -d "${i}" ] && echo "Ignoring subdirectory ${i}" && continue	
     echo ""
+    # because some people publish tarballs containing files with modes u-w
+    awk -e '/^\+\+\+ / { n = match($2, "/"); print substr($2, n + 1); }' "${i}" \
+      | xargs -i chmod -f u+w "$targetdir/{}"
     echo "Applying ${i} using ${type}: " 
     ${uncomp} ${i} | ${PATCH:-patch} -f -p1 -d ${targetdir}
     if [ $? != 0 ] ; then


### PR DESCRIPTION
Occasionally someone publishes a tarball not expecting any of the
source files to be modified (i.e. patched).  This naïve (or perhaps
overly optimistic) assumption breaks our machinery when we do end
up having to patch said files.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
