### PR TITLE
lantiq: improve DGN3500 LED definitions

### DIFF
--- a/target/linux/lantiq/dts/DGN3500.dtsi
+++ b/target/linux/lantiq/dts/DGN3500.dtsi
@@ -15,7 +15,7 @@
 		led-dsl = &dsl;
 		led-internet = &internet;
 		led-usb = &usb;
-		led-wifi = &wifi;
+		led-wifi = &wifi_green;
 	};
 
 	memory@0 {
@@ -106,9 +106,10 @@
 			label = "dgn3500:green:internet";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 		};
-		/*
-			internet red is missing
-		*/
+		internet2: internet2 {
+			label = "dgn3500:red:internet";
+			gpios = <&gpio 30 GPIO_ACTIVE_LOW>;
+		};
 		dsl: dsl {
 			label = "dgn3500:green:dsl";
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
@@ -126,14 +127,15 @@
 			label = "dgn3500:red:power";
 			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
 		};
-		/*
-			power amber is missing
-		*/
-		wifi: wifi {
-			label = "dgn3500:blue:wireless";
+		wifi_green: wifi {
+			label = "dgn3500:green:wireless";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+		wifi_amber: wifi2 {
+			label = "dgn3500:amber:wireless";
 			gpios = <&gpio 51 GPIO_ACTIVE_LOW>;
 		};
-		wps {
+		wps: wps {
 			label = "dgn3500:green:wps";
 			gpios = <&gpio 52 GPIO_ACTIVE_LOW>;
 		};


### PR DESCRIPTION
Add red:internet led on gpio 30 previously claimed as missing.
Wifi led was claimed as blue however there are no blue leds on the
board at all.  Actually there are two wifi leds, green & amber so add
definitions for those.  Make the newly discovered green wifi led gpio
14 the default.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>

Physical LEDS on my board are: (2 physical LEDs shown as dual)

Power - Green & Red Dual
Port 1 - Green & Amber Dual
Port 2 - Green & Amber Dual
Port 3 - Green & Amber Dual
Port 4 - Green & Amber Dual
Wifi - Green & Amber Dual
WPS - Green
USB - Green
DSL - Green
Internet - Green & Red Dual

Port LEDs are controlled directly by the switch rather than any gpio interface.  Green for 1000, Amber for 100/10.  The remaining mystery is to get them to blink on traffic like they do during the initial uboot.

