### PR TITLE
include/packages-defaults.mk: Remove LARGEFILE option

### DIFF
--- a/include/package-defaults.mk
+++ b/include/package-defaults.mk
@@ -92,7 +92,6 @@ CONFIGURE_ARGS = \
 		--mandir=$(CONFIGURE_PREFIX)/man \
 		--infodir=$(CONFIGURE_PREFIX)/info \
 		$(DISABLE_NLS) \
-		$(DISABLE_LARGEFILE) \
 		$(DISABLE_IPV6)
 
 CONFIGURE_VARS = \


### PR DESCRIPTION
Remove LARGEFILE option, support was removed back in 2011 (OpenWrt rev 25208).

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>