### PR TITLE
base-files: fix default procd reload

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -130,7 +130,7 @@ ${INIT_TRACE:+set -x}
 		if eval "type reload_service" 2>/dev/null >/dev/null; then
 			reload_service "$@"
 		else
-			restart
+			start
 		fi
 	}
 


### PR DESCRIPTION
Bug introduced with 6713694.

I did not count on procd handling reload as mentioned
in this doc:
https://wiki.openwrt.org/inbox/procd-init-scripts

```
procd_set_param file /var/etc/your_service.conf # /etc/init.d/your_service reload will restart the daemon if these files have changed
procd_set_param netdev dev # likewise, except if dev's ifindex changes.
procd_set_param data name=value ... # likewise, except if this data changes.
```

The service would be restarted regardless of any of those params.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>

Thanks for your contribution to the LEDE project!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
