### PR TITLE
mac80211: ath10k: allow failure getting board id via otp

### DIFF
--- a/package/kernel/mac80211/patches/936-ath10k-fix-otp-failure-result.patch
+++ b/package/kernel/mac80211/patches/936-ath10k-fix-otp-failure-result.patch
@@ -1,0 +1,11 @@
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -686,7 +686,7 @@
+ 	if (ret) {
+ 		ath10k_err(ar, "could not execute otp for board id check: %d\n",
+ 			   ret);
+-		return ret;
++		return -EOPNOTSUPP;
+ 	}
+ 
+ 	board_id = MS(result, ATH10K_BMI_BOARD_ID_FROM_OTP);


### PR DESCRIPTION
**Fix the currently broken wifi for existing ipq806x devices**

ath10k tries to fetch board id via otp, but that fails for many chips like QCA988x, QCA9984 etc. Recent commit cc189c0b7f that introduced support for QCA4019 removed the earlier hack that had allowed the existing QCA radios to work, as that hack was incompatible with QCA4019.

Restore functionality for the already existing wifi chips by modifying the return value of the 'board id via otp' function to a value that is recognised as a harmless error, so that name evaluation continues by using the board file.

Reference to discusion starting from
https://forum.lede-project.org/t/netgear-r7800-exploration-ipq8065-qca9984/285/267

Patch originally suggested by Christian Lamparter (@chunkeey ) in forum discussion:
https://forum.lede-project.org/t/netgear-r7800-exploration-ipq8065-qca9984/285/276

Run-tested with R7800 / ipq806x at r3850-dce3b0057b 

### Explanation of the patch:

The return value of "ath10k_core_get_board_id_from_otp" is set to be -EOPNOTSUPP when there is failure, as the function "ath10k_core_probe_fw" allows just that error code as a "harmless" failure for the otp board id check call. If it sees that error it uses the board file as a backup source.

* line 688 at https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/tree/drivers/net/wireless/ath/ath10k/core.c?h=linux-4.9.y#n651
* line 2108 here: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/tree/drivers/net/wireless/ath/ath10k/core.c?h=linux-4.9.y#n2107

Kernel log for one radio with the patch applied:
```
[   15.958930] ath10k_pci 0000:01:00.0: enabling device (0140 -> 0142)
[   15.959015] ath10k_pci 0000:01:00.0: enabling bus mastering
[   15.959568] ath10k_pci 0000:01:00.0: pci irq msi oper_irq_mode 2 irq_mode 0 reset_mode 0
[   16.132726] ath10k_pci 0000:01:00.0: Direct firmware load for ath10k/pre-cal-pci-0000:01:00.0.bin failed with error -2
[   16.132769] ath10k_pci 0000:01:00.0: Falling back to user helper
[   22.663013] firmware ath10k!pre-cal-pci-0000:01:00.0.bin: firmware_loading_store: map pages failed
[   22.663241] ath10k_pci 0000:01:00.0: Direct firmware load for ath10k/cal-pci-0000:01:00.0.bin failed with error -2
[   22.670982] ath10k_pci 0000:01:00.0: Falling back to user helper
[   23.164668] ath10k_pci 0000:01:00.0: qca9984/qca9994 hw1.0 target 0x01000000 chip_id 0x00000000 sub 168c:cafe
[   23.164709] ath10k_pci 0000:01:00.0: kconfig debug 0 debugfs 1 tracing 0 dfs 1 testmode 1
[   23.178058] ath10k_pci 0000:01:00.0: firmware ver 10.4-3.4-00074 api 5 features no-p2p,mfp,peer-flow-ctrl,btcoex-param,allows-mesh-bcast crc32 fa32e88e
[   25.219282] ath10k_pci 0000:01:00.0: unable to read from the device
[   25.219306] ath10k_pci 0000:01:00.0: could not execute otp for board id check: -110
[   25.237356] ath10k_pci 0000:01:00.0: failed to fetch board data for bus=pci,vendor=168c,device=0046,subsystem-vendor=168c,subsystem-device=cafem
[   25.237356] ??????,? from ath10k/QCA9984/hw1.0/board-2.bin
[   25.238117] ath10k_pci 0000:01:00.0: board_file api 1 bmi_id N/A crc32 dd636801
[   26.754733] ath10k_pci 0000:01:00.0: htt-ver 2.2 wmi-op 6 htt-op 4 cal file max-sta 512 raw 0 hwcrypto 1
[   26.842026] ath: EEPROM regdomain: 0x0
[   26.842035] ath: EEPROM indicates default country code should be used
[   26.842041] ath: doing EEPROM country->regdmn map search
[   26.842052] ath: country maps to regdmn code: 0x3a
[   26.842061] ath: Country alpha2 being used: US
[   26.842068] ath: Regpair used: 0x3a
```

@blogic @chunkeey @dissent1 
