### PR TITLE
package/grub2: update to 2.02

### DIFF
--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -9,15 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=grub
-PKG_VERSION:=2.02~rc2
+PKG_VERSION:=2.02
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://alpha.gnu.org/gnu/grub \
-	http://gnualpha.uib.no/grub/ \
-	http://mirrors.fe.up.pt/pub/gnu-alpha/grub/ \
-	http://www.nic.funet.fi/pub/gnu/alpha/gnu/grub/
-PKG_HASH:=053bfcbe366733e4f5a1baf4eb15e1efd977225bdd323b78087ce5fa172fc246
+PKG_SOURCE_URL:=@GNU/grub
+PKG_HASH:=810b3798d316394f94096ec2797909dbf23c858e48f7b3830826b8daa06b7b0f
 
 PKG_FIXUP:=autoreconf
 HOST_BUILD_PARALLEL:=1


### PR DESCRIPTION
Update to version 2.02

Full changelog can be viewed [here](https://git.savannah.gnu.org/cgit/grub.git/log/?h=grub-2.02)