### PR TITLE
package/boot/uboot-kirkwood: fix build errors for nsa310 and nsa325

### DIFF
--- a/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
@@ -528,10 +528,11 @@ new file mode 100644
 index 0000000..d26ef35
 --- /dev/null
 +++ b/configs/nsa310_defconfig
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,22 @@
 +CONFIG_ARM=y
 +CONFIG_KIRKWOOD=y
 +CONFIG_TARGET_NSA310=y
++CONFIG_IDENT_STRING="\nZyXEL NSA310 1-Bay Power Media Server"
 +CONFIG_BOOTDELAY=3
 +CONFIG_SYS_PROMPT="NSA310> "
 +# CONFIG_CMD_IMLS is not set
@@ -541,11 +542,13 @@ index 0000000..d26ef35
 +CONFIG_OF_LIBFDT=y
 +CONFIG_CMD_SETEXPR=y
 +CONFIG_CMD_DHCP=y
-+CONFIG_CMD_NAND=y
++CONFIG_CMD_MII=y
 +CONFIG_CMD_PING=y
 +CONFIG_CMD_USB=y
 +CONFIG_CMD_EXT2=y
 +CONFIG_CMD_FAT=y
++CONFIG_EFI_PARTITION=y
++CONFIG_CMD_UBI=y
 +CONFIG_USB=y
 +CONFIG_USB_STORAGE=y
 diff --git a/include/configs/nsa310.h b/include/configs/nsa310.h
@@ -553,7 +556,7 @@ new file mode 100644
 index 0000000..86ef825
 --- /dev/null
 +++ b/include/configs/nsa310.h
-@@ -0,0 +1,168 @@
+@@ -0,0 +1,144 @@
 +/* Copyright (C) 2015-2016 bodhi <mibodhi@gmail.com>
 + *
 + * Based on
@@ -587,12 +590,6 @@ index 0000000..86ef825
 +#define _CONFIG_NSA310_H
 +
 +/*
-+ * Version number information
-+ */
-+
-+#define CONFIG_IDENT_STRING	"\nZyXEL NSA310 1-Bay Power Media Server \n"
-+
-+/*
 + * High Level Configuration Options (easy to change)
 + */
 +#define CONFIG_FEROCEON_88FR131		/* CPU Core subversion */
@@ -608,15 +605,9 @@ index 0000000..86ef825
 +/*
 + * Commands configuration
 + */
-+#define CONFIG_SYS_NO_FLASH		/* Declare no flash (NOR/SPI) */
-+#define CONFIG_SYS_MVFS                 /* Picks up Filesystem from mv-common.h */
-+#define CONFIG_CMD_DHCP
 +#define CONFIG_CMD_ENV
 +#define CONFIG_CMD_IDE
-+#define CONFIG_CMD_MII
 +#define CONFIG_CMD_NAND
-+#define CONFIG_CMD_PING
-+#define CONFIG_CMD_USB
 +#define CONFIG_CMD_DATE
 +#define CONFIG_SYS_LONGHELP
 +#define CONFIG_PREBOOT
@@ -628,10 +619,6 @@ index 0000000..86ef825
 + * to enable certain macros
 + */
 +#include "mv-common.h"
-+
-+/* Remove or override few declarations from mv-common.h */
-+#undef CONFIG_SYS_PROMPT	/* previously defined in mv-common.h */
-+#define CONFIG_SYS_PROMPT	"NSA310> "	/* Command Prompt */
 +
 +/*
 + * Environment variables configurations
@@ -693,24 +680,16 @@ index 0000000..86ef825
 +/*
 + * File system
 + */
-+#define CONFIG_CMD_EXT2
 +#define CONFIG_CMD_EXT4
-+#define CONFIG_CMD_FAT
 +#define CONFIG_CMD_JFFS2
 +#define CONFIG_JFFS2_NAND
 +#define CONFIG_JFFS2_LZO
-+#define CONFIG_CMD_UBI
 +#define CONFIG_CMD_UBIFS
 +#define CONFIG_RBTREE
 +#define CONFIG_MTD_DEVICE               /* needed for mtdparts commands */
 +#define CONFIG_MTD_PARTITIONS
 +#define CONFIG_CMD_MTDPARTS
 +#define CONFIG_LZO
-+
-+/*
-+ * EFI partition
-+ */
-+#define CONFIG_EFI_PARTITION
 +
 +/*
 + *  Date Time

--- a/package/boot/uboot-kirkwood/patches/008-nsa325-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/008-nsa325-uboot-generic.patch
@@ -511,10 +511,11 @@ new file mode 100644
 index 0000000..48e09cc
 --- /dev/null
 +++ b/configs/nsa325_defconfig
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,22 @@
 +CONFIG_ARM=y
 +CONFIG_KIRKWOOD=y
 +CONFIG_TARGET_NSA325=y
++CONFIG_IDENT_STRING="\nZyXEL NSA325 2-Bay Power Media Server"
 +CONFIG_BOOTDELAY=3
 +CONFIG_SYS_PROMPT="NSA325> "
 +# CONFIG_CMD_IMLS is not set
@@ -524,19 +525,21 @@ index 0000000..48e09cc
 +CONFIG_OF_LIBFDT=y
 +CONFIG_CMD_SETEXPR=y
 +CONFIG_CMD_DHCP=y
-+CONFIG_CMD_NAND=y
++CONFIG_CMD_MII=y
 +CONFIG_CMD_PING=y
 +CONFIG_CMD_USB=y
 +CONFIG_USB=y
++CONFIG_CMD_EXT2=y
 +CONFIG_CMD_FAT=y
++CONFIG_EFI_PARTITION=y
++CONFIG_CMD_UBI=y
 +CONFIG_USB_STORAGE=y
-\ No newline at end of file
 diff --git a/include/configs/nsa325.h b/include/configs/nsa325.h
 new file mode 100644
 index 0000000..e5a8e2a
 --- /dev/null
 +++ b/include/configs/nsa325.h
-@@ -0,0 +1,170 @@
+@@ -0,0 +1,148 @@
 +/*
 + * (C) Copyright 2016 bodhi <mibodhi@gmail.com>
 + *
@@ -573,11 +576,6 @@ index 0000000..e5a8e2a
 +#define _CONFIG_NSA325_H
 +
 +/*
-+ * Version number information
-+ */
-+#define CONFIG_IDENT_STRING	"\nZyXEL NSA325 2-Bay Power Media Server"
-+
-+/*
 + * High Level Configuration Options (easy to change)
 + */
 +#define CONFIG_FEROCEON_88FR131	1	/* CPU Core subversion */
@@ -594,15 +592,9 @@ index 0000000..e5a8e2a
 +/*
 + * Commands configuration
 + */
-+#define CONFIG_SYS_NO_FLASH             /* Declare no flash (NOR/SPI) */
-+#define CONFIG_SYS_MVFS                 /* Picks up Filesystem from mv-common.h */
-+#define CONFIG_CMD_DHCP
 +#define CONFIG_CMD_ENV
 +#define CONFIG_CMD_IDE
-+#define CONFIG_CMD_MII
 +#define CONFIG_CMD_NAND
-+#define CONFIG_CMD_PING
-+#define CONFIG_CMD_USB
 +#define CONFIG_CMD_DATE
 +#define CONFIG_SYS_LONGHELP
 +#define CONFIG_PREBOOT
@@ -614,9 +606,6 @@ index 0000000..e5a8e2a
 + * to enable certain macros
 + */
 +#include "mv-common.h"
-+
-+#undef CONFIG_SYS_PROMPT	/* previously defined in mv-common.h */
-+#define CONFIG_SYS_PROMPT	"NSA325> "	/* Command Prompt */
 +
 +/*
 + *  Environment variables configurations
@@ -676,24 +665,16 @@ index 0000000..e5a8e2a
 +/*
 + * File system
 + */
-+#define CONFIG_CMD_EXT2
 +#define CONFIG_CMD_EXT4
-+#define CONFIG_CMD_FAT
 +#define CONFIG_CMD_JFFS2
 +#define CONFIG_JFFS2_NAND
 +#define CONFIG_JFFS2_LZO
-+#define CONFIG_CMD_UBI
 +#define CONFIG_CMD_UBIFS
 +#define CONFIG_RBTREE
 +#define CONFIG_MTD_DEVICE               /* needed for mtdparts commands */
 +#define CONFIG_MTD_PARTITIONS
 +#define CONFIG_CMD_MTDPARTS
 +#define CONFIG_LZO
-+
-+/*
-+ * EFI partition
-+ */
-+#define CONFIG_EFI_PARTITION
 +
 +/*
 + *  Date Time

--- a/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
+++ b/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
@@ -107,7 +107,7 @@
  #endif /* _CONFIG_GOFLEXHOME_H */
 --- a/include/configs/nsa310.h
 +++ b/include/configs/nsa310.h
-@@ -165,4 +165,6 @@
+@@ -141,4 +141,6 @@
  #define CONFIG_CMD_DNS
  #endif /* CONFIG_CMD_DATE */
 


### PR DESCRIPTION
Maintainer: @lperkov

As @mkresin has pointed out in [1], my last update introduced build errors for the
nsa310 and nsa325 targets of this package. This is related to some upstream changes.
It's fixed here; every uboot-kirkwood target is compile tested.
Maybe @bobafetthotmail can run test the nsa310/nsa325 targets?

Some parts of the configuration must not be done in the header file any more,
but instead in the <target>_defconfig file. Further, some warnings due to redefinitions
in both of those files have been clean up

[1]:
https://github.com/lede-project/source/pull/953#issuecomment-288877812