### PR TITLE
gpio-ich/itco-wdt/w83627hf-wdt: add modules for Xeon platforms

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -1018,3 +1018,18 @@ define KernelPackage/tpm-i2c-infineon/description
 endef
 
 $(eval $(call KernelPackage,tpm-i2c-infineon))
+
+
+define KernelPackage/w83627hf-wdt
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Winbond 83627HF Watchdog Timer
+  KCONFIG:=CONFIG_W83627HF_WDT
+  FILES:=$(LINUX_DIR)/drivers/$(WATCHDOG_DIR)/w83627hf_wdt.ko
+  AUTOLOAD:=$(call AutoLoad,50,w83627hf-wdt,1)
+endef
+
+define KernelPackage/w83627hf-wdt/description
+  Kernel module for Winbond 83627HF Watchdog Timer
+endef
+
+$(eval $(call KernelPackage,w83627hf-wdt))


### PR DESCRIPTION
Drivers for supporting current Xeon motherboards.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
