### PR TITLE
toolchain/binutils: Set 2.28 as default version

### DIFF
--- a/toolchain/binutils/Config.in
+++ b/toolchain/binutils/Config.in
@@ -2,7 +2,7 @@
 
 choice
 	prompt "Binutils Version" if TOOLCHAINOPTS
-	default BINUTILS_USE_VERSION_2_27 if !arc
+	default BINUTILS_USE_VERSION_2_28 if !arc
 	default BINUTILS_USE_VERSION_2_27_ARC if arc
 	help
 	  Select the version of binutils you wish to use.

--- a/toolchain/binutils/Config.version
+++ b/toolchain/binutils/Config.version
@@ -1,8 +1,8 @@
 config BINUTILS_VERSION_2_27
-	default y if (!TOOLCHAINOPTS && !arc)
 	bool
 
 config BINUTILS_VERSION_2_28
+	default y if (!TOOLCHAINOPTS && !arc)
 	bool
 
 config BINUTILS_VERSION_2_27_ARC


### PR DESCRIPTION
Use 2.28 by default

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>