### PR TITLE
x86_64: add CPU_TYPE options for all compiler-supported archs

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -174,6 +174,13 @@ ifeq ($(DUMP),1)
     CPU_CFLAGS_pentium = -march=pentium-mmx
     CPU_CFLAGS_pentium4 = -march=pentium4
   endif
+  ifeq ($(ARCH),x86_64)
+    CPU_TYPE ?= x86_64
+    ifneq ($(findstring $(CPU_TYPE), nocona core2 nehalem westmere sandybridge ivybridge haswell broadwell bonnell silvermont knl k8 opteron athlon64 athlon-fx k8-sse3 opteron-sse3 athlon64-sse3 amdfam10 barcelona bdver1 bdver2 bdver3 bdver4 btver1 btver2),)
+       CPU_CFLAGS_$(CPU_TYPE) = -march=$(CPU_TYPE)
+    endif
+    CPU_CFLAGS_x86_64 = -march=x86-64
+  endif
   ifneq ($(findstring arm,$(ARCH)),)
     CPU_TYPE ?= xscale
     CPU_CFLAGS_arm920t = -mcpu=arm920t


### PR DESCRIPTION
The user should be able to tune the instruction set (and scheduling)
to be optimal for that processor he desires.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
