### PR TITLE
 gdb: disable simulator ; it's broken on ppc

### DIFF
--- a/package/devel/gdb/Makefile
+++ b/package/devel/gdb/Makefile
@@ -60,13 +60,6 @@ CONFIGURE_ARGS+= \
 CONFIGURE_VARS+= \
 	ac_cv_search_tgetent="$(TARGET_LDFLAGS) -lncurses -lreadline"
 
-define Build/Compile
-	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		CPPFLAGS="$(TARGET_CPPFLAGS)" \
-		all
-endef
-
 define Build/Install
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		DESTDIR="$(PKG_INSTALL_DIR)" \

--- a/package/devel/gdb/Makefile
+++ b/package/devel/gdb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gdb
 PKG_VERSION:=7.12.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gdb
@@ -55,6 +55,7 @@ CONFIGURE_ARGS+= \
 	--with-system-readline \
 	--without-expat \
 	--without-lzma \
+	--disable-sim \
 	--disable-werror
 
 CONFIGURE_VARS+= \


### PR DESCRIPTION
Error is:
```
ompile-loc2c.o compile-c-support.o inflow.o    init.o \
	  ../sim/ppc/libsim.a -lreadline ../opcodes/libopcodes.a ../bfd/libbfd.a -L./../zlib -lz  ../libiberty/libiberty.a ../libdecnumber/libdecnumber.a    -lncurses -lm     ../libiberty/libiberty.a  build-gnulib/import/libgnu.a  -ldl -Wl,--dynamic-list=./proc-service.list
../sim/ppc/libsim.a(idecode.o): In function `update_time_from_event':
idecode.c:(.text+0x170): undefined reference to `error'
../sim/ppc/libsim.a(idecode.o): In function `event_queue_tick':
idecode.c:(.text+0x1cc): undefined reference to `error'
idecode.c:(.text+0x28c): undefined reference to `error'
idecode.c:(.text+0x318): undefined reference to `error'
../sim/ppc/libsim.a(idecode.o): In function `cpu_halt.constprop.6':
idecode.c:(.text+0x398): undefined reference to `error'
../sim/ppc/libsim.a(idecode.o):idecode.c:(.text+0x4e4): more undefined references to `error' follow
collect2: error: ld returned 1 exit status
Makefile:1420: recipe for target 'gdb' failed
make[5]: *** [gdb] Error 1
```

Seems others are running into this as well.
The problem seems to be that some code may be built
as C++ and not C, which may explain the linker error.

On this thread reply:
   https://sourceware.org/ml/gdb/2016-11/msg00045.html
it mentions that the simulator should not call GDB's
"error" function directly, but rather use the "host_callback"
struct.

I have no idea about the use of the GDB simulator within
the OpenWrt/LEDE community.

So, I took the easier route, which is to disable the simulator.
(Also suggested here: https://sourceware.org/ml/gdb/2016-11/msg00047.html )

If needed, I can make an effort to fix the simulator for PPC.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>