### PR TITLE
kernel: add hwmon for W83627EHF and family

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -97,7 +97,7 @@ define KernelPackage/hwmon-nct6775
   TITLE:=NCT6106D/6775F/6776F/6779D/6791D/6792D/6793D and compatibles monitoring support
   KCONFIG:=CONFIG_SENSORS_NCT6775
   FILES:=$(LINUX_DIR)/drivers/hwmon/nct6775.ko
-  AUTOLOAD:=$(call AutoProbe,nct6775)
+  AUTOLOAD:=$(call AutoLoad,51,nct6775)
   $(call AddDepends/hwmon,@PCI_SUPPORT @TARGET_x86 +kmod-hwmon-vid)
 endef
 
@@ -311,6 +311,21 @@ define KernelPackage/hwmon-w83627hf/description
 endef
 
 $(eval $(call KernelPackage,hwmon-w83627hf))
+
+
+define KernelPackage/hwmon-w83627ehf
+  TITLE:=Winbond W83627EHF/EHG/DHG/UHG, W83667HG, NCT6775F, NCT6776F monitoring support
+  KCONFIG:=CONFIG_SENSORS_W83627EHF
+  FILES:=$(LINUX_DIR)/drivers/hwmon/w83627ehf.ko
+  AUTOLOAD:=$(call AutoLoad,52,w83627ehf)
+  $(call AddDepends/hwmon,@TARGET_x86 +kmod-hwmon-vid)
+endef
+
+define KernelPackage/hwmon-w83627ehf/description
+ Kernel module for Winbond W83627EHF/EHG/DHG/UHG, W83667HG, NCT6775F, NCT6776F thermal monitor chip
+endef
+
+$(eval $(call KernelPackage,hwmon-w83627ehf))
 
 
 define KernelPackage/hwmon-w83793


### PR DESCRIPTION
NCT6775 driver needs to run before W83627EHF, however, as it's the
driver of choice for NCT6775/6 (and family) chips and you want that
module to load first.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
