### PR TITLE
dnsmasq: add dhcp-script hook for other packages

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.77rc5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq/release-candidates
@@ -150,10 +150,15 @@ define Package/dnsmasq/install
 	$(INSTALL_DATA) ./files/dnsmasq.conf $(1)/etc/dnsmasq.conf
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/dnsmasq.init $(1)/etc/init.d/dnsmasq
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/dhcp
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/neigh
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/ntp
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/tftp
 	$(INSTALL_DATA) ./files/dnsmasqsec.hotplug $(1)/etc/hotplug.d/ntp/25-dnsmasqsec
 	$(INSTALL_DIR) $(1)/usr/share/dnsmasq
 	$(INSTALL_DATA) ./files/rfc6761.conf $(1)/usr/share/dnsmasq/
+	$(INSTALL_DIR) $(1)/usr/lib/dnsmasq
+	$(INSTALL_BIN) ./files/dhcp-script.sh $(1)/usr/lib/dnsmasq/dhcp-script.sh
 endef
 
 Package/dnsmasq-dhcpv6/install = $(Package/dnsmasq/install)

--- a/package/network/services/dnsmasq/files/dhcp-script.sh
+++ b/package/network/services/dnsmasq/files/dhcp-script.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+case "$1" in
+	add)
+		export ACTION="add"
+		export MACADDR="$2"
+		export IPADDR="$3"
+		export HOSTNAME="$4"
+		exec /sbin/hotplug-call dhcp
+	;;
+	del)
+		export ACTION="remove"
+		export MACADDR="$2"
+		export IPADDR="$3"
+		export HOSTNAME="$4"
+		exec /sbin/hotplug-call dhcp
+	;;
+	old)
+		export ACTION="update"
+		export MACADDR="$2"
+		export IPADDR="$3"
+		export HOSTNAME="$4"
+		exec /sbin/hotplug-call dhcp
+	;;
+	arp-add)
+		export ACTION="add"
+		export MACADDR="$2"
+		export IPADDR="$3"
+		exec /sbin/hotplug-call neigh
+	;;
+	arp-del)
+		export ACTION="remove"
+		export MACADDR="$2"
+		export IPADDR="$3"
+		exec /sbin/hotplug-call neigh
+	;;
+	tftp)
+		export ACTION="add"
+		export TFTP_SIZE="$2"
+		export TFTP_ADDR="$3"
+		export TFTP_PATH="$4"
+		exec /sbin/hotplug-call tftp
+	;;
+esac

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -18,6 +18,7 @@ TRUSTANCHORSFILE="/usr/share/dnsmasq/trust-anchors.conf"
 TIMEVALIDFILE="/var/state/dnsmasqsec"
 BASEDHCPSTAMPFILE="/var/run/dnsmasq"
 RFC6761FILE="/usr/share/dnsmasq/rfc6761.conf"
+BASESCRIPTFILE="/var/etc/dnsmasq.dhcp-script"
 
 DNSMASQ_DHCP_VER=4
 
@@ -694,6 +695,18 @@ dhcp_relay_add() {
 	fi
 }
 
+dhcp_create_script() {
+	local cfg="$1"
+	SCRIPTFILE="${BASESCRIPTFILE}.${cfg}"
+	{	echo "#!/bin/sh"
+		echo "export DNSMASQ_CONFIG=${cfg}"
+		echo "USERSCRIPT=\$(uci -q get dhcp.\${DNSMASQ_CONFIG}.dhcpscript)"
+		echo "[ -n \"\$USERSCRIPT\" ] && ( . \"\$USERSCRIPT\" \"\$@\" )"
+		echo "( . \"/usr/lib/dnsmasq/dhcp-script.sh\" \"\$@\" )"
+	} > "${SCRIPTFILE}"
+	chmod 755 "${SCRIPTFILE}"
+}
+
 dnsmasq_start()
 {
 	local cfg="$1" disabled resolvfile
@@ -709,11 +722,13 @@ dnsmasq_start()
 	HOSTFILE="${BASEHOSTFILE}.${cfg}"
 	TIMESTAMPFILE="${BASETIMESTAMPFILE}.${cfg}"
 	BASEDHCPSTAMPFILE_CFG="${BASEDHCPSTAMPFILE}.${cfg}"
+	SCRIPTFILE="${BASESCRIPTFILE}.${cfg}"
 
 	# before we can call xappend
 	mkdir -p /var/run/dnsmasq/
 	mkdir -p $(dirname $CONFIGFILE)
 	mkdir -p $(dirname $HOSTFILE)
+	mkdir -p $(dirname $SCRIPTFILE)
 	mkdir -p /var/lib/misc
 	chown dnsmasq:dnsmasq /var/run/dnsmasq
 
@@ -791,7 +806,7 @@ dnsmasq_start()
 	append_bool "$cfg" noping "--no-ping"
 
 	append_parm "$cfg" logfacility "--log-facility"
-	append_parm "$cfg" dhcpscript "--dhcp-script"
+	xappend "--dhcp-script=${SCRIPTFILE}"
 	append_parm "$cfg" cachesize "--cache-size"
 	append_parm "$cfg" dnsforwardmax "--dns-forward-max"
 	append_parm "$cfg" port "--port"
@@ -968,6 +983,8 @@ dnsmasq_start()
 		done
 	}
 
+	dhcp_create_script $cfg
+
 	procd_open_instance $cfg
 	procd_set_param command $PROG -C $CONFIGFILE -k -x /var/run/dnsmasq/dnsmasq."${cfg}".pid
 	procd_set_param file $CONFIGFILE
@@ -979,7 +996,7 @@ dnsmasq_start()
 	fi
 
 	procd_add_jail dnsmasq ubus log
-	procd_add_jail_mount $CONFIGFILE $TRUSTANCHORSFILE $HOSTFILE $RFC6761FILE /etc/passwd /etc/group /etc/TZ /dev/null /dev/urandom $dnsmasqconffile $dnsmasqconfdir $resolvfile $dhcpscript /etc/hosts /etc/ethers $EXTRA_MOUNT
+	procd_add_jail_mount $CONFIGFILE $TRUSTANCHORSFILE $HOSTFILE $RFC6761FILE $SCRIPTFILE /etc/passwd /etc/group /etc/TZ /dev/null /dev/urandom $dnsmasqconffile $dnsmasqconfdir $resolvfile $dhcpscript /etc/hosts /etc/ethers /etc/hotplug.d /sbin/hotplug-call /usr/lib/dnsmasq $EXTRA_MOUNT
 	procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
 
 	procd_close_instance


### PR DESCRIPTION
Adds a script which acts as a hook for when dnsmasq creates/destroys a
lease, or completes a TFTP file transfer. The hook loops through scripts
in '/etc/dnsmasq-dhcp.d', executing each one with the same arguments
supplied by dnsmasq.

Signed-off-by: Nick Brassel <nick@tzarc.org>