### PR TITLE
ar71xx: wpj531: fix GPIOs for LED

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-wpj531.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-wpj531.c
@@ -35,10 +35,10 @@
 #include "dev-wmac.h"
 #include "machtypes.h"
 
-#define WPJ531_GPIO_LED_SIG1    14
-#define WPJ531_GPIO_LED_SIG2    15
-#define WPJ531_GPIO_LED_SIG3    22
-#define WPJ531_GPIO_LED_SIG4    23
+#define WPJ531_GPIO_LED_SIG1    13
+#define WPJ531_GPIO_LED_SIG2    14
+#define WPJ531_GPIO_LED_SIG3    15
+#define WPJ531_GPIO_LED_SIG4    16
 #define WPJ531_GPIO_BUZZER      4
 
 #define WPJ531_GPIO_BTN_RESET   17


### PR DESCRIPTION
The existing values match those in the compex wiki and this document:

http://www.compex.com.sg/wp-content/uploads/2017/01/WPJ531-Hardware-Guide-v1.pdf

That document also contains different values for GPIO pins in the `LED Header` table (`Up pin`).
Those second values produce working LED initialisation.

On 7A03, the LEDs are working with this patch.
Should someone with access to a 7A04 confirm?