### PR TITLE
build: Removes absolute path to perl and replaces by /usr/bin/env perl

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl 
 # (c) 2001, Dave Jones. (the file handling bit)
 # (c) 2005, Joel Schopp <jschopp@austin.ibm.com> (the ugly bit)
 # (c) 2007,2008, Andy Whitcroft <apw@uk.ibm.com> (new conditions, test suite)
@@ -7,6 +7,7 @@
 # Licensed under the terms of the GNU GPL License version 2
 
 use strict;
+use warnings;
 
 my $P = $0;
 $P =~ s@.*/@@g;

--- a/scripts/cleanfile
+++ b/scripts/cleanfile
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # Clean a text file -- or directory of text files -- of stealth whitespace.
 # WARNING: this can be a highly destructive operation.  Use with caution.
@@ -6,6 +6,7 @@
 
 use bytes;
 use File::Basename;
+use warnings;
 
 # Default options
 $max_width = 79;

--- a/scripts/cleanpatch
+++ b/scripts/cleanpatch
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl 
 #
 # Clean a patch file -- or directory of patch files -- of stealth whitespace.
 # WARNING: this can be a highly destructive operation.  Use with caution.
@@ -6,6 +6,7 @@
 
 use bytes;
 use File::Basename;
+use warnings;
 
 # Default options
 $max_width = 79;

--- a/scripts/flashing/adsl2mue_flash.pl
+++ b/scripts/flashing/adsl2mue_flash.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 #   Linksys ADSL2MUE Flash utility.
 #


### PR DESCRIPTION
This patch removes the absolute path to perl. This change is need for distributions like Nixos, that do not support this kind of absolute paths.

Signed-off-by: Bastian Köcher <git@kchr.de>

