### PR TITLE
ar71xx: add support for Mikrotik RB2011iL

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -256,6 +256,7 @@ rb-952ui-5ac2nd)
 rb-962uigs-5hact2hnt)
 	ucidef_set_led_timer "user" "USER/SFP" "rb:green:user" "1000" "1000"
 	;;
+rb-2011il|\
 rb-2011l|\
 rb-2011uas|\
 rb-2011uias|\

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -272,6 +272,7 @@ ar71xx_setup_interfaces()
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:wan:1"
 	;;
 	db120|\
+	rb-2011il|\
 	rb-2011l|\
 	rb-2011uas|\
 	rb-2011uas-2hnd|\

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -284,6 +284,7 @@ get_status_led() {
 	r602n)
 		status_led="$board:green:wan"
 		;;
+	rb-2011il|\
 	rb-2011l|\
 	rb-2011uas|\
 	rb-2011uas-2hnd)

--- a/target/linux/ar71xx/base-files/etc/uci-defaults/03_network-switchX-migration
+++ b/target/linux/ar71xx/base-files/etc/uci-defaults/03_network-switchX-migration
@@ -86,8 +86,9 @@ rb-450)
 	migrate_switch_name "eth1" "switch0"
 	;;
 
-db120 |\
-rb-2011l | \
+db120|\
+rb-2011il|\
+rb-2011l|\
 rb-2011uas-2hnd)
 	migrate_switch_name "eth0" "switch0"
 	migrate_switch_name "eth1" "switch1"

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -824,6 +824,9 @@ ar71xx_board_detect() {
 	*"Rocket M XW")
 		name="rocket-m-xw"
 		;;
+	*"RouterBOARD 2011iL")
+		name="rb-2011il"
+		;;
 	*"RouterBOARD 2011L")
 		name="rb-2011l"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -507,6 +507,7 @@ platform_check_image() {
 	rb-951g-2hnd|\
 	rb-951ui-2hnd|\
 	rb-2011l|\
+	rb-2011il|\
 	rb-2011uas|\
 	rb-2011uias|\
 	rb-2011uas-2hnd|\
@@ -681,6 +682,7 @@ platform_pre_upgrade() {
 	rb-912uag-5hpnd|\
 	rb-951g-2hnd|\
 	rb-951ui-2hnd|\
+	rb-2011il|\
 	rb-2011l|\
 	rb-2011uas|\
 	rb-2011uias|\


### PR DESCRIPTION
From dmesg:

` [    0.000000] Kernel command line: parts=1 boot_part_size=4194304 gpio=249403 HZ=300000000 mem=64M kmac=4C:5E:0C:37:82:E6 board=2011r5 boot=0 mlc=5 rootfstype=squashfs noinitrd`
`[    0.126556] MIPS: machine is Mikrotik RouterBOARD 2011iL`

In kernel, the `2011r5` is mapped to `Mikrotik RouterBOARD 2011UiAS(-2Hnd) `. While not ideal, it still works for me. This just means that the kernel will attempt to turn on the RB2011UiAS's feature set: SFP, USB, and WLAN. These do not exist on the RB2011iL. 

The RB2011iL matches the RB2011L offerings more closely. So basically, any userland references to RB2011L should also be accompanied by RB2011iL.