### PR TITLE
tools/cmake: update to 3.8.0

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=3.7.2
+PKG_VERSION:=3.8.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://cmake.org/files/v3.7/ \
+PKG_SOURCE_URL:=https://cmake.org/files/v3.8/ \
 		https://fossies.org/linux/misc/
-PKG_HASH:=dc1246c4e6d168ea4d6e042cfba577c1acd65feea27e56f5ff37df920c30cae0
+PKG_HASH:=cab99162e648257343a20f61bcd0b287f5e88e36fcb2f1d77959da60b7f35969
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1

--- a/tools/cmake/patches/100-disable_qt_tests.patch
+++ b/tools/cmake/patches/100-disable_qt_tests.patch
@@ -1,6 +1,6 @@
 --- a/Tests/RunCMake/CMakeLists.txt
 +++ b/Tests/RunCMake/CMakeLists.txt
-@@ -225,15 +225,6 @@ add_RunCMake_test(no_install_prefix)
+@@ -244,15 +244,6 @@ add_RunCMake_test(no_install_prefix)
  add_RunCMake_test(configure_file)
  add_RunCMake_test(CTestTimeoutAfterMatch)
  
@@ -18,7 +18,7 @@
    add_RunCMake_test(FindPkgConfig)
 --- a/Tests/CMakeLists.txt
 +++ b/Tests/CMakeLists.txt
-@@ -393,10 +393,6 @@ if(BUILD_TESTING)
+@@ -398,10 +398,6 @@ if(BUILD_TESTING)
  
    list(APPEND TEST_BUILD_DIRS ${CMake_TEST_INSTALL_PREFIX})
  

--- a/tools/cmake/patches/110-freebsd-compat.patch
+++ b/tools/cmake/patches/110-freebsd-compat.patch
@@ -21,10 +21,10 @@ Change-Id: I3b91ed7ac0e6878035aee202b3336c536cc6d2ff
 
 --- a/Source/kwsys/SystemInformation.cxx
 +++ b/Source/kwsys/SystemInformation.cxx
-@@ -89,6 +89,15 @@ typedef int siginfo_t;
- #  include <ifaddrs.h>
- #  define KWSYS_SYSTEMINFORMATION_IMPLEMENT_FQDN
- # endif
+@@ -82,6 +82,15 @@ typedef int siginfo_t;
+ #include <net/if.h>
+ #define KWSYS_SYSTEMINFORMATION_IMPLEMENT_FQDN
+ #endif
 +# if defined(KWSYS_SYSTEMINFORMATION_HAS_BACKTRACE)
 +#  include <execinfo.h>
 +#  if defined(KWSYS_SYSTEMINFORMATION_HAS_CPP_DEMANGLE)

--- a/tools/cmake/patches/140-curl-fix-libressl-linking.patch
+++ b/tools/cmake/patches/140-curl-fix-libressl-linking.patch
@@ -19,7 +19,7 @@ and unconditionally link the rt library when the symbol is found.
 Signed-off-by: Jo-Philipp Wich <jo@mein.io>
 --- a/Utilities/cmcurl/CMakeLists.txt
 +++ b/Utilities/cmcurl/CMakeLists.txt
-@@ -362,6 +362,10 @@ set(HAVE_LIBSSL OFF)
+@@ -374,6 +374,10 @@ set(HAVE_LIBSSL OFF)
  if(CMAKE_USE_OPENSSL)
    find_package(OpenSSL)
    if(OPENSSL_FOUND)

--- a/tools/cmake/patches/150-bootstrap_parallel_make_flag.patch
+++ b/tools/cmake/patches/150-bootstrap_parallel_make_flag.patch
@@ -1,6 +1,6 @@
 --- a/bootstrap
 +++ b/bootstrap
-@@ -958,7 +958,10 @@ int main(){ printf("1%c", (char)0x0a); r
+@@ -1046,7 +1046,10 @@ int main(){ printf("1%c", (char)0x0a); r
  ' > "test.c"
  cmake_original_make_flags="${cmake_make_flags}"
  if [ "x${cmake_parallel_make}" != "x" ]; then


### PR DESCRIPTION
* update cmake to 3.8.0
* refresh patches

Release notes:
https://cmake.org/cmake/help/v3.8/release/3.8.html

Compile-tested with ipx806x, firmware build successfully.