### PR TITLE
utils/util-linux: Disable more

### DIFF
--- a/package/utils/util-linux/Makefile
+++ b/package/utils/util-linux/Makefile
@@ -440,6 +440,7 @@ CONFIGURE_ARGS += \
 	--without-python	\
 	--without-udev		\
 	--without-readline	\
+	--disable-more		\
 	$(if $(CONFIG_PACKAGE_cal)$(CONFIG_PACKAGE_cfdisk)$(CONFIG_PACKAGE_setterm),--with-ncursesw,--without-ncurses)
 
 TARGET_CFLAGS += $(FPIC) -std=gnu99


### PR DESCRIPTION
Disable more as it fails to build on some platforms as a quick-fix.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>