### PR TITLE
busybox: Enable sendfile by default

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -273,7 +273,7 @@ config BUSYBOX_DEFAULT_FEATURE_VERBOSE_CP_MESSAGE
 	default n
 config BUSYBOX_DEFAULT_FEATURE_USE_SENDFILE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_COPYBUF_KB
 	int
 	default 4


### PR DESCRIPTION
Enable sendfile system call by default.
http://lists.busybox.net/pipermail/busybox-cvs/2014-November/034831.html

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>