### PR TITLE
dnsmasq: bump to 2.77rc3

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
-PKG_VERSION:=2.77test5
-PKG_RELEASE:=3
+PKG_VERSION:=2.77rc3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq/test-releases
-PKG_HASH:=5d57d575944769f4c6142ac3d6e81c3e60f20f6817d52f18df8056b6e0a9112d
+PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq/release-candidates
+PKG_HASH:=2ba2fcf5728581c559d7deb036f5d3298d5aa1ae44d1cac795b092d553e0bf63
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/package/network/services/dnsmasq/patches/210-dnssec-improve-timestamp-heuristic.patch
+++ b/package/network/services/dnsmasq/patches/210-dnssec-improve-timestamp-heuristic.patch
@@ -35,13 +35,13 @@ Signed-off-by: Steven Barth <steven@midlink.org>
 +      if (difftime(now, base) >= 0 && difftime(timestamp_time, now) <= 0)
  	{
  	  /* time already OK, update timestamp, and do key checking from the start. */
- 	  if (utime(daemon->timestamp_file, NULL) == -1)
+ 	  if (utimes(daemon->timestamp_file, NULL) == -1)
 @@ -493,7 +500,7 @@ int setup_timestamp(void)
  
  	  close(fd);
  	  
--	  timestamp_time = timbuf.actime = timbuf.modtime = 1420070400; /* 1-1-2015 */
-+	  timestamp_time = timbuf.actime = timbuf.modtime = base;
- 	  if (utime(daemon->timestamp_file, &timbuf) == 0)
- 	    goto check_and_exit;
- 	}
+-	  timestamp_time = 1420070400; /* 1-1-2015 */
++	  timestamp_time = base; /* 1-1-2015 */
+ 	  tv[0].tv_sec = tv[1].tv_sec = timestamp_time;
+ 	  tv[0].tv_usec = tv[1].tv_usec = 0;
+ 	  if (utimes(daemon->timestamp_file, tv) == 0)


### PR DESCRIPTION
Fix [FS#766] Intermittent SIGSEGV crash of dnsmasq-full

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>

This one works, honest!  Definitely issues DHCPv4 & v6 leases ;-)
