### PR TITLE
Generate EFI grub images for x86 platforms

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -185,21 +185,29 @@ menu "Target Images"
 		select PACKAGE_grub2
 		default y
 
+	config EFI_IMAGES
+		bool "Build EFI GRUB images (Linux x86 or x86_64 host only)"
+		depends on TARGET_x86
+		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_ISO || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS
+		select PACKAGE_grub2
+		select PACKAGE_grub2-efi
+		default y
+
 	config GRUB_CONSOLE
 		bool "Use Console Terminal (in addition to Serial)"
-		depends on GRUB_IMAGES
+		depends on GRUB_IMAGES || EFI_IMAGES
 		default n if (TARGET_x86_generic_Soekris45xx || TARGET_x86_generic_Soekris48xx || TARGET_x86_net5501 || TARGET_x86_geos || TARGET_x86_alix2)
 		default y
 
 	config GRUB_SERIAL
 		string "Serial port device"
-		depends on GRUB_IMAGES
+		depends on GRUB_IMAGES || EFI_IMAGES
 		default "hvc0" if TARGET_x86_xen_domu
 		default "ttyS0" if ! TARGET_x86_xen_domu
 
 	config GRUB_BAUDRATE
 		int "Serial port baud rate"
-		depends on GRUB_IMAGES
+		depends on GRUB_IMAGES || EFI_IMAGES
 		default 38400 if TARGET_x86_generic
 		default 115200
 
@@ -210,14 +218,14 @@ menu "Target Images"
 
 	config GRUB_BOOTOPTS
 		string "Extra kernel boot options"
-		depends on GRUB_IMAGES
+		depends on GRUB_IMAGES || EFI_IMAGES
 		default "xencons=hvc" if TARGET_x86_xen_domu
 		help
 		  If you don't know, just leave it blank.
 
 	config GRUB_TIMEOUT
 		string "Seconds to wait before booting the default entry"
-		depends on GRUB_IMAGES
+		depends on GRUB_IMAGES || EFI_IMAGES
 		default "5"
 		help
 		  If you don't know, 5 seconds is a reasonable default.
@@ -225,14 +233,14 @@ menu "Target Images"
 	config VDI_IMAGES
 		bool "Build VirtualBox image files (VDI)"
 		depends on TARGET_x86 || TARGET_x86_64
-		select GRUB_IMAGES
+		depends on GRUB_IMAGES || EFI_IMAGES
 		select TARGET_IMAGES_PAD
 		select PACKAGE_kmod-e1000
 
 	config VMDK_IMAGES
 		bool "Build VMware image files (VMDK)"
 		depends on TARGET_x86 || TARGET_x86_64
-		select GRUB_IMAGES
+		depends on GRUB_IMAGES || EFI_IMAGES
 		select TARGET_IMAGES_PAD
 		select PACKAGE_kmod-e1000
 
@@ -251,19 +259,19 @@ menu "Target Images"
 
 	config TARGET_KERNEL_PARTSIZE
 		int "Kernel partition size (in MB)"
-		depends on GRUB_IMAGES
+		depends on GRUB_IMAGES || EFI_IMAGES
 		default 16
 
 	config TARGET_ROOTFS_PARTSIZE
 		int "Root filesystem partition size (in MB)"
-		depends on GRUB_IMAGES || TARGET_ROOTFS_EXT4FS || TARGET_rb532 || TARGET_mvebu || TARGET_uml
+		depends on GRUB_IMAGES || EFI_IMAGES || TARGET_ROOTFS_EXT4FS || TARGET_rb532 || TARGET_mvebu || TARGET_uml
 		default 256
 		help
 		  Select the root filesystem partition size.
 
 	config TARGET_ROOTFS_PARTNAME
 		string "Root partition on target device"
-		depends on GRUB_IMAGES
+		depends on GRUB_IMAGES || EFI_IMAGES
 		help
 		  Override the root partition on the final device. If left empty,
 		  it will be mounted by PARTUUID which makes the kernel find the

--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -117,6 +117,24 @@ export_bootdevice() {
 		esac
 
 		case "$disk" in
+			PARTUUID=[A-F0-9][A-F0-9][A-F0-9][A-F0-9][A-F0-9][A-F0-9][A-F0-9][A-F0-9]-[A-F0-9][A-F0-9][A-F0-9][A-F0-9]-[A-F0-9][A-F0-9][A-F0-9][A-F0-9]-[A-F0-9][A-F0-9][A-F0-9][A-F0-9]-[A-F0-9][A-F0-9][A-F0-9][A-F0-9][A-F0-9][A-F0-9][A-F0-9][A-F0-9]0002)
+				uuid="${disk#PARTUUID=}"
+				uuid="${uuid%0002}0002"
+				for disk in $(find /dev -type b); do
+					set -- $(dd if=$disk bs=1 skip=$((2*512+256+128+16)) count=16 2>/dev/null | hexdump -v -e '4/1 "%02x"' | awk '{ \
+							for(i=1;i<9;i=i+2) first=substr($0,i,1) substr($0,i+1,1) first; \
+							for(i=9;i<13;i=i+2) second=substr($0,i,1) substr($0,i+1,1) second; \
+							for(i=13;i<16;i=i+2) third=substr($0,i,1) substr($0,i+1,1) third; \
+							fourth = substr($0,17,4); \
+							five = substr($0,21,12); \
+						} END { print toupper(first"-"second"-"third"-"fourth"-"five) }')
+					if [ "$1" = "$uuid" ]; then
+						uevent="/sys/class/block/${disk##*/}/uevent"
+						export SAVE_PARTITIONS=0
+						break
+					fi
+				done
+			;;
 			PARTUUID=[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]-02)
 				uuid="${disk#PARTUUID=}"
 				uuid="${uuid%-02}"

--- a/package/boot/grub2/common.mk
+++ b/package/boot/grub2/common.mk
@@ -1,51 +1,29 @@
-#
-# Copyright (C) 2006-2015 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
-
-include $(TOPDIR)/rules.mk
-include $(INCLUDE_DIR)/kernel.mk
-
-PKG_NAME:=grub
 PKG_VERSION:=2.02
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=grub-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/grub
 PKG_HASH:=810b3798d316394f94096ec2797909dbf23c858e48f7b3830826b8daa06b7b0f
 
 PKG_FIXUP:=autoreconf
 HOST_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=grub2/host
 
 PKG_SSP:=0
 
 PKG_FLAGS:=nonshared
 
+PATCH_DIR := ../patches
+HOST_PATCH_DIR := ../patches
+
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
-define Package/grub2
+define Package/grub2/Default
   CATEGORY:=Boot Loaders
   SECTION:=boot
   TITLE:=GRand Unified Bootloader
   URL:=http://www.gnu.org/software/grub/
   DEPENDS:=@TARGET_x86||TARGET_x86_64
-endef
-
-define Package/grub2-editenv
-  CATEGORY:=Utilities
-  SECTION:=utils
-  SUBMENU:=Boot Loaders
-  TITLE:=Grub2 Environment editor
-  URL:=http://www.gnu.org/software/grub/
-  DEPENDS:=@TARGET_x86||TARGET_x86_64
-endef
-
-define Package/grub2-editenv/description
-	Edit grub2 environment files.
 endef
 
 HOST_BUILD_PREFIX := $(STAGING_DIR_HOST)
@@ -81,11 +59,3 @@ define Host/Configure
 	$(Host/Configure/Default)
 endef
 
-define Package/grub2-editenv/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/grub-editenv $(1)/usr/sbin/
-endef
-
-$(eval $(call HostBuild))
-$(eval $(call BuildPackage,grub2))
-$(eval $(call BuildPackage,grub2-editenv))

--- a/package/boot/grub2/grub2-efi/Makefile
+++ b/package/boot/grub2/grub2-efi/Makefile
@@ -1,0 +1,22 @@
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=grub-efi
+
+include ../common.mk
+
+TAR_OPTIONS:= --transform 's/grub-${PKG_VERSION}/${PKG_NAME}-${PKG_VERSION}/' $(TAR_OPTIONS)
+
+PKG_BUILD_DEPENDS:=grub2-efi/host
+
+CONFIGURE_ARGS += --with-platform=efi
+HOST_CONFIGURE_ARGS += --with-platform=efi --program-suffix=-efi
+
+define Package/grub2-efi
+$(call Package/grub2/Default)
+HIDDEN:=1
+TITLE += (with EFI support)
+endef
+
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,grub2-efi))

--- a/package/boot/grub2/grub2/Makefile
+++ b/package/boot/grub2/grub2/Makefile
@@ -1,0 +1,33 @@
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=grub
+
+include ../common.mk
+
+PKG_BUILD_DEPENDS:=grub2/host
+
+define Package/grub2
+$(call Package/grub2/Default)
+endef
+
+define Package/grub2-editenv
+  CATEGORY:=Utilities
+  SECTION:=utils
+  TITLE:=Grub2 Environment editor
+  URL:=http://www.gnu.org/software/grub/
+  DEPENDS:=@TARGET_x86||TARGET_x86_64
+endef
+
+define Package/grub2-editenv/description
+	Edit grub2 environment files.
+endef
+
+define Package/grub2-editenv/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/grub-editenv $(1)/usr/sbin/
+endef
+
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,grub2))
+$(eval $(call BuildPackage,grub2-editenv))

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -10,6 +10,9 @@ include $(INCLUDE_DIR)/image.mk
 export PATH=$(TARGET_PATH):/sbin
 
 GRUB2_MODULES = biosdisk boot chain configfile ext2 linux ls part_msdos reboot serial vga
+GRUB2_MODULES_LEGACY = $(GRUB2_MODULES)
+GRUB2_MODULES_LEGACY += part_gpt search fat exfat
+GRUB2_MODULES_EFI = boot chain configfile ext2 linux ls part_msdos reboot serial part_gpt part_msdos search fat exfat ext2 efi_gop efi_uga gfxterm
 GRUB2_MODULES_ISO = biosdisk boot chain configfile iso9660 linux ls part_msdos reboot serial vga
 GRUB_TERMINALS =
 GRUB_SERIAL_CONFIG =
@@ -42,6 +45,8 @@ ifneq ($(GRUB_TERMINALS),)
 endif
 
 SIGNATURE:=$(shell perl -e 'printf("%08x", rand(0xFFFFFFFF))')
+EFI_SIGNATURE:=$(shell perl -e 'printf("%08x-%04x-%04x-%04x-%06x%06x", rand(0xFFFFFFFF), rand(0xFFFF), rand(0xFFFF), rand(0xFFFF), rand(0xFFFFFF), rand(0xFFFFFF))')
+
 ROOTPART:=$(call qstrip,$(CONFIG_TARGET_ROOTFS_PARTNAME))
 ROOTPART:=$(if $(ROOTPART),$(ROOTPART),PARTUUID=$(SIGNATURE)-02)
 
@@ -51,7 +56,7 @@ ifneq ($(CONFIG_TARGET_x86_xen_domu),)
   GRUB_ROOT = xen/xvda,msdos1
 endif
 
-ifneq ($(CONFIG_GRUB_IMAGES),)
+ifneq ($(CONFIG_GRUB_IMAGES)$(CONFIG_EFI_IMAGES),)
 
   BOOTOPTS:=$(call qstrip,$(CONFIG_GRUB_BOOTOPTS))
 
@@ -63,6 +68,90 @@ ifneq ($(CONFIG_GRUB_IMAGES),)
     root=$(ROOTPART) rootfstype=squashfs rootwait
   endef
 
+  ifneq ($(CONFIG_EFI_IMAGES),)
+
+  define Image/cmdline/efi
+    $(subst $(SIGNATURE)-02,$2,$(call Image/cmdline/$(1)))
+  endef
+
+  define Image/Build/efi
+	# left here because the image builder doesnt need these
+	rm -rf $(KDIR)/root.grub/ || true
+	$(INSTALL_DIR) $(KDIR)/root.grub/boot/grub $(KDIR)/grub2
+	$(CP) $(KDIR)/bzImage $(KDIR)/root.grub/boot/vmlinuz
+	echo '(hd0) $(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img' > $(KDIR)/grub2/device.map
+	sed \
+		-e 's#@SERIAL_CONFIG@#$(strip $(GRUB_SERIAL_CONFIG))#g' \
+		-e 's#@TERMINAL_CONFIG@#$(strip $(GRUB_TERMINAL_CONFIG))#g' \
+		-e 's#@CMDLINE@#$(strip $(call Image/cmdline/efi,$(1),$(EFI_SIGNATURE)) $(BOOTOPTS) $(GRUB_CONSOLE_CMDLINE))#g' \
+		-e 's#@TIMEOUT@#$(GRUB_TIMEOUT)#g' \
+		-e 's#set root.*#search --file /boot/grub/$(SIGNATURE).cfg --set=root#g' \
+		./grub.cfg > $(KDIR)/root.grub/boot/grub/grub.cfg
+	$(CP) $(KDIR)/root.grub/boot/grub/grub.cfg $(KDIR)/root.grub/boot/grub/$(SIGNATURE).cfg
+	grub-mkimage \
+		-d $(STAGING_DIR_HOST)/lib/grub/i386-pc \
+		-o $(KDIR)/grub2/core.img \
+		-O i386-pc \
+		-p '(hd0,gpt1)/boot/grub' \
+		-c $(KDIR)/root.grub/boot/grub/grub.cfg \
+		$(GRUB2_MODULES_LEGACY)
+	$(CP) $(STAGING_DIR_HOST)/lib/grub/i386-pc/*.img $(KDIR)/grub2/
+
+	# Build the efi grub version
+	rm -rf $(KDIR)/grub2.efi/ || true
+	$(INSTALL_DIR) $(KDIR)/grub2.efi/efi/boot/
+
+	# Generate the grub search root config (grub will search for the $(SIGNATURE).cfg file placed on the boot partition as grub does not support search of GPT UUID yet)
+	echo "search --file /boot/grub/$(SIGNATURE).cfg --set=root" > $(KDIR)/grub2.efi/efi/boot/grub.cfg
+	echo "configfile /boot/grub/grub.cfg" >> $(KDIR)/grub2.efi/efi/boot/grub.cfg
+
+	# Create the EFI grub binary
+	grub-mkimage-efi \
+		-d $(STAGING_DIR_HOST)/lib/grub/x86_64-efi \
+		-o $(KDIR)/grub2.efi/efi/boot/bootx64.efi \
+		-O x86_64-efi \
+		-p /efi/boot \
+		-c $(KDIR)/grub2.efi/efi/boot/grub.cfg \
+		$(GRUB2_MODULES_EFI)
+
+	# Generate the EFI VFAT bootfs
+	rm $(KDIR)/kernel.efi || true
+	mkfs.fat -C $(KDIR)/kernel.efi -S 512 1024
+	mcopy -s -i "$(KDIR)/kernel.efi" $(KDIR)/grub2.efi/* ::/
+
+	SIGNATURE="$(SIGNATURE)" PATH="$(TARGET_PATH)" ./gen_image_efi.sh \
+		$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img \
+		$(CONFIG_TARGET_KERNEL_PARTSIZE) $(KDIR)/root.grub \
+		1 $(KDIR)/kernel.efi \
+		1 \
+		$(CONFIG_TARGET_ROOTFS_PARTSIZE) $(KDIR)/root.$(1) \
+		256
+
+	# Setup legacy bios for hybrid MBR (optional)
+	grub-bios-setup \
+		--device-map="$(KDIR)/grub2/device.map" \
+		-d "$(KDIR)/grub2" \
+		-r "hd0,msdos1" \
+		"$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
+
+	# Convert the MBR partition to GPT and set EFI ROOTFS signature
+	dd if=/dev/zero of="$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img" bs=512 count=33 conv=notrunc oflag=append
+	sgdisk -g "$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
+	sgdisk -t 2:EF00 "$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
+	sgdisk -t 3:EF02 "$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
+	sgdisk -u 4:$(EFI_SIGNATURE) "$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
+	sgdisk -h "$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
+
+	# Setup EFI grub
+	grub-bios-setup-efi \
+		--device-map="$(KDIR)/grub2/device.map" \
+		-d "$(KDIR)/grub2" \
+		-r "hd0,gpt1" \
+		"$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
+  endef
+  endif
+
+  ifneq ($(CONFIG_GRUB_IMAGES),)
   define Image/Build/grub2
 	# left here because the image builder doesnt need these
 	$(INSTALL_DIR) $(KDIR)/root.grub/boot/grub $(KDIR)/grub2
@@ -94,6 +183,8 @@ ifneq ($(CONFIG_GRUB_IMAGES),)
 		-r "hd0,msdos1" \
 		"$(BIN_DIR)/$(IMG_PREFIX)-combined-$(1).img"
   endef
+  endif
+
 endif
 
 define Image/Build/squashfs
@@ -133,6 +224,14 @@ ifneq ($(CONFIG_VDI_IMAGES),)
 	# XXX: VBoxManage insists on setting perms to 0600
 	chmod 0644 $(BIN_DIR)/$(IMG_PREFIX)-combined-$(1).vdi
   endef
+  define Image/Build/vdi_efi
+	rm $(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).vdi || true
+	qemu-img convert -f raw -O vdi \
+		$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img \
+		$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).vdi
+	# XXX: VBoxManage insists on setting perms to 0600
+	chmod 0644 $(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).vdi
+  endef
 endif
 
 ifneq ($(CONFIG_VMDK_IMAGES),)
@@ -142,11 +241,22 @@ ifneq ($(CONFIG_VMDK_IMAGES),)
 		$(BIN_DIR)/$(IMG_PREFIX)-combined-$(1).img \
 		$(BIN_DIR)/$(IMG_PREFIX)-combined-$(1).vmdk
   endef
+  define Image/Build/vmdk_efi
+	rm $(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).vmdk || true
+	qemu-img convert -f raw -O vmdk \
+		$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img \
+		$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).vmdk
+  endef
 endif
 
 define Image/Build/gzip
-	gzip -f9n $(BIN_DIR)/$(IMG_PREFIX)-combined-$(1).img
 	gzip -f9n $(BIN_DIR)/$(IMG_PREFIX)-rootfs-$(1).img
+ifneq ($(CONFIG_GRUB_IMAGES),)
+	gzip -f9n $(BIN_DIR)/$(IMG_PREFIX)-combined-$(1).img
+endif
+ifneq ($(CONFIG_EFI_IMAGES),)
+	gzip -f9n $(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img
+endif
 endef
 
 ifneq ($(CONFIG_TARGET_IMAGES_GZIP),)
@@ -174,8 +284,15 @@ define Image/Build
 	$(call Image/Build/$(1))
   ifneq ($(1),iso)
 	$(call Image/Build/grub2,$(1))
+	$(call Image/Build/efi,$(1))
+ifneq ($(CONFIG_GRUB_IMAGES),)
 	$(call Image/Build/vdi,$(1))
 	$(call Image/Build/vmdk,$(1))
+endif
+ifneq ($(CONFIG_EFI_IMAGES),)
+	$(call Image/Build/vdi_efi,$(1))
+	$(call Image/Build/vmdk_efi,$(1))
+endif
 	$(CP) $(KDIR)/root.$(1) $(BIN_DIR)/$(IMG_PREFIX)-rootfs-$(1).img
   else
 	$(CP) $(KDIR)/root.iso $(BIN_DIR)/$(IMG_PREFIX).iso

--- a/target/linux/x86/image/gen_image_efi.sh
+++ b/target/linux/x86/image/gen_image_efi.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -x
+[ $# == 8 -o $# == 9 ] || {
+    echo "SYNTAX: $0 <file> <kernel size> <kernel directory> <efi size> <efi image> <efigrubmodule size> <rootfs size> <rootfs image> [<align>]"
+    exit 1
+}
+
+OUTPUT="$1"
+KERNELSIZE="$2"
+KERNELDIR="$3"
+EFISIZE="$4"
+EFIIMAGE="$5"
+EFIGRUBSIZE="$6"
+ROOTFSSIZE="$7"
+ROOTFSIMAGE="$8"
+ALIGN="$9"
+
+rm -f "$OUTPUT"
+
+head=16
+sect=63
+cyl=$(( ($KERNELSIZE + $EFISIZE + $EFIGRUBSIZE + $ROOTFSSIZE) * 1024 * 1024 / ($head * $sect * 512) ))
+
+# create partition table
+set `ptgen -o "$OUTPUT" -h $head -s $sect -p ${KERNELSIZE}m -p ${EFISIZE}m -p ${EFIGRUBSIZE}m -p ${ROOTFSSIZE}m ${ALIGN:+-l $ALIGN} ${SIGNATURE:+-S 0x$SIGNATURE}`
+
+KERNELOFFSET="$(($1 / 512))"
+KERNELSIZE="$2"
+EFIOFFSET="$(($3 / 512))"
+EFISIZE="$(($4 / 512))"
+EFIGRUBOFFSET="$(($5 / 512))"
+EFIGRUBSIZE="$(($6 / 512))"
+ROOTFSOFFSET="$(($7 / 512))"
+ROOTFSSIZE="$(($8 / 512))"
+
+dd if=/dev/zero of="$OUTPUT" bs=512 seek="$ROOTFSOFFSET" conv=notrunc count="$ROOTFSSIZE"
+dd if="$ROOTFSIMAGE" of="$OUTPUT" bs=512 seek="$ROOTFSOFFSET" conv=notrunc
+dd if="$EFIIMAGE" of="$OUTPUT" bs=512 seek="$EFIOFFSET" conv=notrunc
+
+[ -n "$NOGRUB" ] && exit 0
+
+make_ext4fs -J -l "$KERNELSIZE" "$OUTPUT.kernel" "$KERNELDIR"
+dd if="$OUTPUT.kernel" of="$OUTPUT" bs=512 seek="$KERNELOFFSET" conv=notrunc
+rm -f "$OUTPUT.kernel"

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -29,6 +29,7 @@ tools-y += mm-macros missing-macros cmake scons bc findutils gengetopt patchelf
 tools-y += mtools dosfstools libressl
 tools-$(CONFIG_TARGET_orion_generic) += wrt350nv2-builder upslug2
 tools-$(CONFIG_TARGET_x86) += qemu
+tools-$(CONFIG_EFI_IMAGES) += popt gptfdisk
 tools-$(CONFIG_TARGET_mxs) += elftosb sdimage
 tools-$(CONFIG_TARGET_ar71xx) += lzma-old squashfs
 tools-$(CONFIG_USES_MINOR) += kernel2minor
@@ -71,6 +72,7 @@ $(curdir)/libressl/compile := $(curdir)/pkg-config/compile
 $(curdir)/mkimage/compile += $(curdir)/libressl/compile
 $(curdir)/firmware-utils/compile += $(curdir)/libressl/compile
 $(curdir)/cmake/compile += $(curdir)/libressl/compile
+$(curdir)/gptfdisk/compile += $(curdir)/popt/compile $(curdir)/e2fsprogs/compile
 
 ifneq ($(HOST_OS),Linux)
   tools-y += coreutils

--- a/tools/gptfdisk/Makefile
+++ b/tools/gptfdisk/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gptfdisk
+PKG_VERSION:=1.0.1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.rodsbooks.com/gdisk/
+PKG_HASH:=864c8aee2efdda50346804d7e6230407d5f42a8ae754df70404dd8b2fdfaeac7
+
+HOST_BUILD_PARALLEL := 1
+
+include $(INCLUDE_DIR)/host-build.mk
+
+HOST_CONFIGURE_VARS += \
+        MAKEFLAGS="$(HOST_JOBS)" \
+        CXXFLAGS="$(HOST_CFLAGS)"
+
+HOST_CONFIGURE_ARGS := \
+        $(if $(MAKE_JOBSERVER),--parallel="$(MAKE_JOBSERVER)") \
+        --prefix=$(STAGING_DIR_HOST)
+
+define Host/Compile
+        $(MAKE) LDFLAGS="$(HOST_LDFLAGS)" CXXFLAGS="$(HOST_CFLAGS) -I$(STAGING_DIR_HOST)/include/e2fsprogs" -C $(HOST_BUILD_DIR) sgdisk
+endef
+
+define Host/Install
+        $(INSTALL_BIN) $(HOST_BUILD_DIR)/sgdisk $(STAGING_DIR_HOST)/bin/
+endef
+
+define Host/Clean
+        rm -f $(STAGING_DIR_HOST)/bin/sgdisk
+endef
+
+HOSTCC := $(HOSTCC_NOCACHE)
+HOSTCXX := $(HOSTCXX_NOCACHE)
+
+$(eval $(call HostBuild))

--- a/tools/popt/Makefile
+++ b/tools/popt/Makefile
@@ -1,0 +1,20 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=popt
+PKG_VERSION:=1.16
+PKG_HASH:=e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://rpm5.org/files/popt/
+PKG_LICENSE:=MIT
+
+HOST_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/host-build.mk
+
+HOST_CONFIGURE_ARGS += --disable-shared --disable-nls
+HOST_CFLAGS += $(FPIC)
+
+$(eval $(call HostBuild))
+


### PR DESCRIPTION
- Add option in make menuconfig to build an EFI Grub image with legacy grub support.
- Update the x86 Makefile to generate an EFi grub image [ MBR | Kernel | EFI | GrubModule | RootFs ]
- EFI image generate an UUID GPT signature to replace the too small legacy part signature.
- EFI image use the grub search files module to find the boot/kernel partition (as grub does not have a GPT uuid part search support).
- Fork grub build with efi platform support via a common.mk Makefile include to not fork the whole grub package and patches (host need both of legacy and efi modules to setup the bootloader on efi images).
- Add gptfdisk tools package to get sgdisk on host side, used for converting MBR to GPT tables.
- Fork gen_image_generic.sh in gen_image_efi.sh to add EFI related additional's partitions.
- Update common.sh to support GPT UUID root signature in /proc/cmdline and use awk (that is already embeded in pivot root) to reorder bytes of the dumped partition signature.
- Generate VDI and VMDK EFI images

```
GPT EFI partition scheme
+--------------------------------------------------------------------------------------------------------------------------+
| MBR (raw 1MB) | Kernel (ext4 4MB) | EF00 (vfat 1MB) | EF02 (raw 1MB) | Rootfs (ext4/squash XX MB)  | GTP table (raw 16KB)|
+--------------------------------------------------------------------------------------------------------------------------+
```

Known limitations : 
- Sysupgrade -p is forced for EFI/GPT images.

Tested on : 
- Virtualbox legacy mode (LEDE regression see below)
- Virtualbox EFI mode
- Intel Nuc DE3815TYKE legacy mode (LEDE regression see below)
- Intel Nuc DE3815TYKE EFI mode
- Giada F-210 with an EFI only bios
- Intel Cherry trail platform with an EFI only bios

Not tested on x86 32bits platform