### PR TITLE
lldpd: drop specific respawn params [use system-wide]

### DIFF
--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -89,9 +89,6 @@ start_service() {
 
 	# set auto respawn behavior
 	procd_set_param respawn
-	procd_append_param respawn 3600
-	procd_append_param respawn 5
-	procd_append_param respawn -1
 	procd_close_instance
 }
 


### PR DESCRIPTION
I think I added these respawn params [a while back],
when I did the conversion to procd init script format.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>