### PR TITLE
dhcp_option splitting entries with spaces in them

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -546,11 +546,16 @@ dhcp_option_add() {
 
 	[ "$force" = "0" ] && force=
 
-	config_get dhcp_option "$cfg" dhcp_option
-	for o in $dhcp_option; do
-		xappend "--dhcp-option${force:+-force}=${networkid:+$networkid,}$o"
-	done
+	config_list_foreach "$cfg" dhcp_option dhcp_option_add_one "$networkid" "$force"
+}
 
+dhcp_option_add_one() {
+	local networkid="$2"
+	local force="$3"
+
+	[ "$force" = "0" ] && force=
+
+	xappend "--dhcp-option${force:+-force}=${networkid:+$networkid,}$1"
 }
 
 dhcp_domain_add() {


### PR DESCRIPTION
This change is based on https://dev.openwrt.org/ticket/7952 but updated to work with the current version of OpenWRT. This is tested on OpenWRT 15.05, but not with LEDE (yet).

In my case I'm trying to setup network boot for a Raspberry Pi, when adding this to /etc/config/dhcp:

config mac 'raspbian'
	option mac 'aa:bb:cc:*:*:*'
       [snip]
	list dhcp_option '43,Raspberry Pi Boot'

Resulted in this:

dhcp-option=raspbian,43,Raspberry
dhcp-option=raspbian,Pi
dhcp-option=raspbian,Boot

Not very helpful. With the patch I get this result:

dhcp-option=raspbian,43,Raspberry Pi Boot

Which is what I expect, and want.

Thanks for your contribution to the LEDE project!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
