### PR TITLE
apm821xx: Merge Meraki MX60/MX60W images

### DIFF
--- a/target/linux/apm821xx/image/Makefile
+++ b/target/linux/apm821xx/image/Makefile
@@ -69,7 +69,7 @@ endef
 
 define Device/mr24
   DEVICE_TITLE := Cisco Meraki MR24
-  DEVICE_PACKAGES := kmod-spi-gpio kmod-ath9k wpad-mini
+  DEVICE_PACKAGES := kmod-spi-gpio
   DEVICE_PROFILE := MR24
   DEVICE_DTS := MR24
   BLOCKSIZE := 63k
@@ -89,8 +89,8 @@ TARGET_DEVICES += mr24
 
 define Device/mx60
   DEVICE_TITLE := Cisco Meraki MX60
-  DEVICE_PACKAGES := kmod-spi-gpio swconfig kmod-usb-ledtrig-usbport \
-	kmod-usb-dwc2 kmod-usb-storage block-mount
+  DEVICE_PACKAGES := kmod-spi-gpio kmod-usb-ledtrig-usbport kmod-usb-dwc2 \
+  kmod-usb-storage block-mount
   DEVICE_PROFILE := MX60
   DEVICE_DTS := MX60
   BLOCKSIZE := 63k
@@ -115,7 +115,6 @@ TARGET_DEVICES += mx60
 define Device/mx60w
 $(Device/mx60)
   DEVICE_TITLE := Cisco Meraki MX60W
-  DEVICE_PACKAGES += kmod-ath9k wpad-mini
 endef
 TARGET_DEVICES += mx60w
 
@@ -160,10 +159,10 @@ endef
 define Device/WNDR4700
   DEVICE_TITLE := Netgear Centria N900 WNDR4700/WNDR4720
   DEVICE_PACKAGES := badblocks block-mount e2fsprogs \
-	kmod-ath9k kmod-dm kmod-fs-ext4 kmod-fs-vfat kmod-usb-ledtrig-usbport \
+	kmod-dm kmod-fs-ext4 kmod-fs-vfat kmod-usb-ledtrig-usbport \
 	kmod-md-mod kmod-nls-cp437 kmod-nls-iso8859-1 kmod-nls-iso8859-15 \
 	kmod-nls-utf8 kmod-usb3 kmod-usb-dwc2 kmod-usb-storage \
-	partx-utils swconfig wpad-mini
+	partx-utils
   DEVICE_NAME := wndr4700
   DEVICE_PROFILE := wndr4700
   DEVICE_DTS := wndr4700

--- a/target/linux/apm821xx/image/Makefile
+++ b/target/linux/apm821xx/image/Makefile
@@ -88,7 +88,7 @@ endef
 TARGET_DEVICES += mr24
 
 define Device/mx60
-  DEVICE_TITLE := Cisco Meraki MX60
+  DEVICE_TITLE := Cisco Meraki MX60/MX60W
   DEVICE_PACKAGES := kmod-spi-gpio kmod-usb-ledtrig-usbport kmod-usb-dwc2 \
   kmod-usb-storage block-mount
   DEVICE_PROFILE := MX60
@@ -111,12 +111,6 @@ define Device/mx60
   UBINIZE_OPTS := -E 5
 endef
 TARGET_DEVICES += mx60
-
-define Device/mx60w
-$(Device/mx60)
-  DEVICE_TITLE := Cisco Meraki MX60W
-endef
-TARGET_DEVICES += mx60w
 
 define Build/create-uImage-dtb
 	# flat_dt target expect FIT image - which WNDR4700's uboot doesn't support

--- a/target/linux/apm821xx/nand/profiles/00-default.mk
+++ b/target/linux/apm821xx/nand/profiles/00-default.mk
@@ -9,10 +9,10 @@ define Profile/Default
   NAME:=Default Profile
   PRIORITY:=1
   PACKAGES := badblocks block-mount e2fsprogs \
-	kmod-ath9k kmod-dm kmod-fs-ext4 kmod-fs-vfat kmod-usb-ledtrig-usbport \
+	kmod-dm kmod-fs-ext4 kmod-fs-vfat kmod-usb-ledtrig-usbport \
 	kmod-md-mod kmod-nls-cp437 kmod-nls-iso8859-1 kmod-nls-iso8859-15 \
 	kmod-nls-utf8 kmod-usb3 kmod-usb-dwc2 kmod-usb-storage \
-	kmod-spi-gpio partx-utils swconfig wpad-mini
+	kmod-spi-gpio partx-utils
 endef
 
 define Profile/Default/Description

--- a/target/linux/apm821xx/nand/target.mk
+++ b/target/linux/apm821xx/nand/target.mk
@@ -1,6 +1,8 @@
 BOARDNAME:=Devices with NAND flash (Routers)
 FEATURES += nand pcie ramdisk squashfs usb
 
+DEFAULT_PACKAGES += kmod-ath9k swconfig wpad-mini
+
 define Target/Description
 	Build firmware images for APM821XX boards with NAND flash.
 	For routers like the MR24 or the WNDR4700.


### PR DESCRIPTION
The following patches do the following:
 * Set core packages used by the nand subtarget as default
 * Merge the MX60/MX60W boards, as they can now share the same image.

This is done to fix the current broken MX60W images, which when compiled in a multi image environment, lack swconfig and ath9k, making the device inaccessible.