### PR TITLE
download: allow specifying git clone options

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -162,7 +162,7 @@ define DownloadMethod/git
 		cd $(TMP_DIR)/dl && \
 		rm -rf $(SUBDIR) && \
 		[ \! -d $(SUBDIR) ] && \
-		git clone $(OPTS) $(URL) $(SUBDIR) && \
+		git clone $(GIT_OPTS) $(URL) $(SUBDIR) && \
 		(cd $(SUBDIR) && git checkout $(VERSION) && \
 		git submodule update --init --recursive) && \
 		echo "Packing checkout..." && \
@@ -243,7 +243,7 @@ define Download/Defaults
   MIRROR_HASH=$$(MIRROR_MD5SUM)
   MIRROR_MD5SUM:=x
   VERSION:=
-  OPTS:=
+  GIT_OPTS:=
 endef
 
 define Download/default
@@ -257,7 +257,7 @@ define Download/default
   VERSION:=$(PKG_SOURCE_VERSION)
   $(if $(PKG_MD5SUM),MD5SUM:=$(PKG_MD5SUM))
   $(if $(PKG_HASH),HASH:=$(PKG_HASH))
-  $(if $(PKG_SOURCE_OPTS),OPTS:=$(PKG_SOURCE_OPTS))
+  $(if $(PKG_GIT_OPTS),GIT_OPTS:=$(PKG_GIT_OPTS))
 endef
 
 define Download

--- a/include/download.mk
+++ b/include/download.mk
@@ -257,6 +257,7 @@ define Download/default
   VERSION:=$(PKG_SOURCE_VERSION)
   $(if $(PKG_MD5SUM),MD5SUM:=$(PKG_MD5SUM))
   $(if $(PKG_HASH),HASH:=$(PKG_HASH))
+  $(if $(PKG_SOURCE_OPTS),OPTS:=$(PKG_SOURCE_OPTS))
 endef
 
 define Download


### PR DESCRIPTION
- for git, there is an inaccessible OPTS variable already
- allow setting it via PKG_SOURCE_OPTS
- can be used for adding "--depth 1" to the git command for shallow clones

Signed-off-by: Thomas 'fake' Jakobi <thomas@derfake.com>
