### PR TITLE
build: allow specifying flow-control to grub on serial console

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -203,6 +203,11 @@ menu "Target Images"
 		default 38400 if TARGET_x86_generic
 		default 115200
 
+	config GRUB_FLOWCONTROL
+		bool "Use RTE/CTS on serial console"
+		depends on GRUB_SERIAL != ""
+		default n
+
 	config GRUB_BOOTOPTS
 		string "Extra kernel boot options"
 		depends on GRUB_IMAGES

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -32,8 +32,8 @@ endif
 GRUB_SERIAL:=$(call qstrip,$(CONFIG_GRUB_SERIAL))
 
 ifneq ($(GRUB_SERIAL),)
-  GRUB_CONSOLE_CMDLINE += console=$(GRUB_SERIAL),$(CONFIG_GRUB_BAUDRATE)n8
-  GRUB_SERIAL_CONFIG := serial --unit=0 --speed=$(CONFIG_GRUB_BAUDRATE) --word=8 --parity=no --stop=1 --rtscts=off
+  GRUB_CONSOLE_CMDLINE += console=$(GRUB_SERIAL),$(CONFIG_GRUB_BAUDRATE)n8$(if $(CONFIG_GRUB_FLOWCONTROL),r,)
+  GRUB_SERIAL_CONFIG := serial --unit=0 --speed=$(CONFIG_GRUB_BAUDRATE) --word=8 --parity=no --stop=1 --rtscts=$(if $(CONFIG_GRUB_FLOWCONTROL),on,off)
   GRUB_TERMINALS += serial
 endif
 


### PR DESCRIPTION
On the more sophisticated (i.e. deeper FIFO) serial controllers,
flow-control might be needed to avoid dropping output.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
