### PR TITLE
comgt-3g: enable modem before to setpin

### DIFF
--- a/package/network/utils/comgt/Makefile
+++ b/package/network/utils/comgt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=comgt
 PKG_VERSION:=0.32
-PKG_RELEASE:=28
+PKG_RELEASE:=29
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=@SF/comgt

--- a/package/network/utils/comgt/files/setpin.gcom
+++ b/package/network/utils/comgt/files/setpin.gcom
@@ -7,6 +7,7 @@ opengt
 
  let c=0
 :start
+ send "AT+CFUN=1^m"
  send "AT+CPIN?^m"
  waitfor 15 "SIM PUK","SIM PIN","READY","ERROR","ERR"
  if % = -1 goto timeout


### PR DESCRIPTION
some modems needs to be enabled with CFUN=1 before to set the pin

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>