### PR TITLE
kexec-tools: get kexec running on MUSL and x86 hardware

### DIFF
--- a/package/boot/kexec-tools/patches/120-fail-to-get-symbol-debug.patch
+++ b/package/boot/kexec-tools/patches/120-fail-to-get-symbol-debug.patch
@@ -1,0 +1,33 @@
+commit 263e45ccf27b21e9862cc538ed28978533d04e4b
+Author: Baoquan He <bhe@redhat.com>
+Date:   Fri Mar 3 11:52:15 2017 +0800
+
+    Only print debug message when failed to serach for kernel symbol from /proc/kallsyms
+    
+    Kernel symbol page_offset_base could be unavailable when mm KASLR code is
+    not compiled in kernel. It's inappropriate to print out error message
+    when failed to search for page_offset_base from /proc/kallsyms. Seems now
+    there is not a way to find out if mm KASLR is compiled in or not. An
+    alternative approach is only printing out debug message in get_kernel_sym
+    if failed to search a expected kernel symbol.
+    
+    Do it in this patch, a simple fix.
+    
+    Signed-off-by: Baoquan He <bhe@redhat.com>
+    Reviewed-by: Pratyush Anand <panand@redhat.com>
+    Acked-by: Dave Young <dyoung@redhat.com>
+    Signed-off-by: Simon Horman <horms@verge.net.au>
+
+diff --git a/kexec/arch/i386/crashdump-x86.c b/kexec/arch/i386/crashdump-x86.c
+index 88aeee3..c4cf201 100644
+--- a/kexec/arch/i386/crashdump-x86.c
++++ b/kexec/arch/i386/crashdump-x86.c
+@@ -127,7 +127,7 @@ static unsigned long long get_kernel_sym(const char *symbol)
+ 		}
+ 	}
+ 
+-	fprintf(stderr, "Cannot get kernel %s symbol address\n", symbol);
++	dbgprintf("Cannot get kernel %s symbol address\n", symbol);
+ 	return 0;
+ }
+ 

--- a/package/boot/kexec-tools/patches/130-dont-use-percentL.patch
+++ b/package/boot/kexec-tools/patches/130-dont-use-percentL.patch
@@ -1,0 +1,178 @@
+commit f14881e87b1426d2c439e2fad9a1e03a3b35e196
+Author: Philip Prindeville <philipp@redfish-solutions.com>
+Date:   Fri Mar 10 19:57:11 2017 -0700
+
+    Don't use %L width specifier with integer values
+    
+    MUSL doesn't support %L except for floating-point arguments; therefore,
+    %ll must be used instead with integer arguments.
+    
+    Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
+
+diff --git a/kexec/arch/arm/kexec-arm.c b/kexec/arch/arm/kexec-arm.c
+index 2194b7c..49f35b1 100644
+--- a/kexec/arch/arm/kexec-arm.c
++++ b/kexec/arch/arm/kexec-arm.c
+@@ -47,7 +47,7 @@ int get_memory_ranges(struct memory_range **range, int *ranges,
+ 		int count;
+ 		if (memory_ranges >= MAX_MEMORY_RANGES)
+ 			break;
+-		count = sscanf(line, "%Lx-%Lx : %n",
++		count = sscanf(line, "%llx-%llx : %n",
+ 			&start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+diff --git a/kexec/arch/i386/crashdump-x86.c b/kexec/arch/i386/crashdump-x86.c
+index c4cf201..285dea9 100644
+--- a/kexec/arch/i386/crashdump-x86.c
++++ b/kexec/arch/i386/crashdump-x86.c
+@@ -119,7 +119,7 @@ static unsigned long long get_kernel_sym(const char *symbol)
+ 	}
+ 
+ 	while(fgets(line, sizeof(line), fp) != NULL) {
+-		if (sscanf(line, "%Lx %c %s", &vaddr, &type, sym) != 3)
++		if (sscanf(line, "%llx %c %s", &vaddr, &type, sym) != 3)
+ 			continue;
+ 		if (strcmp(sym, symbol) == 0) {
+ 			dbgprintf("kernel symbol %s vaddr = %16llx\n", symbol, vaddr);
+@@ -296,12 +296,12 @@ static int get_crash_memory_ranges(struct memory_range **range, int *ranges,
+ 
+ 		if (memory_ranges >= CRASH_MAX_MEMORY_RANGES)
+ 			break;
+-		count = sscanf(line, "%Lx-%Lx : %n",
++		count = sscanf(line, "%llx-%llx : %n",
+ 			&start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+ 		str = line + consumed;
+-		dbgprintf("%016Lx-%016Lx : %s",
++		dbgprintf("%016llx-%016llx : %s",
+ 			start, end, str);
+ 		/* Only Dumping memory of type System RAM. */
+ 		if (memcmp(str, "System RAM\n", 11) == 0) {
+@@ -778,7 +778,7 @@ static int get_crash_notes(int cpu, uint64_t *addr, uint64_t *len)
+ 		*addr = x86__pa(vaddr + (cpu * MAX_NOTE_BYTES));
+ 		*len = MAX_NOTE_BYTES;
+ 
+-		dbgprintf("crash_notes addr = %Lx\n",
++		dbgprintf("crash_notes addr = %llx\n",
+ 			  (unsigned long long)*addr);
+ 
+ 		fclose(fp);
+diff --git a/kexec/arch/i386/kexec-x86-common.c b/kexec/arch/i386/kexec-x86-common.c
+index 3e97239..be03618 100644
+--- a/kexec/arch/i386/kexec-x86-common.c
++++ b/kexec/arch/i386/kexec-x86-common.c
+@@ -81,7 +81,7 @@ static int get_memory_ranges_proc_iomem(struct memory_range **range, int *ranges
+ 		int count;
+ 		if (memory_ranges >= MAX_MEMORY_RANGES)
+ 			break;
+-		count = sscanf(line, "%Lx-%Lx : %n",
++		count = sscanf(line, "%llx-%llx : %n",
+ 			&start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+diff --git a/kexec/arch/ia64/kexec-elf-rel-ia64.c b/kexec/arch/ia64/kexec-elf-rel-ia64.c
+index 7f7c08c..500f247 100644
+--- a/kexec/arch/ia64/kexec-elf-rel-ia64.c
++++ b/kexec/arch/ia64/kexec-elf-rel-ia64.c
+@@ -155,6 +155,6 @@ void machine_apply_elf_rel(struct mem_ehdr *ehdr,
+ 	}
+ 	return;
+ overflow:
+-	die("overflow in relocation type %lu val %Lx\n", 
++	die("overflow in relocation type %lu val %llx\n",
+ 			r_type, value);
+ }
+diff --git a/kexec/arch/mips/crashdump-mips.c b/kexec/arch/mips/crashdump-mips.c
+index 9c33599..6308ec8 100644
+--- a/kexec/arch/mips/crashdump-mips.c
++++ b/kexec/arch/mips/crashdump-mips.c
+@@ -173,7 +173,7 @@ static int get_crash_memory_ranges(struct memory_range **range, int *ranges)
+ 		int type, consumed, count;
+ 		if (memory_ranges >= CRASH_MAX_MEMORY_RANGES)
+ 			break;
+-		count = sscanf(line, "%Lx-%Lx : %n",
++		count = sscanf(line, "%llx-%llx : %n",
+ 			&start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+diff --git a/kexec/arch/mips/kexec-mips.c b/kexec/arch/mips/kexec-mips.c
+index ee3cd3a..2e5b700 100644
+--- a/kexec/arch/mips/kexec-mips.c
++++ b/kexec/arch/mips/kexec-mips.c
+@@ -48,7 +48,7 @@ int get_memory_ranges(struct memory_range **range, int *ranges,
+ 	while (fgets(line, sizeof(line), fp) != 0) {
+ 		if (memory_ranges >= MAX_MEMORY_RANGES)
+ 			break;
+-		count = sscanf(line, "%Lx-%Lx : %n", &start, &end, &consumed);
++		count = sscanf(line, "%llx-%llx : %n", &start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+ 		str = line + consumed;
+diff --git a/kexec/arch/s390/kexec-s390.c b/kexec/arch/s390/kexec-s390.c
+index f863483..33ba6b9 100644
+--- a/kexec/arch/s390/kexec-s390.c
++++ b/kexec/arch/s390/kexec-s390.c
+@@ -170,7 +170,7 @@ int get_memory_ranges_s390(struct memory_range memory_range[], int *ranges,
+ 		if (current_range == MAX_MEMORY_RANGES)
+ 			break;
+ 
+-		sscanf(line,"%Lx-%Lx : %n", &start, &end, &cons);
++		sscanf(line,"%llx-%llx : %n", &start, &end, &cons);
+ 		str = line+cons;
+ 		if ((memcmp(str, sys_ram, strlen(sys_ram)) == 0) ||
+ 		    ((memcmp(str, crash_kernel, strlen(crash_kernel)) == 0) &&
+diff --git a/kexec/crashdump.c b/kexec/crashdump.c
+index 15c1105..0b363c5 100644
+--- a/kexec/crashdump.c
++++ b/kexec/crashdump.c
+@@ -98,7 +98,7 @@ int get_crash_notes_per_cpu(int cpu, uint64_t *addr, uint64_t *len)
+ 	}
+ 	if (!fgets(line, sizeof(line), fp))
+ 		die("Cannot parse %s: %s\n", crash_notes, strerror(errno));
+-	count = sscanf(line, "%Lx", &temp);
++	count = sscanf(line, "%llx", &temp);
+ 	if (count != 1)
+ 		die("Cannot parse %s: %s\n", crash_notes, strerror(errno));
+ 	*addr = (uint64_t) temp;
+@@ -112,7 +112,7 @@ int get_crash_notes_per_cpu(int cpu, uint64_t *addr, uint64_t *len)
+ 		if (!fgets(line, sizeof(line), fp))
+ 			die("Cannot parse %s: %s\n",
+ 			    crash_notes_size, strerror(errno));
+-		count = sscanf(line, "%Lu", &temp);
++		count = sscanf(line, "%llu", &temp);
+ 		if (count != 1)
+ 			die("Cannot parse %s: %s\n",
+ 			    crash_notes_size, strerror(errno));
+@@ -120,7 +120,7 @@ int get_crash_notes_per_cpu(int cpu, uint64_t *addr, uint64_t *len)
+ 		fclose(fp);
+ 	}
+ 
+-	dbgprintf("%s: crash_notes addr = %Lx, size = %Lu\n", __FUNCTION__,
++	dbgprintf("%s: crash_notes addr = %llx, size = %llu\n", __FUNCTION__,
+ 		  (unsigned long long)*addr, (unsigned long long)*len);
+ 
+ 	return 0;
+@@ -141,7 +141,7 @@ static int get_vmcoreinfo(const char *kdump_info, uint64_t *addr, uint64_t *len)
+ 
+ 	if (!fgets(line, sizeof(line), fp))
+ 		die("Cannot parse %s: %s\n", kdump_info, strerror(errno));
+-	count = sscanf(line, "%Lx %Lx", &temp, &temp2);
++	count = sscanf(line, "%llx %llx", &temp, &temp2);
+ 	if (count != 2)
+ 		die("Cannot parse %s: %s\n", kdump_info, strerror(errno));
+ 
+diff --git a/kexec/kexec-iomem.c b/kexec/kexec-iomem.c
+index 485a2e8..7ec3853 100644
+--- a/kexec/kexec-iomem.c
++++ b/kexec/kexec-iomem.c
+@@ -44,7 +44,7 @@ int kexec_iomem_for_each_line(char *match,
+ 		die("Cannot open %s\n", iomem);
+ 
+ 	while(fgets(line, sizeof(line), fp) != 0) {
+-		count = sscanf(line, "%Lx-%Lx : %n", &start, &end, &consumed);
++		count = sscanf(line, "%llx-%llx : %n", &start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+ 		str = line + consumed;


### PR DESCRIPTION
Couple of important upstream patches (slated for 2.0.15) that
are necessary for kexec to run on MUSL and on x86 hardware.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
