### PR TITLE
build: no target  in the sdk directory like in openwrt

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -32,7 +32,7 @@ EXCLUDE_DIRS:=*/ccache/* \
 	*/doc \
 	*/share/locale
 
-SDK_DIRS = \
+SDK_DIRS = 	$(STAGING_SUBDIR_TARGET)\
 		$(STAGING_SUBDIR_HOST) \
 		$(STAGING_SUBDIR_TOOLCHAIN)
 


### PR DESCRIPTION
When building an image plus the sdk for that image, in openwrt 15.04 you 
get 3 directories under toolchain one of them is called target.... and contains
all the .so's that were installed on the target image. In Lede project this dir
is missing, apparently the reason is the drop of the line i've added. If it was 
done on purpose i don't understand the reason, if by mistake, well , there 
you go, the fix :-)
