### PR TITLE
[RFC] basefiles,procd: start process on reload [if not running]

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -88,10 +88,6 @@ service_triggers() {
 	return 0
 }
 
-service_running() {
-	return 0
-}
-
 ${INIT_TRACE:+set -x}
 
 . "$initscript"
@@ -127,6 +123,10 @@ ${INIT_TRACE:+set -x}
 	}
 
 	reload() {
+		if ! running ; then
+			start
+			return
+		fi
 		if eval "type reload_service" 2>/dev/null >/dev/null; then
 			reload_service "$@"
 		else
@@ -135,7 +135,11 @@ ${INIT_TRACE:+set -x}
 	}
 
 	running() {
-		service_running "$@"
+		if eval "type service_running" 2>/dev/null >/dev/null; then
+			service_running "$@"
+		else
+			procd_service_running "$(basename ${basescript:-$initscript})"
+		fi
 	}
 }
 

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -89,9 +89,6 @@ start_service() {
 
 	# set auto respawn behavior
 	procd_set_param respawn
-	procd_append_param respawn 3600
-	procd_append_param respawn 5
-	procd_append_param respawn -1
 	procd_close_instance
 }
 

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -95,12 +95,7 @@ start_service() {
 	procd_close_instance
 }
 
-service_running() {
-	pgrep -x /usr/sbin/lldpd &> /dev/null
-}
-
 reload_service() {
-	running || return 1
 	$LLDPCLI -u $LLDPSOCKET &> /dev/null <<-EOF
 		pause
 		unconfigure lldp custom-tlv

--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -413,6 +413,33 @@ _procd_set_config_changed() {
 	ubus call service event "$(json_dump)"
 }
 
+procd_service_running() {
+	local service="$1"
+
+	[ -n "$service" ] || return 1
+
+	json_init
+	json_add_string name "$service"
+	local result="$(ubus call service list "$(json_dump)")"
+
+	# load & process result
+	json_load "$result"
+
+	# silence warnings from here on
+	local _json_no_warning=1
+	result=1
+	json_select "$service" && \
+		json_select "instances" && \
+		json_select "instance1" && \
+		json_get_var result running && \
+		[ "$result" == "1" ] && \
+		result=0
+
+	json_cleanup
+
+	return $result
+}
+
 procd_add_mdns_service() {
 	local service proto port
 	service=$1; shift


### PR DESCRIPTION
@dedeckeh @nbd168 

This is a continuation on change 6713694
That one changed the semantic from not doing restart on reload fail,
to defining default reload as restart.

But there is also the case where, if a service is not
running, reload could start it.

Of course, a reload hook could also implement this itself.
But, it feels like this would be a nice feature to have
for procd [able] services.

Still, if a service init script wants/needs to define
it's own `service_running` script, it can do that,
and it will be used instead of relying on procd [by default].

There are 2 base packages (system & qos-scripts) who's start & reload
calls do the same thing.
And it seems that for daemon-less init scripts, reload and start
do the same thing.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>