### PR TITLE
ar71xx: add support for UniFi-AC-Mesh

### DIFF
--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -1154,7 +1154,7 @@ ar71xx_board_detect() {
 	*"UniFi AP Pro")
 		name="uap-pro"
 		;;
-	*"UniFi-AC-LITE")
+	*"UniFi-AC-LITE/MESH")
 		name="unifiac-lite"
 		;;
 	*"UniFi-AC-PRO")

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -1763,7 +1763,7 @@ config ATH79_MACH_UBNT
 	select ATH79_DEV_USB
 
 config ATH79_MACH_UBNT_UNIFIAC
-	bool "Ubiquiti UniFi AC (LITE/LR/PRO) support"
+	bool "Ubiquiti UniFi AC (LITE/LR/MESH/PRO) support"
 	select SOC_QCA956X
 	select ATH79_DEV_AP9X_PCI if PCI
 	select ATH79_DEV_ETH

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-ubnt-unifiac.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-ubnt-unifiac.c
@@ -108,7 +108,7 @@ static void __init ubnt_unifiac_lite_setup(void)
 	                                ubnt_unifiac_gpio_keys);
 }
 
-MIPS_MACHINE(ATH79_MACH_UBNT_UNIFIAC_LITE, "UBNT-UF-AC-LITE", "Ubiquiti UniFi-AC-LITE",
+MIPS_MACHINE(ATH79_MACH_UBNT_UNIFIAC_LITE, "UBNT-UF-AC-LITE", "Ubiquiti UniFi-AC-LITE/MESH",
 	     ubnt_unifiac_lite_setup);
 
 static struct ar8327_pad_cfg ubnt_unifiac_pro_ar8327_pad0_cfg = {

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -274,7 +274,7 @@ enum ath79_mach_type {
 	ATH79_MACH_UBNT_RSPRO,			/* Ubiquiti RouterStation Pro */
 	ATH79_MACH_UBNT_UAP_PRO,		/* Ubiquiti UniFi AP Pro */
 	ATH79_MACH_UBNT_UNIFI,			/* Ubiquiti Unifi */
-	ATH79_MACH_UBNT_UNIFIAC_LITE,		/* Ubiquiti Unifi AC LITE/LR */
+	ATH79_MACH_UBNT_UNIFIAC_LITE,		/* Ubiquiti Unifi AC LITE/LR/MESH */
 	ATH79_MACH_UBNT_UNIFIAC_PRO,		/* Ubiquiti Unifi AC PRO */
 	ATH79_MACH_UBNT_UNIFI_OUTDOOR,		/* Ubiquiti UnifiAP Outdoor */
 	ATH79_MACH_UBNT_UNIFI_OUTDOOR_PLUS,	/* Ubiquiti UnifiAP Outdoor+ */

--- a/target/linux/ar71xx/image/ubnt.mk
+++ b/target/linux/ar71xx/image/ubnt.mk
@@ -133,6 +133,11 @@ define Device/ubnt-unifiac-lite
   BOARDNAME := UBNT-UF-AC-LITE
 endef
 
+define Device/ubnt-unifiac-mesh
+  $(Device/ubnt-unifiac-lite)
+  DEVICE_TITLE := Ubiquiti UniFi AC-Mesh
+endef
+
 define Device/ubnt-unifiac-pro
   $(Device/ubnt-unifiac)
   DEVICE_TITLE := Ubiquiti UniFi AC-Pro
@@ -147,7 +152,7 @@ define Device/ubnt-unifi-outdoor
   BOARDNAME := UBNT-U20
   DEVICE_PROFILE := UBNT UBNTUNIFIOUTDOOR
 endef
-TARGET_DEVICES += ubnt-unifi ubnt-unifiac-lite ubnt-unifiac-pro ubnt-unifi-outdoor
+TARGET_DEVICES += ubnt-unifi ubnt-unifiac-lite ubnt-unifiac-mesh ubnt-unifiac-pro ubnt-unifi-outdoor
 
 define Device/ubnt-nano-m-xw
   $(Device/ubnt-xw)


### PR DESCRIPTION
This adds the build option for the new UniFi AC Mesh.
It is a direct hardware copy from the AC Lite.

- SoC: QCA9563-AL3A (775Mhz)
- RAM: 128MiB
- Flash: 16MiB - dual firmware partitions!
- LAN: 1 1000M - POE
- Wireless:
        2.4G: QCA9563
          5G: UniFi Chip, QCA988X compatible

Thanks to Frank Dietz(@tuennes) for a lot of patience while testing.

See also https://github.com/freifunk-gluon/gluon/issues/1021
