### PR TITLE
gdb: fix linker error for assert on ppc targets

### DIFF
--- a/package/devel/gdb/patches/130-fix-linker-error-for-assert-on-ppc.patch
+++ b/package/devel/gdb/patches/130-fix-linker-error-for-assert-on-ppc.patch
@@ -1,0 +1,13 @@
+diff --git a/sim/ppc/debug.h b/sim/ppc/debug.h
+index 6f19624..d823352 100644
+--- a/sim/ppc/debug.h
++++ b/sim/ppc/debug.h
+@@ -155,7 +155,7 @@ do { \
+ do { \
+   if (WITH_ASSERT) { \
+     if (!(EXPRESSION)) { \
+-      error("%s:%d: assertion failed - %s\n", \
++      sim_io_error("%s:%d: assertion failed - %s\n", \
+ 	    filter_filename(__FILE__), __LINE__, #EXPRESSION); \
+     } \
+   } \


### PR DESCRIPTION
Link:
http://downloads.lede-project.org/snapshots/faillogs/powerpc_8540/base/gdb/compile.txt

Error is:
```
service.list
../sim/ppc/libsim.a(idecode.o): In function `update_time_from_event':
idecode.c:(.text+0x170): undefined reference to `error'
../sim/ppc/libsim.a(idecode.o): In function `event_queue_tick':
idecode.c:(.text+0x1cc): undefined reference to `error'
idecode.c:(.text+0x28c): undefined reference to `error'
idecode.c:(.text+0x318): undefined reference to `error'
../sim/ppc/libsim.a(idecode.o): In function `cpu_halt.constprop.6':
idecode.c:(.text+0x398): undefined reference to `error'
../sim/ppc/libsim.a(idecode.o):idecode.c:(.text+0x4e4): more undefined references to `error' follow
collect2: error: ld returned 1 exit status
Makefile:1420: recipe for target 'gdb' failed
make[6]: *** [gdb] Error 1
```

Seems that for the ppc assert, the `error` function
should be `sim_io_err`, same as in the common
assert function.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>