### PR TITLE
ar71xx: fix tl-wr841n-v8 switch port mapping

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -300,7 +300,6 @@ ar71xx_setup_interfaces()
 	smart-300|\
 	tl-mr3420-v2|\
 	tl-wdr6500-v2|\
-	tl-wr841n-v8|\
 	tl-wr940n-v4|\
 	tl-wr941nd-v5|\
 	tl-wr941nd-v6|\
@@ -431,6 +430,7 @@ ar71xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4"
 		;;
+	tl-wr841n-v8|\
 	tl-wr842n-v2)
 		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
The switch port is eth1. The order of switch ports (shown in `swconfig dev eth1 show`) is CPU,
LAN 4, LAN 1, LAN 2, LAN 3.

Signed-off-by: Oldřich Jedlička <oldium.pro@gmail.com>