### PR TITLE
ramips: fix kn_rc/kn_rf gpios and wan port

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -85,6 +85,7 @@ ramips_setup_interfaces()
 	hc5661a|\
 	hc5962|\
 	hlk-rm04|\
+	kn_rc|\
 	mac1200rv2|\
 	miwifi-mini|\
 	miwifi-nano|\
@@ -227,7 +228,6 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5:lan" "0:wan" "6@eth0"
 		;;
-	kn_rc|\
 	kn_rf)
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6@eth0"

--- a/target/linux/ramips/dts/kn_rc.dts
+++ b/target/linux/ramips/dts/kn_rc.dts
@@ -10,22 +10,18 @@
 
 	gpio-leds {
 		compatible = "gpio-leds";
-
 		wan {
 			label = "kn_rc:green:wan";
-			gpios = <&gpio0 38 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
 		};
-
 		usb {
 			label = "kn_rc:green:usb";
-			gpios = <&gpio0 39 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
-
 		wifi {
 			label = "kn_rc:green:wifi";
-			gpios = <&gpio0 72 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
-
 		power {
 			label = "kn_rc:green:power";
 			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
@@ -67,6 +63,14 @@
 			gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
 };
 
 &spi0 {
@@ -115,7 +119,7 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0x4>;
-	mediatek,portmap = "wllll";
+	mediatek,portmap = "llllw";
 };
 
 &wmac {

--- a/target/linux/ramips/dts/kn_rf.dts
+++ b/target/linux/ramips/dts/kn_rf.dts
@@ -13,7 +13,7 @@
 
 		wan {
 			label = "kn_rc:green:wan";
-			gpios = <&gpio0 38 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
@@ -23,12 +23,12 @@
 
 		wifi {
 			label = "kn_rc:green:wifi";
-			gpios = <&gpio0 72 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "kn_rc:green:power";
-			gpios = <&gpio0 39 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -67,6 +67,14 @@
 			gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
 };
 
 &spi0 {


### PR DESCRIPTION
In Device Tree configuration files was wrong GPIO registers definitions.

Signed-off-by: Alexey Belyaev <spider@spider.vc>