### PR TITLE
procd, base-files: query procd for checking the running state of a service

### DIFF
--- a/package/base-files/files/etc/init.d/gpio_switch
+++ b/package/base-files/files/etc/init.d/gpio_switch
@@ -33,6 +33,11 @@ service_triggers()
 	procd_add_reload_trigger "system"
 }
 
+service_running()
+{
+	return 0
+}
+
 start_service()
 {
 	[ -e /sys/class/gpio/ ] && {

--- a/package/base-files/files/etc/init.d/system
+++ b/package/base-files/files/etc/init.d/system
@@ -45,6 +45,10 @@ service_triggers()
 	procd_add_validation validate_system_section
 }
 
+service_running() {
+	return 0
+}
+
 start_service() {
 	reload_service
 }

--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -88,10 +88,6 @@ service_triggers() {
 	return 0
 }
 
-service_running() {
-	return 0
-}
-
 ${INIT_TRACE:+set -x}
 
 . "$initscript"
@@ -135,7 +131,11 @@ ${INIT_TRACE:+set -x}
 	}
 
 	running() {
-		service_running "$@"
+		if eval "type service_running" 2>/dev/null >/dev/null; then
+			service_running "$@"
+		else
+			procd_service_running "$(basename ${basescript:-$initscript})"
+		fi
 	}
 }
 

--- a/package/network/config/firewall/files/firewall.init
+++ b/package/network/config/firewall/files/firewall.init
@@ -41,6 +41,10 @@ restart() {
 	fw3 restart
 }
 
+service_running() {
+	return 0
+}
+
 start_service() {
 	fw3 ${QUIET} start
 }

--- a/package/network/config/qos-scripts/files/etc/init.d/qos
+++ b/package/network/config/qos-scripts/files/etc/init.d/qos
@@ -19,6 +19,10 @@ service_triggers()
 	qos-start
 }
 
+service_running() {
+	return 0
+}
+
 start_service() {
 	qos-start
 }

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -95,10 +95,6 @@ start_service() {
 	procd_close_instance
 }
 
-service_running() {
-	pgrep -x /usr/sbin/lldpd &> /dev/null
-}
-
 reload_service() {
 	running || return 1
 	$LLDPCLI -u $LLDPSOCKET &> /dev/null <<-EOF

--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -413,6 +413,31 @@ _procd_set_config_changed() {
 	ubus call service event "$(json_dump)"
 }
 
+procd_service_running() {
+	local service="$1"
+	local running
+
+	[ -n "$service" ] || return 1
+
+	json_init
+	json_add_string name "$service"
+
+	# get information from procd via ubus call
+	json_load "$(ubus call service list "$(json_dump)")"
+
+	# silence warnings from here on
+	local _json_no_warning=1
+	# try to get the 'running' param from procd output
+	json_select "$service" && \
+		json_select "instances" && \
+		json_select "instance1" && \
+		json_get_var running running
+
+	json_cleanup
+
+	[ "$running" == "1" ]
+}
+
 procd_add_mdns_service() {
 	local service proto port
 	service=$1; shift


### PR DESCRIPTION
For services that are handled by procd, a ubus call [to procd] can be used to query the running state of that service.

However, certain init.d scripts that set the USE_PROCD var [system, gpio_switch, firewall, qos], don't provide a comand param, so query-ing procd will return that the service is not running.
For those, I've added a dummy service_running() hook that will `return 0`.

For lldpd, I've removed the `service_running()` hook [I added that a while back], since querying procd yields the same result.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>