### PR TITLE
Enable RTC_SUPPORT as a config option

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -39,6 +39,10 @@ menu "Global build settings"
 		bool "Show packages that require graphics support (local or remote)"
 		default n
 
+	config RTC_SUPPORT
+		bool "Enable RTC support"
+		default n
+
 	config BUILD_PATENTED
 		default y
 		bool "Compile with support for patented functionality"

--- a/target/Config.in
+++ b/target/Config.in
@@ -33,9 +33,6 @@ config USB_SUPPORT
 config USB_GADGET_SUPPORT
 	bool
 
-config RTC_SUPPORT
-	bool
-
 config BIG_ENDIAN
 	bool
 


### PR DESCRIPTION
Move RTC_SUPPORT from target/Config.in to config/Config-build.in, making it subject to manipulation by .config.  Some platforms that do not have onboard RTCs can nevertheless have them added (using, e.g. a i2c-tiny-usb and a ds3231 I2C RTC module) and being blocked from building the kernel modules is annoying.

This may not be the correct course of action; RTC_SUPPORT is used sparsely enough around the tree that perhaps removing it is the right answer instead.