### PR TITLE
 ipq806x: add support for Compex WPQ864

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -48,6 +48,14 @@ nbg6817)
 	ucidef_set_interface_macaddr "lan" "$hw_mac_addr"
 	ucidef_set_interface_macaddr "wan" "$(macaddr_add $hw_mac_addr 1)"
 	;;
+wpq864)
+	lan_mac_addr=$(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
+	wan_mac_addr=$(mtd_get_mac_ascii 0:APPSBLENV eth1addr)
+	ucidef_add_switch "switch0" \
+		"1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
+	ucidef_set_interface_macaddr "lan" "$lan_mac_addr"
+	ucidef_set_interface_macaddr "wan" "$wan_mac_addr"
+	;;
 *)
 	echo "Unsupported hardware. Network interfaces not intialized"
 	;;

--- a/target/linux/ipq806x/base-files/lib/ipq806x.sh
+++ b/target/linux/ipq806x/base-files/lib/ipq806x.sh
@@ -47,6 +47,9 @@ ipq806x_board_detect() {
 	*"VR2600v")
 		name="vr2600v"
 		;;
+	*"WPQ864")
+		name="wpq864"
+		;;
 	esac
 
 	[ -z "$name" ] && name="unknown"

--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
@@ -1,0 +1,362 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "qcom-ipq8064-v1.0.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "Compex WPQ864";
+	compatible = "qcom,ipq8064-wpq864", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		rsvd@41200000 {
+			reg = <0x41200000 0x300000>;
+			no-map;
+		};
+	};
+
+	aliases {
+		serial0 = &gsbi4_serial;
+		mdio-gpio0 = &mdio0;
+		
+		led-boot = &rss4;
+		led-failsafe = &rss1;
+		led-running = &rss3;
+		led-upgrade = &rss2;
+	};
+
+	chosen {
+		linux,stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		pinmux@800000 {
+			led_pins: led_pins {
+				mux {
+					pins = "gpio23", "gpio24", "gpio25", "gpio22", "gpio53",
+						"gpio9", "gpio7", "gpio8";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+			button_pins: button_pins {
+				mux {
+					pins = "gpio54";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+			beeper_pins: beeper_pins {
+				mux {
+					pins = "gpio55";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+			i2c4_pins: i2c4_pinmux {
+				pins = "gpio12", "gpio13";
+				function = "gsbi4";
+				bias-disable;
+			};
+
+			spi_pins: spi_pins {
+				mux {
+					pins = "gpio18", "gpio19", "gpio21";
+					function = "gsbi5";
+					drive-strength = <10>;
+					bias-none;
+				};
+			};
+			nand_pins: nand_pins {
+				mux {
+					pins = "gpio34", "gpio35", "gpio36",
+					       "gpio37", "gpio38", "gpio39",
+					       "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
+					bias-disable;
+				};
+				pullups {
+					pins = "gpio39";
+					bias-pull-up;
+				};
+				hold {
+					pins = "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					bias-bus-hold;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+
+			rgmii2_pins: rgmii2_pins {
+				mux {
+					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
+					       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+					function = "rgmii2";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+		};
+
+		gsbi@16300000 {
+			qcom,mode = <GSBI_PROT_I2C_UART>;
+			status = "ok";
+			serial@16340000 {
+				status = "ok";
+			};
+
+			/*
+			* The i2c device on gsbi4 should not be enabled.
+			* On ipq806x designs gsbi4 i2c is meant for exclusive
+			* RPM usage. Turning this on in kernel manifests as
+			* i2c failure for the RPM.
+			*/
+		};
+
+		gsbi5: gsbi@1a200000 {
+			qcom,mode = <GSBI_PROT_SPI>;
+			status = "ok";
+
+			spi4: spi@1a280000 {
+				status = "ok";
+				spi-max-frequency = <50000000>;
+
+				pinctrl-0 = <&spi_pins>;
+				pinctrl-names = "default";
+
+				cs-gpios = <&qcom_pinmux 20 0>;
+
+				flash: m25p80@0 {
+					compatible = "s25fl256s1";
+					#address-cells = <1>;
+					#size-cells = <1>;
+					spi-max-frequency = <50000000>;
+					reg = <0>;
+
+					linux,part-probe = "qcom-smem";
+				};
+			};
+		};
+
+		sata-phy@1b400000 {
+			status = "ok";
+		};
+
+		sata@29000000 {
+			status = "ok";
+		};
+
+		phy@100f8800 {		/* USB3 port 1 HS phy */
+			status = "ok";
+		};
+
+		phy@100f8830 {		/* USB3 port 1 SS phy */
+			status = "ok";
+		};
+
+		phy@110f8800 {		/* USB3 port 0 HS phy */
+			status = "ok";
+		};
+
+		phy@110f8830 {		/* USB3 port 0 SS phy */
+			status = "ok";
+		};
+
+		usb30@0 {
+			status = "ok";
+		};
+
+		usb30@1 {
+			status = "ok";
+		};
+
+		pcie0: pci@1b500000 {
+			status = "ok";
+			phy-tx0-term-offset = <7>;
+		};
+
+		pcie1: pci@1b700000 {
+			status = "ok";
+			phy-tx0-term-offset = <7>;
+		};
+
+		nand@1ac00000 {
+			status = "ok";
+
+			pinctrl-0 = <&nand_pins>;
+			pinctrl-names = "default";
+
+			cs0 {
+				reg = <0>;
+				compatible = "qcom,nandcs";
+
+				nand-ecc-strength = <4>;
+				nand-bus-width = <8>;
+				nand-ecc-step-size = <512>;
+
+				linux,part-probe = "qcom-smem";
+			};
+		};
+
+		mdio0: mdio {
+			compatible = "virtual,mdio-gpio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			gpios = <&qcom_pinmux 1 0 &qcom_pinmux 0 0>;
+			pinctrl-0 = <&mdio0_pins>;
+			pinctrl-names = "default";
+
+			phy0: ethernet-phy@0 {
+				device_type = "ethernet-phy";
+				reg = <0>;
+				qca,ar8327-initvals = <
+					0x00004 0x7600000   /* PAD0_MODE */
+					0x00008 0x1000000   /* PAD5_MODE */
+					0x0000c 0x80        /* PAD6_MODE */
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
+					0x000e0 0xc74164de  /* SGMII_CTRL */
+					0x0007c 0x4e        /* PORT0_STATUS */
+					0x00094 0x4e        /* PORT6_STATUS */
+					>;
+			};
+
+			phy4: ethernet-phy@4 {
+				device_type = "ethernet-phy";
+				reg = <4>;
+			};
+		};
+
+		gmac1: ethernet@37200000 {
+			status = "ok";
+			phy-mode = "rgmii";
+			qcom,id = <1>;
+
+			pinctrl-0 = <&rgmii2_pins>;
+			pinctrl-names = "default";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+
+		gmac2: ethernet@37400000 {
+			status = "ok";
+			phy-mode = "sgmii";
+			qcom,id = <2>;
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		rss4: rss4 {
+			label = "wpq864:green:rss4";
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
+		};
+
+		rss3: rss3 {
+			label = "wpq864:green:rss3";
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
+		};
+
+		rss2: rss2 {
+			label = "wpq864:orange:rss2";
+			gpios = <&qcom_pinmux 25 GPIO_ACTIVE_HIGH>;
+		};
+
+		rss1: rss1 {
+			label = "wpq864:red:rss1";
+			gpios = <&qcom_pinmux 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		pass {
+			label = "wpq864:green:pass";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+		};
+
+		fail {
+			label = "wpq864:green:fail";
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb {
+			label = "wpq864:green:usb";
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		lte {
+			label = "wpq864:green:lte";
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	beeper: beeper {
+		compatible = "gpio-beeper";
+		gpios = <&qcom_pinmux 55 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&tcsr {
+       qcom,usb-ctrl-select = <TCSR_USB_SELECT_USB3_DUAL>;
+       compatible = "qcom,tcsr";
+};
+

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -250,7 +250,18 @@ define Device/VR2600v
 	IMAGE/sysupgrade.bin := pad-extra 512 | append-kernel | pad-to $$$${KERNEL_SIZE} | append-rootfs | pad-rootfs | append-metadata
 endef
 
+define Device/WPQ864
+	$(call Device/LegacyImage)
+	$(call Device/UbiFit)
+	DEVICE_DTS := qcom-ipq8064-wpq864
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	BOARD_NAME := wpq864
+	DEVICE_TITLE := Compex WPQ864
+	DEVICE_PACKAGES := kmod-gpio-beeper
+endef
+
 TARGET_DEVICES += AP148 AP148-legacy C2600 D7800 DB149 EA8500 FRITZ4040 R7500 \
-		  R7500v2 R7800 NBG6817 VR2600v
+		  R7500v2 R7800 NBG6817 VR2600v WPQ864
 
 $(eval $(call BuildImage))

--- a/target/linux/ipq806x/patches-4.9/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-4.9/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -618,7 +618,18 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -618,7 +618,19 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8084-mtp.dtb \
  	qcom-ipq4019-ap.dk01.1-c1.dtb \
  	qcom-ipq4019-ap.dk04.1-c1.dtb \
@@ -26,6 +26,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-r7500v2.dtb \
 +	qcom-ipq8065-nbg6817.dtb \
 +	qcom-ipq8065-r7800.dtb \
++	qcom-ipq8064-wpq864.dtb \
  	qcom-msm8660-surf.dtb \
  	qcom-msm8960-cdp.dtb \
  	qcom-msm8974-lge-nexus5-hammerhead.dtb \


### PR DESCRIPTION
 ipq806x: add support for Compex WPQ864

hardware highlights:
- SoC: Qualcomm Atheros IPQ8064/5 ARM Dual Core CPU
- RAM: 1GB DDR3 System Memory
- Storage: 32MB NOR flash + 256MB NAND flash
- Ethernet: 5x1G
- USB: 1 x USB 3.0 + 1 x USB 3.0 on mini PCIe socket
- PCIe: 2 x mini PCIe
- SIM Card Slot: 2 x Slot

tested and working:
- ethernet / switch / 4 x lan / 1 x wan
- 2 x PCIe
- leds
- reboot button / reboot
- USB 2.0
- buzzer

not working:
- USB 3.0

not tested:
- SIM Card SLot
- Flash
- Sysupgrade

ramload:
- tftpboot lede-ipq806x-WPQ864-initramfs-uImage
- bootm

Signed-off-by: Christian Mehlis <christian@m3hlis.de>