### PR TITLE
imagebuilder: allow customising the target

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -123,6 +123,7 @@ ifneq ($(USER_FILES),)
 	$(MAKE) copy_files
 endif
 	$(MAKE) -s package_postinst
+	$(MAKE) -s customize_image
 	$(MAKE) -s build_image
 	$(MAKE) -s checksum
 
@@ -164,6 +165,11 @@ package_postinst: FORCE
 	rm -f $(TARGET_DIR)/usr/lib/opkg/info/*.postinst
 	$(if $(CONFIG_CLEAN_IPKG),rm -rf $(TARGET_DIR)/usr/lib/opkg)
 
+customize_image: FORCE
+	$(if $(CUSTOMIZE_IMAGE_SCRIPT),if [ -f $(CUSTOMIZE_IMAGE_SCRIPT) ]; then \
+		TARGET_DIR=$(TARGET_DIR) $(CUSTOMIZE_IMAGE_SCRIPT); \
+	fi)
+	
 build_image: FORCE
 	@echo
 	@echo Building images...


### PR DESCRIPTION
It can be useful to be able to customise what's in the target before
actually building up the image.

This patch introduces a hook to allow that.  The variable
CUSTOMIZE_IMAGE_SCRIPT on the "make image" command can
be assigned the name of a script to run that will modify the target
before the image is created.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>