### PR TITLE
usbmode: update usb-modeswitch-data to 20170205

### DIFF
--- a/package/utils/usbmode/Makefile
+++ b/package/utils/usbmode/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=usbmode
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(LEDE_GIT)/project/usbmode.git
@@ -15,7 +15,7 @@ PKG_LICENSE_FILES:=
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 
-PKG_DATA_VERSION:=20150115
+PKG_DATA_VERSION:=20170205
 PKG_DATA_URL:=http://www.draisberghof.de/usb_modeswitch
 PKG_DATA_PATH:=usb-modeswitch-data-$(PKG_DATA_VERSION)
 PKG_DATA_FILENAME:=$(PKG_DATA_PATH).tar.bz2
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/cmake.mk
 define Download/data
   FILE:=$(PKG_DATA_FILENAME)
   URL:=$(PKG_DATA_URL)
-  HASH:=90549f589835a68279369c3dc0d47eb7338ee3bad09d737e7b85e1ab15bd2d8b
+  HASH:=e2dcfd9d28928d8d8f03381571a23442b3c50d48d343bc40a1a07d01662738d1
 endef
 $(eval $(call Download,data))
 


### PR DESCRIPTION
Adds support for new modem models like Huawei E5377

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>

