### PR TITLE
packages/utils/xfsprogs: Hide until updated

### DIFF
--- a/package/utils/xfsprogs/Makefile
+++ b/package/utils/xfsprogs/Makefile
@@ -5,6 +5,9 @@
 # See /LICENSE for more information.
 #
 
+# 3.2.X and newer uses a new on-disk format, disable (hide) xfsprogs until
+# it's updated to avoid unnecessary (bad) surprises.
+
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xfsprogs
@@ -26,6 +29,7 @@ define Package/xfsprogs/default
   SUBMENU:=Filesystem
   DEPENDS:=+libuuid +libpthread +librt
   URL:=http://oss.sgi.com/projects/xfs
+  HIDDEN:=1
 endef
 
 define Package/xfs-mkfs


### PR DESCRIPTION
3.2.X and newer uses a new on-disk format, disable (hide) xfsprogs until
it's updated to avoid unnecessary (bad) surprises.
Source: https://wiki.archlinux.org/index.php/XFS#Integrity

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>