### PR TITLE
Iptables: fix wrong depends for nftable support

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -432,7 +432,7 @@ define Package/libxtables
  ABI_VERSION:=$(PKG_VERSION)
  DEPENDS:= \
 	+IPTABLES_CONNLABEL:libnetfilter-conntrack \
-	+IPTABLES_NFTABLES:libnfnetlink
+	+IPTABLES_NFTABLES:libnftnl
 endef
 
 TARGET_CPPFLAGS := \


### PR DESCRIPTION
The dep for the nftables support was wrong, if someone actually enable that option gain a compilation error. This fix this problem.

Compiled and tested mvebu

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
