### PR TITLE
kernel: add Digi Edgeport USB serial driver package

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -503,6 +503,45 @@ endef
 $(eval $(call KernelPackage,usb-serial-ch341))
 
 
+define KernelPackage/usb-serial-edgeport
+  TITLE:=Support for Digi Edgeport devices
+  KCONFIG:=CONFIG_USB_SERIAL_EDGEPORT
+  FILES:=$(LINUX_DIR)/drivers/usb/serial/io_edgeport.ko
+  AUTOLOAD:=$(call AutoProbe,io_edgeport)
+  $(call AddDepends/usb-serial)
+endef
+
+define KernelPackage/usb-serial-edgeport/description
+ Kernel support for Inside Out Networks (Digi)
+	Edgeport/4
+	Rapidport/4
+	Edgeport/4t
+	Edgeport/2
+	Edgeport/4i
+	Edgeport/2i
+	Edgeport/421
+	Edgeport/21
+	Edgeport/8
+	Edgeport/8 Dual
+	Edgeport/2D8
+	Edgeport/4D8
+	Edgeport/8i
+	Edgeport/2 DIN
+	Edgeport/4 DIN
+	Edgeport/16 Dual
+endef
+
+define KernelPackage/usb-serial-edgeport/install
+	$(INSTALL_DIR) $(1)/lib/firmware/edgeport
+	$(INSTALL_DATA) $(LINUX_DIR)/firmware/edgeport/boot.fw $(1)/lib/firmware/edgeport/
+	$(INSTALL_DATA) $(LINUX_DIR)/firmware/edgeport/boot2.fw $(1)/lib/firmware/edgeport/
+	$(INSTALL_DATA) $(LINUX_DIR)/firmware/edgeport/down.fw $(1)/lib/firmware/edgeport/
+	$(INSTALL_DATA) $(LINUX_DIR)/firmware/edgeport/down2.fw $(1)/lib/firmware/edgeport/
+endef
+
+$(eval $(call KernelPackage,usb-serial-edgeport))
+
+
 define KernelPackage/usb-serial-ftdi
   TITLE:=Support for FTDI devices
   KCONFIG:=CONFIG_USB_SERIAL_FTDI_SIO


### PR DESCRIPTION
Signed-off-by: Bjørn Mork <bjorn@mork.no>

Adding another USB serial driver. The driver needs some firmware blobs which are present in th kernel source tree. These are simply copied into the driver package. They have never been updated, so there is IMHO no point in pulling them from the external firmware tree.  

This has been runtime tested with an "Edgeport 4" adapter connected to a WRT1900ACv1 (mvebu):

[    1.502585] usb 2-2: new full-speed USB device number 2 using xhci_hcd
[   11.739067] usbcore: registered new interface driver usbserial
[   11.745127] usbcore: registered new interface driver usbserial_generic
[   11.751925] usbserial: USB Serial support registered for generic
[   11.782790] usbcore: registered new interface driver io_edgeport
[   11.788965] usbserial: USB Serial support registered for Edgeport 2 port adapter
[   11.796561] usbserial: USB Serial support registered for Edgeport 4 port adapter
[   11.804166] usbserial: USB Serial support registered for Edgeport 8 port adapter
[   11.811723] usbserial: USB Serial support registered for EPiC device
[   11.818231] io_edgeport 2-2:1.0: Edgeport 4 port adapter converter detected
[   11.837828] usb 2-2: Inside Out Networks Edgeport/4 detected
[   14.868432] usb 2-2: Edgeport 4 port adapter converter now attached to ttyUSB0
[   14.876104] usb 2-2: Edgeport 4 port adapter converter now attached to ttyUSB1
[   14.883885] usb 2-2: Edgeport 4 port adapter converter now attached to ttyUSB2
[   14.891471] usb 2-2: Edgeport 4 port adapter converter now attached to ttyUSB3
