### PR TITLE
ar8xxx: merge QSDK fixes for switch driver

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/ar8216.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8216.c
@@ -2106,6 +2106,7 @@ ar8xxx_phy_config_aneg(struct phy_device *phydev)
 static const u32 ar8xxx_phy_ids[] = {
 	0x004dd033,
 	0x004dd034, /* AR8327 */
+	0x004dd035,
 	0x004dd036, /* AR8337 */
 	0x004dd041,
 	0x004dd042,

--- a/target/linux/generic/files/drivers/net/phy/ar8327.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8327.c
@@ -507,14 +507,6 @@ ar8327_hw_config_pdata(struct ar8xxx_priv *priv,
 	ar8xxx_write(priv, AR8327_REG_PAD0_MODE, t);
 
 	t = ar8327_get_pad_cfg(pdata->pad5_cfg);
-	if (chip_is_ar8337(priv)) {
-		/*
-		 * Workaround: RGMII RX delay setting needs to be
-		 * always specified for AR8337 to avoid port 5
-		 * RX hang on high traffic / flood conditions
-		 */
-		t |= AR8327_PAD_RGMII_RXCLK_DELAY_EN;
-	}
 	ar8xxx_write(priv, AR8327_REG_PAD5_MODE, t);
 	t = ar8327_get_pad_cfg(pdata->pad6_cfg);
 	ar8xxx_write(priv, AR8327_REG_PAD6_MODE, t);
@@ -680,7 +672,20 @@ ar8327_init_globals(struct ar8xxx_priv *priv)
 	for (i = 0; i < AR8XXX_NUM_PHYS; i++)
 		data->eee[i] = false;
 
+	if (chip_is_ar8327(priv))
+		ar8xxx_write(priv, AR8327_REG_GLOBAL_FC_THRESH,
+				AR8327_GLOBAL_FC_THRESH_DFLT_VAL);
+
 	if (chip_is_ar8337(priv)) {
+
+		/*
+		 * Workaround: RGMII RX delay setting needs to be
+		 * always specified for AR8337 to avoid port 5
+		 * RX hang on high traffic / flood conditions
+		 */
+		ar8xxx_write(priv, AR8327_REG_PAD5_MODE,
+			AR8327_PAD_RGMII_RXCLK_DELAY_EN);
+
 		/* Update HOL registers with values suggested by QCA switch team */
 		for (i = 0; i < AR8327_NUM_PORTS; i++) {
 			if (i == AR8216_PORT_CPU || i == 5 || i == 6) {

--- a/target/linux/generic/files/drivers/net/phy/ar8327.h
+++ b/target/linux/generic/files/drivers/net/phy/ar8327.h
@@ -2,6 +2,7 @@
  * ar8327.h: AR8216 switch driver
  *
  * Copyright (C) 2009 Felix Fietkau <nbd@nbd.name>
+ * Copyright (c) 2017 The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -295,6 +296,9 @@
 #define   AR8327_PORT_HOL_CTRL1_EG_PORT_BUF_EN	BIT(7)
 #define   AR8327_PORT_HOL_CTRL1_WRED_EN		BIT(8)
 #define   AR8327_PORT_HOL_CTRL1_EG_MIRROR_EN	BIT(16)
+
+#define AR8327_REG_GLOBAL_FC_THRESH		0x800
+#define AR8327_GLOBAL_FC_THRESH_DFLT_VAL	0x12001f0
 
 #define AR8337_PAD_MAC06_EXCHANGE_EN		BIT(31)
 


### PR DESCRIPTION
Merging fixes for ar8xxxx driver found in Qualcomm SDK repository.

This commit:
- changes MTU size configuration logic
- adds certain switch HOL registers configuration during init as
proposed by QCA switch dev team
- adds support for ar8327 switch revision found in ap136/ap137/ap143/ap147/ap152
- some coding clean ups

https://source.codeaurora.org/quic/qsdk/oss/kernel/linux-msm/commit/drivers/net/phy/ar8216.c?h=release/endive_preview&id=f68b461945b3e68bdcc4c39b80045cc9a986652d
https://source.codeaurora.org/quic/qsdk/oss/kernel/linux-msm/commit/drivers/net/phy/ar8216.c?h=release/endive_preview&id=6ff699c6f50263910d188ed993dd3bc365956003
