### PR TITLE
kernel: Fix F2FS module dependencies

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -200,6 +200,7 @@ $(eval $(call KernelPackage,fs-ext4))
 define KernelPackage/fs-f2fs
   SUBMENU:=$(FS_MENU)
   TITLE:=F2FS filesystem support
+  DEPENDS:= +kmod-crypto-hash +kmod-crypto-crc32
   KCONFIG:= \
 	CONFIG_F2FS_FS \
 	CONFIG_F2FS_STAT_FS=y \


### PR DESCRIPTION
F2FS depends on the crc32_generic module (NOT crc32c_generic)

This PR depends on the kmod-crypto-crc32 PR:

https://github.com/lede-project/source/pull/998

Briefly, in kernel 4.6+, the F2FS module requires the "crc32" module (crc32_generic.ko).
The crc32c_generic.ko module is not sufficient for F2FS at this time.  This PR, and the aforementioned PR, adds the crc32_generic module in the package kmod-crypto-crc32, and explicitly makes the F2FS package depend on that.

Signed-off-by: Shane Peelar <lookatyouhacker@gmail.com>
