### PR TITLE
dnsmasq: make tftp root if not existing

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -761,7 +761,7 @@ dnsmasq_start()
 	append_bool "$cfg" dbus "--enable-dbus"
 	append_bool "$cfg" expandhosts "--expand-hosts"
 	config_get tftp_root "$cfg" "tftp_root"
-	[ -d "$tftp_root" ] && append_bool "$cfg" enable_tftp "--enable-tftp"
+	[ -n "$tftp_root" ] && mkdir -p "$tftp_root" && append_bool "$cfg" enable_tftp "--enable-tftp"
 	append_bool "$cfg" tftp_no_fail "--tftp-no-fail"
 	append_bool "$cfg" nonwildcard "--bind-dynamic"
 	append_bool "$cfg" fqdn "--dhcp-fqdn"


### PR DESCRIPTION
If there's a TFTP root directory configured, create it with mkdir -p 
(which does not throw an error if the folder exists already)
before starting dnsmasq. This is useful for TFTP roots in /tmp, for example.

Originally submitted by nfw user aka Nathaniel Wesley Filardo

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>
