### PR TITLE
ramips: Add support for ATEL ALR-U270

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -413,6 +413,10 @@ youku-yk1)
 	set_wifi_led "$board:blue:air"
 	set_usb_led "$board:blue:usb"
 	;;
+atel-u270)
+	ucidef_set_led_default "power" "power" "$board:orange:power" "0"
+	set_wifi_led "$board:orange:wifi"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -682,6 +682,9 @@ ramips_board_detect() {
 	*"YK1")
 		name="youku-yk1"
 		;;
+	*"ATEL U270")
+		name="atel-u270"
+		;;
 	*)
 		name="generic"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -200,7 +200,8 @@ platform_check_image() {
 	zbt-wg3526-32M|\
 	zbt-wr8305rt|\
 	zte-q7|\
-	youku-yk1)
+	youku-yk1|\
+ atel-u270)
 		[ "$magic" != "27051956" ] && {
 			echo "Invalid image type."
 			return 1

--- a/target/linux/ramips/dts/ATEL-U270.dts
+++ b/target/linux/ramips/dts/ATEL-U270.dts
@@ -1,0 +1,177 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+/ {
+	compatible = "ATEL-U270", "ralink,mt7620a-soc";
+	model = "ATEL U270";
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		wan {
+			label = "atel-u270:orange:wan";
+			gpios = <&gpio2 27 1>;
+		};
+		wifi {
+			label = "atel-u270:orange:wifi";
+			gpios = <&gpio3 0 1>;
+		};
+		wps {
+			label = "atel-u270:orange:wps";
+			gpios = <&gpio2 28 1>;
+		};
+		power {
+			label = "atel-u270:orange:power";
+			gpios = <&gpio2 20 1>;
+		};
+		power-red {
+			label = "atel-u270:red:power";
+			gpios = <&gpio2 21 1>;
+		};
+  signal1 {
+   label = "atel-u270:white:signal1";
+   gpios = <&gpio2 26 1>;
+  };
+  signal2 {
+   label = "atel-u270:white:signal2";
+   gpios = <&gpio2 23 1>;
+  };
+  signal3 {
+   label = "atel-u270:white:signal3";
+   gpios = <&gpio2 24 1>;
+  };
+  signal4 {
+   label = "atel-u270:white:signal4";
+   gpios = <&gpio2 25 1>;
+  };
+  signal5 {
+   label = "atel-u270:white:signal5";
+   gpios = <&gpio2 22 1>;
+  };
+  signal-blue {
+   label = "atel-u270:blue:signal";
+   gpios = <&gpio1 7 1>;
+  };
+  signal-red {
+   label = "atel-u270:red:signal";
+   gpios = <&gpio1 8 1>;
+  };
+  signal-green {
+   label = "atel-u270:green:signal";
+   gpios = <&gpio1 9 1>;
+  };
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+/*		power {
+			label = "power";
+			gpios = <&gpio2 31 1>;
+			linux,code = <0x198>;
+		};
+		wps {
+			label = "wps";
+			gpios = <&gpio2 30 1>;
+			linux,code = <0x211>;
+	 };
+  */
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+/*		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio2 12 1>;
+		};*/
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80", "w25q256";
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x7b0000>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "i2c", "uartf", "rgmii1", "rgmii2", "ephy", "wled", "nd_sd";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&ephy_pins>;
+	mtd-mac-address = <&factory 0x4>;
+	mediatek,portmap = "llllw";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -458,6 +458,13 @@ define Device/youku-yk1
 endef
 TARGET_DEVICES += youku-yk1
 
+define Device/atel-u270
+  DTS := ATEL-U270
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  DEVICE_TITLE := ATEL U270
+endef
+TARGET_DEVICES += atel-u270
+
 define Device/zbt-ape522ii
   DTS := ZBT-APE522II
   DEVICE_TITLE := Zbtlink ZBT-APE522II


### PR DESCRIPTION
MT7620A-based LTE router with 16MB serial flash, 64MB DRAM, LTE modem (&
sim slot in battery bay), WiFi, 4x Ethernet ports, I/O, RS232, 2x18650
backup battery.

These routers are manufactured by ATEL and rebranded net1.dk, net1.se,
and ice.net (Norway), among others.

https://wikidevi.com/wiki/ATEL_ALR-U270

Running from tftp:

A 10-pin mini-USB port is inside the battery bay. Using the pinout at
http://chargeconverter.com/blog/?p=130, pin 9 is TX and pin 4 is RX.
Looking at the PCB, with the mini-USB port opening facing you, counting
left to right, this corresponds to pins 7 (TX) and 8 (RX) on the PCB.

With serial connected, Ralink U-boot gives options to load and boot from
RAM via TFTP, flash via TFTP, etc.

Signed-off-by: Donn Morrison <donn.morrison@gmail.com>