### PR TITLE
ramips: support jumbo frame on mt7621 up to 2k

### DIFF
--- a/target/linux/ramips/patches-4.4/0501-net-next-mediatek-add-the-drivers-core-files.patch
+++ b/target/linux/ramips/patches-4.4/0501-net-next-mediatek-add-the-drivers-core-files.patch
@@ -600,7 +600,7 @@ Signed-off-by: Michael Lee <igvtee@gmail.com>
 +#endif
 --- /dev/null
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -0,0 +1,1587 @@
+@@ -0,0 +1,1593 @@
 +/*   This program is free software; you can redistribute it and/or modify
 + *   it under the terms of the GNU General Public License as published by
 + *   the Free Software Foundation; version 2 of the License
@@ -1945,6 +1945,10 @@ Signed-off-by: Michael Lee <igvtee@gmail.com>
 +	if (!(priv->flags & FE_FLAG_JUMBO_FRAME))
 +		return eth_change_mtu(dev, new_mtu);
 +
++	if (IS_ENABLED(CONFIG_SOC_MT7621))
++		if (new_mtu > 2048)
++			return -EINVAL;
++
 +	frag_size = fe_max_frag_size(new_mtu);
 +	if (new_mtu < 68 || frag_size > PAGE_SIZE)
 +		return -EINVAL;
@@ -1968,15 +1972,17 @@ Signed-off-by: Michael Lee <igvtee@gmail.com>
 +		return 0;
 +
 +	fe_stop(dev);
-+	fwd_cfg = fe_r32(FE_GDMA1_FWD_CFG);
-+	if (new_mtu <= ETH_DATA_LEN) {
-+		fwd_cfg &= ~FE_GDM1_JMB_EN;
-+	} else {
-+		fwd_cfg &= ~(FE_GDM1_JMB_LEN_MASK << FE_GDM1_JMB_LEN_SHIFT);
-+		fwd_cfg |= (DIV_ROUND_UP(frag_size, 1024) <<
-+				FE_GDM1_JMB_LEN_SHIFT) | FE_GDM1_JMB_EN;
++	if (!IS_ENABLED(CONFIG_SOC_MT7621)) {
++		fwd_cfg = fe_r32(FE_GDMA1_FWD_CFG);
++		if (new_mtu <= ETH_DATA_LEN) {
++			fwd_cfg &= ~FE_GDM1_JMB_EN;
++		} else {
++			fwd_cfg &= ~(FE_GDM1_JMB_LEN_MASK << FE_GDM1_JMB_LEN_SHIFT);
++			fwd_cfg |= (DIV_ROUND_UP(frag_size, 1024) <<
++					FE_GDM1_JMB_LEN_SHIFT) | FE_GDM1_JMB_EN;
++		}
++		fe_w32(fwd_cfg, FE_GDMA1_FWD_CFG);
 +	}
-+	fe_w32(fwd_cfg, FE_GDMA1_FWD_CFG);
 +
 +	return fe_open(dev);
 +}

--- a/target/linux/ramips/patches-4.4/0503-net-next-mediatek-add-switch-driver-for-mt7620.patch
+++ b/target/linux/ramips/patches-4.4/0503-net-next-mediatek-add-switch-driver-for-mt7620.patch
@@ -274,7 +274,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +MODULE_VERSION(MTK_FE_DRV_VERSION);
 --- /dev/null
 +++ b/drivers/net/ethernet/mediatek/gsw_mt7620.h
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,123 @@
 +/*   This program is free software; you can redistribute it and/or modify
 + *   it under the terms of the GNU General Public License as published by
 + *   the Free Software Foundation; version 2 of the License
@@ -321,6 +321,12 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#define GSW_REG_IMR		0x7008
 +#define GSW_REG_ISR		0x700c
 +#define GSW_REG_GPC1		0x7014
++
++#define GSW_REG_MAC_P0_MCR	0x100
++#define GSW_REG_MAC_P1_MCR	0x200
++
++// Global MAC control register
++#define GSW_REG_GMACCR		0x30E0
 +
 +#define SYSC_REG_CHIP_REV_ID	0x0c
 +#define SYSC_REG_CFG1		0x14

--- a/target/linux/ramips/patches-4.4/0504-net-next-mediatek-add-switch-driver-for-mt7621.patch
+++ b/target/linux/ramips/patches-4.4/0504-net-next-mediatek-add-switch-driver-for-mt7621.patch
@@ -14,7 +14,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 
 --- /dev/null
 +++ b/drivers/net/ethernet/mediatek/gsw_mt7621.c
-@@ -0,0 +1,284 @@
+@@ -0,0 +1,287 @@
 +/*   This program is free software; you can redistribute it and/or modify
 + *   it under the terms of the GNU General Public License as published by
 + *   the Free Software Foundation; version 2 of the License
@@ -115,17 +115,20 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	usleep_range(10, 20);
 +
 +	if ((rt_sysc_r32(SYSC_REG_CHIP_REV_ID) & 0xFFFF) == 0x0101) {
-+		/* (GE1, Force 1000M/FD, FC ON, MAX_RX_LENGTH 1536) */
-+		mtk_switch_w32(gsw, 0x2105e30b, 0x100);
++		/* (GE1, Force 1000M/FD, FC ON, MAX_RX_LENGTH 2k) */
++		mtk_switch_w32(gsw, 0x2305e30b, GSW_REG_MAC_P0_MCR);
 +		mt7530_mdio_w32(gsw, 0x3600, 0x5e30b);
 +	} else {
-+		/* (GE1, Force 1000M/FD, FC ON, MAX_RX_LENGTH 1536) */
-+		mtk_switch_w32(gsw, 0x2105e33b, 0x100);
++		/* (GE1, Force 1000M/FD, FC ON, MAX_RX_LENGTH 2k) */
++		mtk_switch_w32(gsw, 0x2305e33b, GSW_REG_MAC_P0_MCR);
 +		mt7530_mdio_w32(gsw, 0x3600, 0x5e33b);
 +	}
 +
 +	/* (GE2, Link down) */
-+	mtk_switch_w32(gsw, 0x8000, 0x200);
++	mtk_switch_w32(gsw, 0x8000, GSW_REG_MAC_P1_MCR);
++
++	/* Set switch max RX frame length to 2k */
++	mt7530_mdio_w32(gsw, GSW_REG_GMACCR, 0x3F0B);
 +
 +	/* Enable Port 6, P5 as GMAC5, P5 disable */
 +	val = mt7530_mdio_r32(gsw, 0x7804);

--- a/target/linux/ramips/patches-4.4/0509-net-next-mediatek-add-support-for-mt7621.patch
+++ b/target/linux/ramips/patches-4.4/0509-net-next-mediatek-add-support-for-mt7621.patch
@@ -163,7 +163,7 @@ Signed-off-by: Michael Lee <igvtee@gmail.com>
 +
 +	priv->flags = FE_FLAG_PADDING_64B | FE_FLAG_RX_2B_OFFSET |
 +		FE_FLAG_RX_SG_DMA | FE_FLAG_NAPI_WEIGHT |
-+		FE_FLAG_HAS_SWITCH;
++		FE_FLAG_HAS_SWITCH | FE_FLAG_JUMBO_FRAME;
 +
 +	netdev->hw_features = NETIF_F_IP_CSUM | NETIF_F_RXCSUM |
 +		NETIF_F_HW_VLAN_CTAG_TX | NETIF_F_SG | NETIF_F_TSO |


### PR DESCRIPTION
This patch is base on Gaetano Catalli work.

i change mtk_eth_soc.c driver part. because mt7621 don't need to
set FE_GDMA1_FWD_CFG register to enable jumbo frame. and keep
MAX_RX_LENGTH because other chips need it.

Signed-off-by: Michael Lee <igvtee@gmail.com>