### PR TITLE
ath10k-firmware: update the qca988x firmware to 10.2.4-1.0-00029

### DIFF
--- a/package/firmware/ath10k-firmware/Makefile
+++ b/package/firmware/ath10k-firmware/Makefile
@@ -8,9 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath10k-firmware
-PKG_SOURCE_DATE:=2017-03-13
-PKG_SOURCE_VERSION:=2209b0f8d41aef3435c7238b9eb99de7ed36fd5a
-PKG_MIRROR_HASH:=884e4678f6b6b5d8b367a90769784ef6449d6774b749104d7a20552b5601b041
+PKG_SOURCE_DATE:=2017-03-29
+PKG_SOURCE_VERSION:=956e2609b7e42c8c710bba10ef925a5be1be5137
+PKG_MIRROR_HASH:=25f724ff38c830281b3efba4a4ddffaae0c4bd8fea0f4c1061591229ff05535b
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
@@ -263,7 +263,7 @@ define Package/ath10k-firmware-qca988x/install
 		$(PKG_BUILD_DIR)/QCA988X/hw2.0/board.bin \
 		$(1)/lib/firmware/ath10k/QCA988X/hw2.0/
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/QCA988X/hw2.0/10.2.4-1.0/firmware-5.bin_10.2.4-1.0-00016 \
+		$(PKG_BUILD_DIR)/QCA988X/hw2.0/10.2.4-1.0/firmware-5.bin_10.2.4-1.0-00029 \
 		$(1)/lib/firmware/ath10k/QCA988X/hw2.0/firmware-5.bin
 endef
 


### PR DESCRIPTION
update the qca988x firmware to firmware-5.bin_10.2.4-1.0-00029.
According to LEDE Forum, the new firmware supports mesh mode.
Also, it seems to have several improvements.

Compile & run tested on TP-LINK Archer C7 v2.

Signed-off-by: Changmin Jang <ckdalsdk12@gmail.com>