### PR TITLE
ipq806x: add support for wpq864

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ board=$(ipq806x_board_name)
 
 case "$board" in
 ap148 |\
+wpq864 |\
 c2600 |\
 d7800 |\
 r7500 |\

--- a/target/linux/ipq806x/base-files/lib/ipq806x.sh
+++ b/target/linux/ipq806x/base-files/lib/ipq806x.sh
@@ -17,6 +17,9 @@ ipq806x_board_detect() {
 	*"AP148")
 		name="ap148"
 		;;
+	*"WPQ864")
+		name="wpq864"
+		;;
 	*"4040")
 		name="fritz4040"
 		;;

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -12,6 +12,7 @@ platform_pre_upgrade() {
 
 	case "$board" in
 	ap148 |\
+	wpq864 |\
 	d7800 |\
 	nbg6817 |\
 	r7500 |\

--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-wpq864-1g.dts
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-wpq864-1g.dts
@@ -1,0 +1,247 @@
+#include "qcom-ipq8064-v1.0.dtsi"
+
+/ {
+	model = "Compex IPQ8064/WPQ864";
+	compatible = "qcom,ipq8064-wpq864", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x3e000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		rsvd@41200000 {
+			reg = <0x41200000 0x300000>;
+			no-map;
+		};
+	};
+
+	aliases {
+		serial0 = &gsbi4_serial;
+		mdio-gpio0 = &mdio0;
+	};
+
+	chosen {
+		linux,stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		pinmux@800000 {
+			i2c4_pins: i2c4_pinmux {
+				pins = "gpio12", "gpio13";
+				function = "gsbi4";
+				bias-disable;
+			};
+
+			spi_pins: spi_pins {
+				mux {
+					pins = "gpio18", "gpio19", "gpio21";
+					function = "gsbi5";
+					drive-strength = <10>;
+					bias-none;
+				};
+			};
+			nand_pins: nand_pins {
+				mux {
+					pins = "gpio34", "gpio35", "gpio36",
+					       "gpio37", "gpio38", "gpio39",
+					       "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
+					bias-disable;
+				};
+				pullups {
+					pins = "gpio39";
+					bias-pull-up;
+				};
+				hold {
+					pins = "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					bias-bus-hold;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+
+			rgmii2_pins: rgmii2_pins {
+				mux {
+					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
+					       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+					function = "rgmii2";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+		};
+
+		gsbi@16300000 {
+			qcom,mode = <GSBI_PROT_I2C_UART>;
+			status = "ok";
+			serial@16340000 {
+				status = "ok";
+			};
+
+			/*
+			* The i2c device on gsbi4 should not be enabled.
+			* On ipq806x designs gsbi4 i2c is meant for exclusive
+			* RPM usage. Turning this on in kernel manifests as
+			* i2c failure for the RPM.
+			*/
+		};
+
+		gsbi5: gsbi@1a200000 {
+			qcom,mode = <GSBI_PROT_SPI>;
+			status = "ok";
+
+			spi4: spi@1a280000 {
+				status = "ok";
+				spi-max-frequency = <50000000>;
+
+				pinctrl-0 = <&spi_pins>;
+				pinctrl-names = "default";
+
+				cs-gpios = <&qcom_pinmux 20 0>;
+
+				flash: m25p80@0 {
+					compatible = "s25fl256s1";
+					#address-cells = <1>;
+					#size-cells = <1>;
+					spi-max-frequency = <50000000>;
+					reg = <0>;
+
+					linux,part-probe = "qcom-smem";
+				};
+			};
+		};
+
+		sata-phy@1b400000 {
+			status = "ok";
+		};
+
+		sata@29000000 {
+			status = "ok";
+		};
+
+		phy@100f8800 {		/* USB3 port 1 HS phy */
+			status = "ok";
+		};
+
+		phy@100f8830 {		/* USB3 port 1 SS phy */
+			status = "ok";
+		};
+
+		phy@110f8800 {		/* USB3 port 0 HS phy */
+			status = "ok";
+		};
+
+		phy@110f8830 {		/* USB3 port 0 SS phy */
+			status = "ok";
+		};
+
+		usb30@0 {
+			status = "ok";
+		};
+
+		usb30@1 {
+			status = "ok";
+		};
+
+		pcie0: pci@1b500000 {
+			status = "ok";
+			phy-tx0-term-offset = <7>;
+		};
+
+		pcie1: pci@1b700000 {
+			status = "ok";
+			phy-tx0-term-offset = <7>;
+		};
+
+		nand@1ac00000 {
+			status = "ok";
+
+			pinctrl-0 = <&nand_pins>;
+			pinctrl-names = "default";
+
+			cs0 {
+				reg = <0>;
+				compatible = "qcom,nandcs";
+
+				nand-ecc-strength = <4>;
+				nand-bus-width = <8>;
+				nand-ecc-step-size = <512>;
+
+				linux,part-probe = "qcom-smem";
+			};
+		};
+
+		mdio0: mdio {
+			compatible = "virtual,mdio-gpio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			gpios = <&qcom_pinmux 1 0 &qcom_pinmux 0 0>;
+			pinctrl-0 = <&mdio0_pins>;
+			pinctrl-names = "default";
+
+			phy0: ethernet-phy@0 {
+				device_type = "ethernet-phy";
+				reg = <0>;
+				qca,ar8327-initvals = <
+					0x00004 0x7600000   /* PAD0_MODE */
+					0x00008 0x1000000   /* PAD5_MODE */
+					0x0000c 0x80        /* PAD6_MODE */
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
+					0x000e0 0xc74164de  /* SGMII_CTRL */
+					0x0007c 0x4e        /* PORT0_STATUS */
+					0x00094 0x4e        /* PORT6_STATUS */
+					>;
+			};
+
+			phy4: ethernet-phy@4 {
+				device_type = "ethernet-phy";
+				reg = <4>;
+			};
+		};
+
+		gmac1: ethernet@37200000 {
+			status = "ok";
+			phy-mode = "rgmii";
+			qcom,id = <1>;
+
+			pinctrl-0 = <&rgmii2_pins>;
+			pinctrl-names = "default";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+
+		gmac2: ethernet@37400000 {
+			status = "ok";
+			phy-mode = "sgmii";
+			qcom,id = <2>;
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&adm_dma {
+	status = "ok";
+};

--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-wpq864-1g.dts
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-wpq864-1g.dts
@@ -85,6 +85,16 @@
 					bias-disable;
 				};
 			};
+
+			pcie3_pins: pcie3_pinmux {
+				mux {
+					pins = "gpio16";
+					function = "pcie3_rst";
+					drive-strength = <2>;
+					bias-disable;
+				};
+			};
+
 		};
 
 		gsbi@16300000 {
@@ -167,6 +177,13 @@
 		pcie1: pci@1b700000 {
 			status = "ok";
 			phy-tx0-term-offset = <7>;
+		};
+
+		pcie2: pci@1b900000 {
+			status = "ok";
+			phy-tx0-term-offset = <7>;
+			pinctrl-0 = <&pcie3_pins>;
+			perst-gpios = <&qcom_pinmux 16 GPIO_ACTIVE_LOW>;
 		};
 
 		nand@1ac00000 {

--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
@@ -85,6 +85,16 @@
 					bias-disable;
 				};
 			};
+
+			pcie3_pins: pcie3_pinmux {
+				mux {
+					pins = "gpio16";
+					function = "pcie3_rst";
+					drive-strength = <2>;
+					bias-disable;
+				};
+			};
+
 		};
 
 		gsbi@16300000 {
@@ -167,6 +177,13 @@
 		pcie1: pci@1b700000 {
 			status = "ok";
 			phy-tx0-term-offset = <7>;
+		};
+
+		pcie2: pci@1b900000 {
+			status = "ok";
+			phy-tx0-term-offset = <7>;
+			pinctrl-0 = <&pcie3_pins>;
+			perst-gpios = <&qcom_pinmux 16 GPIO_ACTIVE_LOW>;
 		};
 
 		nand@1ac00000 {

--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
@@ -1,0 +1,247 @@
+#include "qcom-ipq8064-v1.0.dtsi"
+
+/ {
+	model = "Compex IPQ8064/WPQ864";
+	compatible = "qcom,ipq8064-wpq864", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		rsvd@41200000 {
+			reg = <0x41200000 0x300000>;
+			no-map;
+		};
+	};
+
+	aliases {
+		serial0 = &gsbi4_serial;
+		mdio-gpio0 = &mdio0;
+	};
+
+	chosen {
+		linux,stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		pinmux@800000 {
+			i2c4_pins: i2c4_pinmux {
+				pins = "gpio12", "gpio13";
+				function = "gsbi4";
+				bias-disable;
+			};
+
+			spi_pins: spi_pins {
+				mux {
+					pins = "gpio18", "gpio19", "gpio21";
+					function = "gsbi5";
+					drive-strength = <10>;
+					bias-none;
+				};
+			};
+			nand_pins: nand_pins {
+				mux {
+					pins = "gpio34", "gpio35", "gpio36",
+					       "gpio37", "gpio38", "gpio39",
+					       "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
+					bias-disable;
+				};
+				pullups {
+					pins = "gpio39";
+					bias-pull-up;
+				};
+				hold {
+					pins = "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					bias-bus-hold;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+
+			rgmii2_pins: rgmii2_pins {
+				mux {
+					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
+					       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+					function = "rgmii2";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+		};
+
+		gsbi@16300000 {
+			qcom,mode = <GSBI_PROT_I2C_UART>;
+			status = "ok";
+			serial@16340000 {
+				status = "ok";
+			};
+
+			/*
+			* The i2c device on gsbi4 should not be enabled.
+			* On ipq806x designs gsbi4 i2c is meant for exclusive
+			* RPM usage. Turning this on in kernel manifests as
+			* i2c failure for the RPM.
+			*/
+		};
+
+		gsbi5: gsbi@1a200000 {
+			qcom,mode = <GSBI_PROT_SPI>;
+			status = "ok";
+
+			spi4: spi@1a280000 {
+				status = "ok";
+				spi-max-frequency = <50000000>;
+
+				pinctrl-0 = <&spi_pins>;
+				pinctrl-names = "default";
+
+				cs-gpios = <&qcom_pinmux 20 0>;
+
+				flash: m25p80@0 {
+					compatible = "s25fl256s1";
+					#address-cells = <1>;
+					#size-cells = <1>;
+					spi-max-frequency = <50000000>;
+					reg = <0>;
+
+					linux,part-probe = "qcom-smem";
+				};
+			};
+		};
+
+		sata-phy@1b400000 {
+			status = "ok";
+		};
+
+		sata@29000000 {
+			status = "ok";
+		};
+
+		phy@100f8800 {		/* USB3 port 1 HS phy */
+			status = "ok";
+		};
+
+		phy@100f8830 {		/* USB3 port 1 SS phy */
+			status = "ok";
+		};
+
+		phy@110f8800 {		/* USB3 port 0 HS phy */
+			status = "ok";
+		};
+
+		phy@110f8830 {		/* USB3 port 0 SS phy */
+			status = "ok";
+		};
+
+		usb30@0 {
+			status = "ok";
+		};
+
+		usb30@1 {
+			status = "ok";
+		};
+
+		pcie0: pci@1b500000 {
+			status = "ok";
+			phy-tx0-term-offset = <7>;
+		};
+
+		pcie1: pci@1b700000 {
+			status = "ok";
+			phy-tx0-term-offset = <7>;
+		};
+
+		nand@1ac00000 {
+			status = "ok";
+
+			pinctrl-0 = <&nand_pins>;
+			pinctrl-names = "default";
+
+			cs0 {
+				reg = <0>;
+				compatible = "qcom,nandcs";
+
+				nand-ecc-strength = <4>;
+				nand-bus-width = <8>;
+				nand-ecc-step-size = <512>;
+
+				linux,part-probe = "qcom-smem";
+			};
+		};
+
+		mdio0: mdio {
+			compatible = "virtual,mdio-gpio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			gpios = <&qcom_pinmux 1 0 &qcom_pinmux 0 0>;
+			pinctrl-0 = <&mdio0_pins>;
+			pinctrl-names = "default";
+
+			phy0: ethernet-phy@0 {
+				device_type = "ethernet-phy";
+				reg = <0>;
+				qca,ar8327-initvals = <
+					0x00004 0x7600000   /* PAD0_MODE */
+					0x00008 0x1000000   /* PAD5_MODE */
+					0x0000c 0x80        /* PAD6_MODE */
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
+					0x000e0 0xc74164de  /* SGMII_CTRL */
+					0x0007c 0x4e        /* PORT0_STATUS */
+					0x00094 0x4e        /* PORT6_STATUS */
+					>;
+			};
+
+			phy4: ethernet-phy@4 {
+				device_type = "ethernet-phy";
+				reg = <4>;
+			};
+		};
+
+		gmac1: ethernet@37200000 {
+			status = "ok";
+			phy-mode = "rgmii";
+			qcom,id = <1>;
+
+			pinctrl-0 = <&rgmii2_pins>;
+			pinctrl-names = "default";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+
+		gmac2: ethernet@37400000 {
+			status = "ok";
+			phy-mode = "sgmii";
+			qcom,id = <2>;
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&adm_dma {
+	status = "ok";
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -120,6 +120,28 @@ define Device/AP148-legacy
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
 
+define Device/WPQ864-legacy-1g
+	$(call Device/LegacyImage)
+	$(call Device/UbiFit)
+	DEVICE_DTS := qcom-ipq8064-wpq864-1g
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	BOARD_NAME := wpq864
+	DEVICE_TITLE := Compex WPQ864 (legacy) RAM 1G
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0
+endef
+
+define Device/WPQ864-legacy
+	$(call Device/LegacyImage)
+	$(call Device/UbiFit)
+	DEVICE_DTS := qcom-ipq8064-wpq864
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	BOARD_NAME := wpq864
+	DEVICE_TITLE := Compex WPQ864 (legacy) RAM 512M
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0
+endef
+
 define Device/C2600
 	$(call Device/TpSafeImage)
 	DEVICE_DTS := qcom-ipq8064-c2600
@@ -250,7 +272,7 @@ define Device/VR2600v
 	IMAGE/sysupgrade.bin := pad-extra 512 | append-kernel | pad-to $$$${KERNEL_SIZE} | append-rootfs | pad-rootfs | append-metadata
 endef
 
-TARGET_DEVICES += AP148 AP148-legacy C2600 D7800 DB149 EA8500 FRITZ4040 R7500 \
+TARGET_DEVICES += AP148 AP148-legacy WPQ864-legacy WPQ864-legacy-1g C2600 D7800 DB149 EA8500 FRITZ4040 R7500 \
 		  R7500v2 R7800 NBG6817 VR2600v
 
 $(eval $(call BuildImage))

--- a/target/linux/ipq806x/patches-4.9/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-4.9/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -618,7 +618,18 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -618,7 +618,20 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8084-mtp.dtb \
  	qcom-ipq4019-ap.dk01.1-c1.dtb \
  	qcom-ipq4019-ap.dk04.1-c1.dtb \
@@ -18,6 +18,8 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4019-nbg6617.dtb \
 +	qcom-ipq4019-rt-ac58u.dtb \
  	qcom-ipq8064-ap148.dtb \
++	qcom-ipq8064-wpq864.dtb \
++	qcom-ipq8064-wpq864-1g.dtb \
 +	qcom-ipq8064-c2600.dtb \
 +	qcom-ipq8064-d7800.dtb \
 +	qcom-ipq8064-db149.dtb \


### PR DESCRIPTION
    hardware highlights:
    - SoC: Qualcomm Atheros IPQ8064 ARM Dual Core CPU
    - RAM: 512MB/1GB DDR3 System Memory
    - Storage: 32MB NOR flash + 256MB NAND flash
    - Ethernet: 5x1G
    - USB: 1 x USB 3.0 + 1 x USB 2.0 on mini PCIe3 socket
    - PCIe: 3 x mini PCIe
    - SIM Card Slot: 2 x Slot

    tested and working:
    - ethernet / switch / 4 x lan / 1 x wan
    - 2 x PCIe(PCIe1/PCIe2)
    - leds
    - Flash
    - Sysupgrade
    - USB 2.0

    not working:
    - USB 3.0
    - PCIe3
    - reboot button / reboot

    not tested:
    - SIM Card SLot
    - buzzer

    ramload:
    - tftpboot lede-ipq806x-WPQ864-legacy-1g-initramfs-uImage
    - bootm

    flashing for nand:
    - update firmware form offical site.
      http://downloads.compex.com.sg/?dir=uploads/QSDK/WPQ864/
      use nand-ipq806x-single.img to flash
      use readme file for flash instructions
    - set the jumper boot from nand
    - tftpboot lede-ipq806x-WPQ864-legacy-1g-ubifs-nand-factory.ubi
    - nand erase 0x1340000 0x4000000
    - nand write $fileaddr 0x1340000 $filesize
    - reset

    enable PCIe3 on WPQ864
    issues:
    - if you want PCIe3(0x1b900000) wireless card working, you must have a
      working PCIe wireless card on PCIe1(0x1b500000). Maybe someone can
      help
    - pinctrl output
      [    0.362700] ipq8064-pinctrl 800000.pinmux: invalid group "gpio16"
      for function "pcie3_rst"
      but PCIe3 works
