### PR TITLE
dgn3500 - blink switch port leds on activity

### DIFF
--- a/target/linux/lantiq/dts/DGN3500.dtsi
+++ b/target/linux/lantiq/dts/DGN3500.dtsi
@@ -75,7 +75,22 @@
 		compatible = "realtek,rtl8366rb";
 		gpio-sda = <&gpio 35 GPIO_ACTIVE_HIGH>;
 		gpio-sck = <&gpio 37 GPIO_ACTIVE_HIGH>;
+
+		realtek,initvals = <
+			0x0000 0x0830
+			0x0400 0x8130
+			0x000A 0x83ED
+			0x0F51 0x0017
+			0x02F5 0x0048
+			0x02FA 0xFFDF
+			0x02FB 0xFFE0
+			0x0450 0x0000
+			0x0401 0x0000
+			0x0431 0x0960
+		>;
 	};
+
+
 
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";


### PR DESCRIPTION
2 commits here, 1 to enable initvals from DTS for the rtl8366rb switch, and another to take advantage of the new feature and set the LED register to blink switch leds on activity as per the stock firmware.