### PR TITLE
ramips: add support for Asus RT-AC51U

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -313,6 +313,10 @@ rp-n53)
 	ucidef_set_led_netdev "eth" "Network" "$board:white:back" "eth0"
 	set_wifi_led "$board:blue:wifi"
 	;;
+rt-ac51u)
+	set_wifi_led "$board:blue:wifi"
+	set_usb_led "$board:blue:usb" "1-1"
+	;;
 rt-n14u)
 	ucidef_set_led_default "power" "power" "$board:blue:power" "1"
 	ucidef_set_led_netdev "lan" "lan" "$board:blue:lan" eth0.1

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -134,6 +134,10 @@ ramips_setup_interfaces()
 		;;
 	ar670w|\
 	ar725w|\
+	rt-ac51u)
+	        ucidef_add_switch "switch0" \
+                        "0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
+		;;
 	rt-n15|\
 	wl-351)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -116,6 +116,7 @@ get_status_led() {
 	dap-1350|\
 	na930|\
 	pbr-m1|\
+	rt-ac51u|\
 	rt-n13u|\
 	rt-n14u|\
 	rt-n15|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -436,6 +436,9 @@ ramips_board_detect() {
 	*"RT5350F-OLinuXino-EVB")
 		name="rt5350f-olinuxino-evb"
 		;;
+	*"RT-AC51U")
+		name="rt-ac51u"
+		;;
 	*"RT-G32 B1")
 		name="rt-g32-b1"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -126,6 +126,7 @@ platform_check_image() {
 	rp-n53|\
 	rt5350f-olinuxino|\
 	rt5350f-olinuxino-evb|\
+	rt-ac51u|\
 	rt-g32-b1|\
 	rt-n10-plus|\
 	rt-n13u|\

--- a/target/linux/ramips/dts/RT-AC51U.dts
+++ b/target/linux/ramips/dts/RT-AC51U.dts
@@ -1,0 +1,126 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "asus,rt-ac51u", "ralink,mt7620a-soc";
+	model = "Asus RT-AC51U";
+
+	gpio-leds {
+		compatible = "gpio-leds";
+				
+		power {
+			label = "rt-ac51u:blue:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;			
+		};
+
+		usb {
+                        label = "rt-ac51u:blue:usb";
+                        gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+                };
+
+		wifi {
+			label = "rt-ac51u:blue:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+	
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;			
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		enable-leds {
+			gpio-export,name = "enable-leds";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfb0000>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+	mtd-mac-address = <&factory 0x4>;
+	mediatek,portmap = "wllll";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "wled", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -350,6 +350,14 @@ define Device/rt-n14u
 endef
 TARGET_DEVICES += rt-n14u
 
+define Device/rt-ac51u
+  DTS := RT-AC51U
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Asus RT-AC51U
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ehci kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += rt-ac51u
+
 define Device/tiny-ac
   DTS := TINY-AC
   DEVICE_TITLE := Dovado Tiny AC


### PR DESCRIPTION
Specification:
 - SoC: MediaTek MT7620A (580 MHz)
 - RAM: 64 MiB (Winbond W9751G6JB-25)
 - Flash: 16 MiB (Spansion S25FL128SAIF00)
 - LAN: x4 100M
 - WAN: x1 100M
 - Others: USB 2.0, reset button, wps button and 9 LEDs

Issues:
 - 5 GHz band is not functional (missing driver support)
 - No webui flashing due to custom asus TRX header

How to install:
 - Write squashfs-sysupgrade file to flash using U-boot and TFTP.

Signed-off-by: Ørjan Malde <foxyred333@gmail.com>