### PR TITLE
dnsmasq: don't split dhcp_option entries on spaces

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -546,11 +546,16 @@ dhcp_option_add() {
 
 	[ "$force" = "0" ] && force=
 
-	config_get dhcp_option "$cfg" dhcp_option
-	for o in $dhcp_option; do
-		xappend "--dhcp-option${force:+-force}=${networkid:+$networkid,}$o"
-	done
+	config_list_foreach "$cfg" dhcp_option dhcp_option_add_one "$networkid" "$force"
+}
 
+dhcp_option_add_one() {
+	local networkid="$2"
+	local force="$3"
+
+	[ "$force" = "0" ] && force=
+
+	xappend "--dhcp-option${force:+-force}=${networkid:+$networkid,}$1"
 }
 
 dhcp_domain_add() {


### PR DESCRIPTION
Previosuly dhcp_option in /etc/config/dnsmasq would be split on any
spaces. This is unexpected, and prevents useful usecases.

This change is based on https://dev.openwrt.org/ticket/7952 but updated to
work with version 15.05 of OpenWRT. This is tested on OpenWRT 15.05,
but not with LEDE (yet).

In my case I'm trying to setup network boot for a Raspberry Pi, when adding
this to /etc/config/dhcp:

config mac 'raspbian'
	option mac 'aa:bb:cc:*:*:*'
       [snip]
	list dhcp_option '43,Raspberry Pi Boot'

Resulted in this:

dhcp-option=raspbian,43,Raspberry
dhcp-option=raspbian,Pi
dhcp-option=raspbian,Boot

Not very helpful. With this patch I now get this result:

dhcp-option=raspbian,43,Raspberry Pi Boot

Which is what I expect, and want.

Signed-off-by: Andrew Ruthven <andrew@etc.gen.nz>