### PR TITLE
mvebu add support for ClearFog Base

### DIFF
--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -23,7 +23,7 @@ endef
 
 define U-Boot/clearfog
   NAME:=SolidRun ClearFog A1
-  BUILD_DEVICES:=armada-388-clearfog-pro
+  BUILD_DEVICES:=armada-388-clearfog-base armada-388-clearfog-pro
   UBOOT_IMAGE:=u-boot-spl.kwb
 endef
 

--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -23,7 +23,7 @@ endef
 
 define U-Boot/clearfog
   NAME:=SolidRun ClearFog A1
-  BUILD_DEVICES:=armada-388-clearfog
+  BUILD_DEVICES:=armada-388-clearfog-pro
   UBOOT_IMAGE:=u-boot-spl.kwb
 endef
 

--- a/target/linux/mvebu/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/base-files/etc/board.d/02_network
@@ -27,7 +27,7 @@ armada-385-db-ap)
 armada-xp-gp)
 	ucidef_set_interface_lan "eth0 eth1 eth2 eth3"
 	;;
-armada-388-clearfog)
+armada-388-clearfog-pro)
 	ucidef_set_interfaces_lan_wan "eth0 eth1" "eth2"
 	swconfig list 2>&1 | grep -q switch0 && \
 		ucidef_add_switch "switch0" \

--- a/target/linux/mvebu/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/base-files/etc/board.d/02_network
@@ -33,6 +33,9 @@ armada-388-clearfog-pro)
 		ucidef_add_switch "switch0" \
 			"0:lan:5" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5u@eth0" "6:lan:6"
 	;;
+armada-388-clearfog-base)
+	ucidef_set_interfaces_lan_wan "eth0" "eth1"
+	;;
 *)
 	ucidef_set_interface_lan "eth0"
 	;;

--- a/target/linux/mvebu/base-files/lib/mvebu.sh
+++ b/target/linux/mvebu/base-files/lib/mvebu.sh
@@ -56,6 +56,9 @@ mvebu_board_detect() {
 	*"SolidRun Clearfog Pro A1")
 		name="armada-388-clearfog-pro"
 		;;
+	*"SolidRun Clearfog Base A1")
+		name="armada-388-clearfog-base"
+		;;
 	esac
 
 	[ -z "$name" ] && name="unknown"

--- a/target/linux/mvebu/base-files/lib/mvebu.sh
+++ b/target/linux/mvebu/base-files/lib/mvebu.sh
@@ -53,8 +53,8 @@ mvebu_board_detect() {
 	*"Marvell Armada XP Development Board DB-MV784MP-GP")
 		name="armada-xp-gp"
 		;;
-	*"SolidRun Clearfog A1")
-		name="armada-388-clearfog"
+	*"SolidRun Clearfog Pro A1")
+		name="armada-388-clearfog-pro"
 		;;
 	esac
 

--- a/target/linux/mvebu/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/base-files/lib/upgrade/platform.sh
@@ -19,7 +19,7 @@ platform_do_upgrade() {
 	armada-385-linksys-caiman|armada-385-linksys-cobra|armada-385-linksys-rango|armada-385-linksys-shelby|armada-xp-linksys-mamba)
 		platform_do_upgrade_linksys "$ARGV"
 		;;
-	armada-388-clearfog)
+	armada-388-clearfog-pro)
 		platform_do_upgrade_clearfog "$ARGV"
 		;;
 	*)

--- a/target/linux/mvebu/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/base-files/lib/upgrade/platform.sh
@@ -22,6 +22,9 @@ platform_do_upgrade() {
 	armada-388-clearfog-pro)
 		platform_do_upgrade_clearfog "$ARGV"
 		;;
+	armada-388-clearfog-base)
+		platform_do_upgrade_clearfog "$ARGV"
+		;;
 	*)
 		default_do_upgrade "$ARGV"
 		;;

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -28,6 +28,11 @@ define Build/boot-scr-cfpro
 	mkimage -A arm -O linux -T script -C none -a 0 -e 0 -d cfpro-boot.script $@.bootscript
 endef
 
+define Build/boot-scr-cfbase
+	rm -f $@.bootscript
+	mkimage -A arm -O linux -T script -C none -a 0 -e 0 -d cfbase-boot.script $@.bootscript
+endef
+
 define Build/boot-img
 	rm -f $@.boot
 	mkfs.fat -C $@.boot 16384
@@ -181,6 +186,21 @@ define Device/armada-388-clearfog-pro
   IMAGE_NAME = $$(IMAGE_PREFIX)-$$(2)
 endef
 TARGET_DEVICES += armada-388-clearfog-pro
+
+define Device/armada-388-clearfog-base
+  KERNEL_INSTALL := 1
+  KERNEL := dtb | kernel-bin
+  DEVICE_TITLE := SolidRun ClearFog Base
+  DEVICE_PACKAGES := \
+	  kmod-nls-cp437 kmod-nls-iso8859-1 \
+	  mkf2fs e2fsprogs kmod-fs-vfat kmod-fuse kmod-fs-f2fs \
+	  kmod-ata-core kmod-ata-ahci kmod-ata-marvell-sata kmod-scsi-core kmod-scsi-generic \
+	  kmod-button-hotplug kmod-gpio-button-hotplug
+  IMAGES := sdcard.img.gz
+  IMAGE/sdcard.img.gz := boot-scr-cfbase | boot-img | sdcard-img | gzip
+  IMAGE_NAME = $$(IMAGE_PREFIX)-$$(2)
+endef
+TARGET_DEVICES += armada-388-clearfog-base
 
 define Device/globalscale-mirabox
   $(Device/NAND-512K)

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -23,9 +23,9 @@ endef
 # Partition 1:   32768 sectors
 # Partition 2:   98304 sectors (configurable)
 
-define Build/boot-scr
+define Build/boot-scr-cfpro
 	rm -f $@.bootscript
-	mkimage -A arm -O linux -T script -C none -a 0 -e 0 -d boot.script $@.bootscript
+	mkimage -A arm -O linux -T script -C none -a 0 -e 0 -d cfpro-boot.script $@.bootscript
 endef
 
 define Build/boot-img
@@ -171,16 +171,16 @@ define Device/armada-388-rd
 endef
 TARGET_DEVICES += armada-388-rd
 
-define Device/armada-388-clearfog
+define Device/armada-388-clearfog-pro
   KERNEL_INSTALL := 1
   KERNEL := dtb | kernel-bin
-  DEVICE_TITLE := SolidRun ClearFog
+  DEVICE_TITLE := SolidRun ClearFog Pro
   DEVICE_PACKAGES := mkf2fs e2fsprogs swconfig kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1
   IMAGES := sdcard.img.gz
-  IMAGE/sdcard.img.gz := boot-scr | boot-img | sdcard-img | gzip | append-metadata
+  IMAGE/sdcard.img.gz := boot-scr-cfpro | boot-img | sdcard-img | gzip | append-metadata
   IMAGE_NAME = $$(IMAGE_PREFIX)-$$(2)
 endef
-TARGET_DEVICES += armada-388-clearfog
+TARGET_DEVICES += armada-388-clearfog-pro
 
 define Device/globalscale-mirabox
   $(Device/NAND-512K)

--- a/target/linux/mvebu/image/cfbase-boot.script
+++ b/target/linux/mvebu/image/cfbase-boot.script
@@ -1,0 +1,7 @@
+setenv bootargs console=ttyS0,115200n8 root=/dev/mmcblk0p2 rootfstype=squashfs rootwait overlay=/dev/mmcblk0p3
+setenv fdt_high 0x07a12000
+
+fatload mmc 0:1 0x02000000 zImage
+fatload mmc 0:1 0x05F00000 armada-388-clearfog-base.dtb
+
+bootz 0x02000000 - 0x05F00000

--- a/target/linux/mvebu/image/cfpro-boot.script
+++ b/target/linux/mvebu/image/cfpro-boot.script
@@ -2,6 +2,6 @@ setenv bootargs console=ttyS0,115200n8 root=/dev/mmcblk0p2 rootfstype=squashfs r
 setenv fdt_high 0x07a12000
 
 fatload mmc 0:1 0x02000000 zImage
-fatload mmc 0:1 0x05F00000 armada-388-clearfog.dtb
+fatload mmc 0:1 0x05F00000 armada-388-clearfog-pro.dtb
 
 bootz 0x02000000 - 0x05F00000

--- a/target/linux/mvebu/patches-4.9/470-ClearFog-renamed-upstream.patch
+++ b/target/linux/mvebu/patches-4.9/470-ClearFog-renamed-upstream.patch
@@ -1,0 +1,88 @@
+From b0db8cc1fe7eab722bc1f7c386132b3905d67f30 Mon Sep 17 00:00:00 2001
+From: Marko Ratkaj <marko.ratkaj@sartura.hr>
+Date: Fri, 7 Apr 2017 11:01:26 +0200
+Subject: [PATCH 1/2] ClearFog renamed upstream
+
+Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>
+---
+ arch/arm/boot/dts/Makefile                    |  1 +
+ arch/arm/boot/dts/armada-388-clearfog-pro.dts | 55 +++++++++++++++++++++++++++
+ 2 files changed, 56 insertions(+)
+ create mode 100644 arch/arm/boot/dts/armada-388-clearfog-pro.dts
+
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index d3873a3..fd65cd0 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -924,6 +924,7 @@ dtb-$(CONFIG_MACH_ARMADA_38X) += \
+ 	armada-385-linksys-rango.dtb \
+ 	armada-385-linksys-shelby.dtb \
+ 	armada-388-clearfog.dtb \
++	armada-388-clearfog-pro.dtb \
+ 	armada-388-db.dtb \
+ 	armada-388-gp.dtb \
+ 	armada-388-rd.dtb
+diff --git a/arch/arm/boot/dts/armada-388-clearfog-pro.dts b/arch/arm/boot/dts/armada-388-clearfog-pro.dts
+new file mode 100644
+index 0000000..bd85870
+--- /dev/null
++++ b/arch/arm/boot/dts/armada-388-clearfog-pro.dts
+@@ -0,0 +1,55 @@
++/*
++ * Device Tree file for SolidRun Clearfog Pro revision A1 rev 2.0 (88F6828)
++ *
++ *  Copyright (C) 2015 Russell King
++ *
++ * This board is in development; the contents of this file work with
++ * the A1 rev 2.0 of the board, which does not represent final
++ * production board.  Things will change, don't expect this file to
++ * remain compatible info the future.
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License
++ *     version 2 as published by the Free Software Foundation.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include "armada-388-clearfog.dts"
++
++/ {
++	model = "SolidRun Clearfog Pro A1";
++	compatible = "solidrun,clearfog-pro-a1",
++		"solidrun,clearfog-a1", "marvell,armada388",
++		"marvell,armada385", "marvell,armada380";
++};
+-- 
+2.10.2
+

--- a/target/linux/mvebu/patches-4.9/471-add-ClearFog-Base-device-tree-files.patch
+++ b/target/linux/mvebu/patches-4.9/471-add-ClearFog-Base-device-tree-files.patch
@@ -1,0 +1,554 @@
+From b4ac5820bdc98ee24a2f73b8bd7fdf7f82db3a46 Mon Sep 17 00:00:00 2001
+From: Marko Ratkaj <marko.ratkaj@sartura.hr>
+Date: Fri, 7 Apr 2017 11:02:30 +0200
+Subject: [PATCH 2/2] add ClearFog Base device tree files
+
+Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>
+---
+ arch/arm/boot/dts/Makefile                         |   1 +
+ arch/arm/boot/dts/armada-388-clearfog-base.dts     | 161 ++++++++++++
+ arch/arm/boot/dts/armada-388-clearfog.dtsi         | 282 +++++++++++++++++++++
+ .../dts/armada-38x-solidrun-microsom-emmc.dtsi     |  62 +++++
+ 4 files changed, 506 insertions(+)
+ create mode 100644 arch/arm/boot/dts/armada-388-clearfog-base.dts
+ create mode 100644 arch/arm/boot/dts/armada-388-clearfog.dtsi
+ create mode 100644 arch/arm/boot/dts/armada-38x-solidrun-microsom-emmc.dtsi
+
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index fd65cd0..bcf5480 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -925,6 +925,7 @@ dtb-$(CONFIG_MACH_ARMADA_38X) += \
+ 	armada-385-linksys-shelby.dtb \
+ 	armada-388-clearfog.dtb \
+ 	armada-388-clearfog-pro.dtb \
++	armada-388-clearfog-base.dtb \
+ 	armada-388-db.dtb \
+ 	armada-388-gp.dtb \
+ 	armada-388-rd.dtb
+diff --git a/arch/arm/boot/dts/armada-388-clearfog-base.dts b/arch/arm/boot/dts/armada-388-clearfog-base.dts
+new file mode 100644
+index 0000000..5438bdb
+--- /dev/null
++++ b/arch/arm/boot/dts/armada-388-clearfog-base.dts
+@@ -0,0 +1,161 @@
++/*
++ * Device Tree file for SolidRun Clearfog Base revision A1 rev 2.0 (88F6828)
++ *
++ *  Copyright (C) 2015 Russell King
++ *
++ * This board is in development; the contents of this file work with
++ * the A1 rev 2.0 of the board, which does not represent final
++ * production board.  Things will change, don't expect this file to
++ * remain compatible info the future.
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License
++ *     version 2 as published by the Free Software Foundation.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/dts-v1/;
++#include "armada-388-clearfog.dtsi"
++#include "armada-38x-solidrun-microsom-emmc.dtsi"
++
++/ {
++	model = "SolidRun Clearfog Base A1";
++	compatible = "solidrun,clearfog-base-a1",
++		"solidrun,clearfog-a1", "marvell,armada388",
++		"marvell,armada385", "marvell,armada380";
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		pinctrl-0 = <&rear_button_pins>;
++		pinctrl-names = "default";
++
++		button_0 {
++			/* The rear SW3 button */
++			label = "Rear Button";
++			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
++			linux,can-disable;
++			linux,code = <BTN_0>;
++		};
++	};
++};
++
++&eth1 {
++	phy = <&phy1>;
++};
++
++&gpio0 {
++	phy1_reset {
++		gpio-hog;
++		gpios = <19 GPIO_ACTIVE_LOW>;
++		output-low;
++		line-name = "phy1-reset";
++	};
++};
++
++&mdio {
++	pinctrl-0 = <&mdio_pins &microsom_phy_clk_pins &clearfog_phy_pins>;
++	phy1: ethernet-phy@1 {
++		/*
++		 * Annoyingly, the marvell phy driver configures the LED
++		 * register, rather than preserving reset-loaded setting.
++		 * We undo that rubbish here.
++		 */
++		marvell,reg-init = <3 16 0 0x101e>;
++		reg = <1>;
++	};
++};
++
++&pinctrl {
++	/* phy1 reset */
++	clearfog_phy_pins: clearfog-phy-pins {
++		marvell,pins = "mpp19";
++		marvell,function = "gpio";
++	};
++	rear_button_pins: rear-button-pins {
++		marvell,pins = "mpp44";
++		marvell,function = "gpio";
++	};
++};
++
++/*
++MPP
++18: pu	gpio		pca9655 int
++19:	gpio		phy reset
++20: pu	gpio		sd0 detect
++21:	sd0:cmd
++22: pd	gpio		mikro int
++23:
++
++24:	ua1:rxd		mikro rx
++25:	ua1:txd		mikro tx
++26: pu	i2c1:sck
++27: pu	i2c1:sda
++28:	sd0:clk
++29: pd	gpio		mikro rst
++30:
++31:
++
++32:
++33:
++34:
++35:
++36:
++37:	sd0:d3
++38:	sd0:d0
++39:	sd0:d1
++
++40:	sd0:d2
++41:
++42:
++43:	spi1:cs2	mikro cs
++44:	gpio		rear button sw3
++45:	ref:clk_out0	phy#0 clock
++46:	ref:clk_out1	phy#1 clock
++47:
++
++48:	gpio		J18 spare gpio
++49:	gpio		U10 I2C_IRQ(GNSS)
++50:	gpio		board id?
++51:
++52:
++53:
++54:	gpio		mikro pwm
++55:
++
++56: pu	spi1:mosi	mikro mosi
++57: pd	spi1:sck	mikro sck
++58:	spi1:miso	mikro miso
++59:
++*/
+diff --git a/arch/arm/boot/dts/armada-388-clearfog.dtsi b/arch/arm/boot/dts/armada-388-clearfog.dtsi
+new file mode 100644
+index 0000000..ffa3957
+--- /dev/null
++++ b/arch/arm/boot/dts/armada-388-clearfog.dtsi
+@@ -0,0 +1,282 @@
++/*
++ * Device Tree include file for SolidRun Clearfog 88F6828 based boards
++ *
++ *  Copyright (C) 2015 Russell King
++ *
++ * This board is in development; the contents of this file work with
++ * the A1 rev 2.0 of the board, which does not represent final
++ * production board.  Things will change, don't expect this file to
++ * remain compatible info the future.
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License
++ *     version 2 as published by the Free Software Foundation.
++ *
++ *     This file is distributed in the hope that it will be useful
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED , WITHOUT WARRANTY OF ANY KIND
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#include "armada-388.dtsi"
++#include "armada-38x-solidrun-microsom.dtsi"
++
++/ {
++	aliases {
++		/* So that mvebu u-boot can update the MAC addresses */
++		ethernet1 = &eth0;
++		ethernet2 = &eth1;
++		ethernet3 = &eth2;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	reg_3p3v: regulator-3p3v {
++		compatible = "regulator-fixed";
++		regulator-name = "3P3V";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-always-on;
++	};
++
++	soc {
++		internal-regs {
++			sata@a8000 {
++				/* pinctrl? */
++				status = "okay";
++			};
++
++			sata@e0000 {
++				/* pinctrl? */
++				status = "okay";
++			};
++
++			sdhci@d8000 {
++				bus-width = <4>;
++				cd-gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
++				no-1-8-v;
++				pinctrl-0 = <&microsom_sdhci_pins
++					     &clearfog_sdhci_cd_pins>;
++				pinctrl-names = "default";
++				status = "okay";
++				vmmc = <&reg_3p3v>;
++				wp-inverted;
++			};
++
++			usb@58000 {
++				/* CON3, nearest  power. */
++				status = "okay";
++			};
++
++			usb3@f8000 {
++				/* CON7 */
++				status = "okay";
++			};
++		};
++
++		pcie-controller {
++			status = "okay";
++			/*
++			 * The two PCIe units are accessible through
++			 * the mini-PCIe connectors on the board.
++			 */
++			pcie@2,0 {
++				/* Port 1, Lane 0. CON3, nearest power. */
++				reset-gpios = <&expander0 1 GPIO_ACTIVE_LOW>;
++				status = "okay";
++			};
++		};
++	};
++
++	sfp: sfp {
++		compatible = "sff,sfp";
++		i2c-bus = <&i2c1>;
++		los-gpio = <&expander0 12 GPIO_ACTIVE_HIGH>;
++		moddef0-gpio = <&expander0 15 GPIO_ACTIVE_LOW>;
++		sfp,ethernet = <&eth2>;
++		tx-disable-gpio = <&expander0 14 GPIO_ACTIVE_HIGH>;
++		tx-fault-gpio = <&expander0 13 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&eth1 {
++	/* ethernet@30000 */
++	bm,pool-long = <2>;
++	bm,pool-short = <1>;
++	buffer-manager = <&bm>;
++	phy-mode = "sgmii";
++	status = "okay";
++};
++
++&eth2 {
++	/* ethernet@34000 */
++	bm,pool-long = <3>;
++	bm,pool-short = <1>;
++	buffer-manager = <&bm>;
++	managed = "in-band-status";
++	phy-mode = "sgmii";
++	status = "okay";
++};
++
++&i2c0 {
++	clock-frequency = <400000>;
++	pinctrl-0 = <&i2c0_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++
++	/*
++	 * PCA9655 GPIO expander, up to 1MHz clock.
++	 *  0-CON3 CLKREQ#
++	 *  1-CON3 PERST#
++	 *  2-
++	 *  3-CON3 W_DISABLE
++	 *  4-
++	 *  5-USB3 overcurrent
++	 *  6-USB3 power
++	 *  7-
++	 *  8-JP4 P1
++	 *  9-JP4 P4
++	 * 10-JP4 P5
++	 * 11-m.2 DEVSLP
++	 * 12-SFP_LOS
++	 * 13-SFP_TX_FAULT
++	 * 14-SFP_TX_DISABLE
++	 * 15-SFP_MOD_DEF0
++	 */
++	expander0: gpio-expander@20 {
++		/*
++		 * This is how it should be:
++		 * compatible = "onnn,pca9655", "nxp,pca9555";
++		 * but you can't do this because of the way I2C works.
++		 */
++		compatible = "nxp,pca9555";
++		gpio-controller;
++		#gpio-cells = <2>;
++		reg = <0x20>;
++
++		pcie1_0_clkreq {
++			gpio-hog;
++			gpios = <0 GPIO_ACTIVE_LOW>;
++			input;
++			line-name = "pcie1.0-clkreq";
++		};
++		pcie1_0_w_disable {
++			gpio-hog;
++			gpios = <3 GPIO_ACTIVE_LOW>;
++			output-low;
++			line-name = "pcie1.0-w-disable";
++		};
++		usb3_ilimit {
++			gpio-hog;
++			gpios = <5 GPIO_ACTIVE_LOW>;
++			input;
++			line-name = "usb3-current-limit";
++		};
++		usb3_power {
++			gpio-hog;
++			gpios = <6 GPIO_ACTIVE_HIGH>;
++			output-high;
++			line-name = "usb3-power";
++		};
++		m2_devslp {
++			gpio-hog;
++			gpios = <11 GPIO_ACTIVE_HIGH>;
++			output-low;
++			line-name = "m.2 devslp";
++		};
++	};
++
++	/* The MCP3021 supports standard and fast modes */
++	mikrobus_adc: mcp3021@4c {
++		compatible = "microchip,mcp3021";
++		reg = <0x4c>;
++	};
++};
++
++&i2c1 {
++	/*
++	 * Routed to SFP, mikrobus, and PCIe.
++	 * SFP limits this to 100kHz, and requires an AT24C01A/02/04 with
++	 *  address pins tied low, which takes addresses 0x50 and 0x51.
++	 * Mikrobus doesn't specify beyond an I2C bus being present.
++	 * PCIe uses ARP to assign addresses, or 0x63-0x64.
++	 */
++	clock-frequency = <100000>;
++	pinctrl-0 = <&clearfog_i2c1_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&pinctrl {
++	clearfog_i2c1_pins: i2c1-pins {
++		/* SFP, PCIe, mSATA, mikrobus */
++		marvell,pins = "mpp26", "mpp27";
++		marvell,function = "i2c1";
++	};
++	clearfog_sdhci_cd_pins: clearfog-sdhci-cd-pins {
++		marvell,pins = "mpp20";
++		marvell,function = "gpio";
++	};
++	mikro_pins: mikro-pins {
++		/* int: mpp22 rst: mpp29 */
++		marvell,pins = "mpp22", "mpp29";
++		marvell,function = "gpio";
++	};
++	mikro_spi_pins: mikro-spi-pins {
++		marvell,pins = "mpp43";
++		marvell,function = "spi1";
++	};
++	mikro_uart_pins: mikro-uart-pins {
++		marvell,pins = "mpp24", "mpp25";
++		marvell,function = "ua1";
++	};
++};
++
++&spi1 {
++	/*
++	 * Add SPI CS pins for clearfog:
++	 * CS0: W25Q32 (not populated on uSOM)
++	 * CS1: PIC microcontroller (Pro models)
++	 * CS2: mikrobus
++	 */
++	pinctrl-0 = <&spi1_pins &mikro_spi_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&uart1 {
++	/* mikrobus uart */
++	pinctrl-0 = <&mikro_uart_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
+diff --git a/arch/arm/boot/dts/armada-38x-solidrun-microsom-emmc.dtsi b/arch/arm/boot/dts/armada-38x-solidrun-microsom-emmc.dtsi
+new file mode 100644
+index 0000000..6b623b6
+--- /dev/null
++++ b/arch/arm/boot/dts/armada-38x-solidrun-microsom-emmc.dtsi
+@@ -0,0 +1,62 @@
++/*
++ * Device Tree file for SolidRun Armada 38x Microsom add-on for eMMC
++ *
++ *  Copyright (C) 2015 Russell King
++ *
++ * This board is in development; the contents of this file work with
++ * the A1 rev 2.0 of the board, which does not represent final
++ * production board.  Things will change, don't expect this file to
++ * remain compatible info the future.
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License
++ *     version 2 as published by the Free Software Foundation.
++ *
++ *     This file is distributed in the hope that it will be useful
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED , WITHOUT WARRANTY OF ANY KIND
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++/ {
++	soc {
++		internal-regs {
++			sdhci@d8000 {
++				bus-width = <4>;
++				no-1-8-v;
++				non-removable;
++				pinctrl-0 = <&microsom_sdhci_pins>;
++				pinctrl-names = "default";
++				status = "okay";
++				wp-inverted;
++			};
++		};
++	};
++};
+-- 
+2.10.2
+

--- a/target/linux/mvebu/patches-4.9/472-armada-solidrun-microsom-backport-improvements.patch
+++ b/target/linux/mvebu/patches-4.9/472-armada-solidrun-microsom-backport-improvements.patch
@@ -1,0 +1,190 @@
+From fc5783a00be9251196091be6b9cdd54fe196630b Mon Sep 17 00:00:00 2001
+From: Marko Ratkaj <marko.ratkaj@sartura.hr>
+Date: Fri, 7 Apr 2017 11:24:19 +0200
+Subject: [PATCH] armada-38x-solidrun-microsom backport improvements from
+ upstream
+
+Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>
+---
+ .../arm/boot/dts/armada-38x-solidrun-microsom.dtsi | 130 ++++++++++++---------
+ 1 file changed, 74 insertions(+), 56 deletions(-)
+
+diff --git a/arch/arm/boot/dts/armada-38x-solidrun-microsom.dtsi b/arch/arm/boot/dts/armada-38x-solidrun-microsom.dtsi
+index 8c98422..9b508a8 100644
+--- a/arch/arm/boot/dts/armada-38x-solidrun-microsom.dtsi
++++ b/arch/arm/boot/dts/armada-38x-solidrun-microsom.dtsi
+@@ -17,17 +17,17 @@
+  *     modify it under the terms of the GNU General Public License
+  *     version 2 as published by the Free Software Foundation.
+  *
+- *     This file is distributed in the hope that it will be useful
++ *     This file is distributed in the hope that it will be useful,
+  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  *     GNU General Public License for more details.
+  *
+- * Or, alternatively
++ * Or, alternatively,
+  *
+  *  b) Permission is hereby granted, free of charge, to any person
+  *     obtaining a copy of this software and associated documentation
+  *     files (the "Software"), to deal in the Software without
+- *     restriction, including without limitation the rights to use
++ *     restriction, including without limitation the rights to use,
+  *     copy, modify, merge, publish, distribute, sublicense, and/or
+  *     sell copies of the Software, and to permit persons to whom the
+  *     Software is furnished to do so, subject to the following
+@@ -36,11 +36,11 @@
+  *     The above copyright notice and this permission notice shall be
+  *     included in all copies or substantial portions of the Software.
+  *
+- *     THE SOFTWARE IS PROVIDED , WITHOUT WARRANTY OF ANY KIND
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+- *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  *     OTHER DEALINGS IN THE SOFTWARE.
+@@ -62,45 +62,6 @@
+ 			  MBUS_ID(0x0c, 0x04) 0 0xf1200000 0x100000>;
+ 
+ 		internal-regs {
+-			ethernet@70000 {
+-				pinctrl-0 = <&ge0_rgmii_pins>;
+-				pinctrl-names = "default";
+-				phy = <&phy_dedicated>;
+-				phy-mode = "rgmii-id";
+-				buffer-manager = <&bm>;
+-				bm,pool-long = <0>;
+-				bm,pool-short = <1>;
+-				status = "okay";
+-			};
+-
+-			mdio@72004 {
+-				/*
+-				 * Add the phy clock here, so the phy can be
+-				 * accessed to read its IDs prior to binding
+-				 * with the driver.
+-				 */
+-				pinctrl-0 = <&mdio_pins &microsom_phy_clk_pins>;
+-				pinctrl-names = "default";
+-
+-				phy_dedicated: ethernet-phy@0 {
+-					/*
+-					 * Annoyingly, the marvell phy driver
+-					 * configures the LED register, rather
+-					 * than preserving reset-loaded setting.
+-					 * We undo that rubbish here.
+-					 */
+-					marvell,reg-init = <3 16 0 0x101e>;
+-					reg = <0>;
+-				};
+-			};
+-
+-			pinctrl@18000 {
+-				microsom_phy_clk_pins: microsom-phy-clk-pins {
+-					marvell,pins = "mpp45";
+-					marvell,function = "ref";
+-				};
+-			};
+-
+ 			rtc@a3800 {
+ 				/*
+ 				 * If the rtc doesn't work, run "date reset"
+@@ -108,21 +69,78 @@
+ 				 */
+ 				status = "okay";
+ 			};
++		};
++	};
++};
+ 
+-			serial@12000 {
+-				pinctrl-0 = <&uart0_pins>;
+-				pinctrl-names = "default";
+-				status = "okay";
+-			};
++&bm {
++	status = "okay";
++};
+ 
+-			bm@c8000 {
+-				status = "okay";
+-			};
+-		};
++&bm_bppi {
++	status = "okay";
++};
+ 
+-		bm-bppi {
+-			status = "okay";
+-		};
++&eth0 {
++	/* ethernet@70000 */
++	pinctrl-0 = <&ge0_rgmii_pins>;
++	pinctrl-names = "default";
++	phy = <&phy_dedicated>;
++	phy-mode = "rgmii-id";
++	buffer-manager = <&bm>;
++	bm,pool-long = <0>;
++	bm,pool-short = <1>;
++	status = "okay";
++};
++
++&mdio {
++	/*
++	 * Add the phy clock here, so the phy can be accessed to read its
++	 * IDs prior to binding with the driver.
++	 */
++	pinctrl-0 = <&mdio_pins &microsom_phy_clk_pins>;
++	pinctrl-names = "default";
++
++	phy_dedicated: ethernet-phy@0 {
++		/*
++		 * Annoyingly, the marvell phy driver configures the LED
++		 * register, rather than preserving reset-loaded setting.
++		 * We undo that rubbish here.
++		 */
++		marvell,reg-init = <3 16 0 0x101e>;
++		reg = <0>;
++	};
++};
++
++&pinctrl {
++	microsom_phy_clk_pins: microsom-phy-clk-pins {
++		marvell,pins = "mpp45";
++		marvell,function = "ref";
++	};
++	/* Optional eMMC */
++	microsom_sdhci_pins: microsom-sdhci-pins {
++		marvell,pins = "mpp21", "mpp28", "mpp37",
++			       "mpp38", "mpp39", "mpp40";
++		marvell,function = "sd0";
++	};
++};
++
++&spi1 {
++	/* The microsom has an optional W25Q32 on board, connected to CS0 */
++	pinctrl-0 = <&spi1_pins>;
+ 
++	w25q32: spi-flash@0 {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		compatible = "w25q32", "jedec,spi-nor";
++		reg = <0>; /* Chip select 0 */
++		spi-max-frequency = <3000000>;
++		status = "disabled";
+ 	};
+ };
++
++&uart0 {
++	pinctrl-0 = <&uart0_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
+-- 
+2.10.2
+

--- a/target/linux/mvebu/patches-4.9/473-fix-marvell-phy-initialization-issues.patch
+++ b/target/linux/mvebu/patches-4.9/473-fix-marvell-phy-initialization-issues.patch
@@ -1,0 +1,67 @@
+From 0ae0ddebb03dcc6d401743de649cfaed6a87c9ae Mon Sep 17 00:00:00 2001
+From: Marko Ratkaj <marko.ratkaj@sartura.hr>
+Date: Fri, 7 Apr 2017 13:30:30 +0200
+Subject: [PATCH] fix marvell phy initialization issues
+
+Fix Marvell PHYs initialization issues and optimize
+logic for page changing during init
+
+Board affected with initialization bug:
+  SolidRun ClearFog Base
+
+Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>
+---
+ drivers/net/phy/marvell.c | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/phy/marvell.c b/drivers/net/phy/marvell.c
+index ed9d8d9..b8a2462 100644
+--- a/drivers/net/phy/marvell.c
++++ b/drivers/net/phy/marvell.c
+@@ -361,7 +361,7 @@ static int m88e1111_config_aneg(struct phy_device *phydev)
+ static int marvell_of_reg_init(struct phy_device *phydev)
+ {
+ 	const __be32 *paddr;
+-	int len, i, saved_page, current_page, page_changed, ret;
++	int len, i, saved_page, current_page, ret;
+ 
+ 	if (!phydev->mdio.dev.of_node)
+ 		return 0;
+@@ -374,7 +374,6 @@ static int marvell_of_reg_init(struct phy_device *phydev)
+ 	saved_page = phy_read(phydev, MII_MARVELL_PHY_PAGE);
+ 	if (saved_page < 0)
+ 		return saved_page;
+-	page_changed = 0;
+ 	current_page = saved_page;
+ 
+ 	ret = 0;
+@@ -388,7 +387,6 @@ static int marvell_of_reg_init(struct phy_device *phydev)
+ 
+ 		if (reg_page != current_page) {
+ 			current_page = reg_page;
+-			page_changed = 1;
+ 			ret = phy_write(phydev, MII_MARVELL_PHY_PAGE, reg_page);
+ 			if (ret < 0)
+ 				goto err;
+@@ -411,7 +409,7 @@ static int marvell_of_reg_init(struct phy_device *phydev)
+ 
+ 	}
+ err:
+-	if (page_changed) {
++	if (current_page != saved_page) {
+ 		i = phy_write(phydev, MII_MARVELL_PHY_PAGE, saved_page);
+ 		if (ret == 0)
+ 			ret = i;
+@@ -1192,7 +1190,8 @@ static int marvell_read_status(struct phy_device *phydev)
+ 	int err;
+ 
+ 	/* Check the fiber mode first */
+-	if (phydev->supported & SUPPORTED_FIBRE) {
++	if (phydev->supported & SUPPORTED_FIBRE &&
++	    phydev->interface != PHY_INTERFACE_MODE_SGMII) {
+ 		err = phy_write(phydev, MII_MARVELL_PHY_PAGE, MII_M1111_FIBER);
+ 		if (err < 0)
+ 			goto error;
+-- 
+2.10.2
+


### PR DESCRIPTION
This patch set does two things:
1. The conventional ClearFog model is now known as the "Clearfog Pro", so rename it
2. Add support for SolidRun ClearFog Base board