### PR TITLE
kernel: add thermal monitor for nct6775/6776, et al

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -93,6 +93,21 @@ endef
 $(eval $(call KernelPackage,hwmon-ina209))
 
 
+define KernelPackage/hwmon-nct6775
+  TITLE:=NCT6106D/6775F/6776F/6779D/6791D/6792D/6793D and compatibles monitoring support
+  KCONFIG:=CONFIG_SENSORS_NCT6775
+  FILES:=$(LINUX_DIR)/drivers/hwmon/nct6775.ko
+  AUTOLOAD:=$(call AutoProbe,nct6775)
+  $(call AddDepends/hwmon,@PCI_SUPPORT @TARGET_x86 +kmod-hwmon-vid)
+endef
+
+define KernelPackage/hwmon-nct6775/description
+ Kernel module for NCT6106D/6775F/6776F/6779D/6791D/6792D/6793D thermal monitor chip
+endef
+
+$(eval $(call KernelPackage,hwmon-nct6775))
+
+
 define KernelPackage/hwmon-ina2xx
   TITLE:=INA2XX monitoring support
   KCONFIG:=CONFIG_SENSORS_INA2XX


### PR DESCRIPTION
Support for the nct6775/6776 hwmon chips, and other compatibles
in the family as well as the Intel on-chip thermal sensors.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
