### PR TITLE
ramips: support the rut5xx hardware watchdog

### DIFF
--- a/package/kernel/om-watchdog/files/om-watchdog.init
+++ b/package/kernel/om-watchdog/files/om-watchdog.init
@@ -48,6 +48,14 @@ get_gpio() {
 				return 16
 				;;
 		esac
+	elif [ -r /lib/ramips.sh ]; then
+		. /lib/ramips.sh
+		local board=$(ramips_board_name)
+		case "$board" in
+			"rut5xx")
+				return 11
+				;;
+		esac 
 	else
 		#we assume it is om1p in this case
 		return 3

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -635,6 +635,7 @@ TARGET_DEVICES += rt-n13u
 define Device/rut5xx
   DTS := RUT5XX
   DEVICE_TITLE := Teltonika RUT5XX
+  DEVICE_PACKAGES := om-watchdog
 endef
 TARGET_DEVICES += rut5xx
 


### PR DESCRIPTION
- add om-watchdog as default package for ramips rut5xx target
- add rut5xx GPIO PIN selection to om-package startup script

Signed-off-by: Steffen Weinreich <steve@weinreich.org>
