### PR TITLE
kirkwood: add support for Cisco ON100 

### DIFF
--- a/package/boot/uboot-envtools/files/kirkwood
+++ b/package/boot/uboot-envtools/files/kirkwood
@@ -20,6 +20,9 @@ ib62x0|\
 linksys-viper|\
 nsa310b|\
 nsa325|\
+on100)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	;;
 pogo_e02|\
 sheevaplug|\
 sheevaplug-esata)

--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -35,6 +35,9 @@ case "$board" in
 	ucidef_set_interface_lan "eth0" "dhcp"
 	ucidef_set_interface_macaddr "lan" $( mtd_get_mac_ascii uboot_env ethaddr )
 	;;
+"on100")
+	ucidef_set_interface_lan "eth0 eth1"
+	;;
 *)
 	ucidef_set_interface_lan "eth0"
 	;;

--- a/target/linux/kirkwood/base-files/etc/diag.sh
+++ b/target/linux/kirkwood/base-files/etc/diag.sh
@@ -23,6 +23,9 @@ get_status_led() {
 	nsa310b)
 		status_led="nsa310:green:sys"
 		;;
+	on100)
+		status_led="on100:green:health"
+		;;
 	esac
 }
 

--- a/target/linux/kirkwood/base-files/lib/kirkwood.sh
+++ b/target/linux/kirkwood/base-files/lib/kirkwood.sh
@@ -33,6 +33,10 @@ kirkwood_board_detect() {
 		name="ib62x0"
 		;;
 
+	"Cisco Systems ON100")
+		name="on100"
+		;;
+
 	"Cloud Engines Pogoplug E02")
 		name="pogo_e02"
 		;;

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
 KERNEL_LOADADDR:=0x8000
-TARGET_DEVICES = linksys-audi linksys-viper dockstar goflexnet goflexhome iconnect pogo_e02 ib62x0 nsa310b nsa325
+TARGET_DEVICES = linksys-audi linksys-viper dockstar goflexnet goflexhome iconnect pogo_e02 ib62x0 nsa310b nsa325 on100
 
 UBI_OPTS := -m 2048 -p 128KiB -s 512
 UBIFS_OPTS := -m 2048 -e 126KiB -c 4096
@@ -92,6 +92,17 @@ $(Device/dockstar)
   DEVICE_TITLE := ZyXEL NSA325 (v1 and v2)
   DEVICE_DTS := kirkwood-nsa325
   DEVICE_PACKAGES := kmod-gpio-button-hotplug kmod-rtc-pcf8563 kmod-usb3
+endef
+
+define Device/on100
+  DEVICE_TITLE := Cisco Systems ON100
+  DEVICE_DTS := kirkwood-on100
+#  DEVICE_PACKAGES := kmod-mvsdio kmod-usb-storage kmod-i2c-core kmod-i2c-mv64xxx kmod-ata-core kmod-btmrvl kmod-btmrvl-sdio kmod-libertas kmod-libertas-sdio
+  DEVICE_PACKAGES := kmod-i2c-mv64xxx
+  KERNEL_SIZE := 5376k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
+  UBINIZE_OPTS := -E 5
 endef
 
 define Device/pogo_e02

--- a/target/linux/kirkwood/patches-4.4/195-on100.patch
+++ b/target/linux/kirkwood/patches-4.4/195-on100.patch
@@ -1,0 +1,173 @@
+--- /dev/null
++++ b/arch/arm/boot/dts/kirkwood-on100.dts
+@@ -0,0 +1,160 @@
++/dts-v1/;
++
++#include "kirkwood.dtsi"
++#include "kirkwood-6282.dtsi"
++
++/ {
++	model = "Cisco Systems ON100";
++	compatible = "cisco,on100", "marvell,kirkwood-88f6282", "marvell,kirkwood";
++
++	memory {
++		device_type = "memory";
++		reg = <0x00000000 0x20000000>;
++	};
++
++	aliases {
++		serial0 = &uart0;
++	};
++
++	chosen {
++		bootargs = "console=ttyS0,115200n8 earlyprintk";
++		stdout-path = "serial0:115200n8";
++	};
++
++ 	gpio_keys {
++		compatible = "gpio-keys";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		pinctrl-0 = <&pmx_btn_reset>;
++		pinctrl-names = "default";
++
++		button@1 {
++			label = "Reset Button";
++			linux,code = <KEY_RESTART>;
++			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++		pinctrl-0 = < &pmx_led_health_r &pmx_led_health_g >;
++		pinctrl-names = "default";
++
++		health-g {
++			label = "on100:green:health";
++			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
++		};
++
++		health-r {
++			label = "on100:red:health";
++			gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
++		};
++
++		health2-g {
++			label = "on100:green:health2";
++			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
++		};
++
++		health2-r {
++			label = "on100:red:health2";
++			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&eth0 {
++	status = "okay";
++
++	ethernet0-port@0 {
++		phy-handle = <&ethphy0>;
++		phy-connection-type = "rgmii-id";
++	};
++};
++
++&eth1 {
++	status = "okay";
++
++	ethernet1-port@0 {
++		phy-handle = <&ethphy1>;
++		phy-connection-type = "rgmii-id";
++	};
++};
++
++&mdio {
++	status = "okay";
++
++	ethphy0: ethernet-phy@0 {
++		/* Marvell 88E1121R */
++		compatible = "ethernet-phy-id0141.0cb0",
++			     "ethernet-phy-ieee802.3-c22";
++		reg = <0>;
++	};
++
++	ethphy1: ethernet-phy@1 {
++		/* Marvell 88E1121R */
++		compatible = "ethernet-phy-id0141.0cb0",
++			     "ethernet-phy-ieee802.3-c22";
++		reg = <1>;
++	};
++};
++
++&nand {
++	status = "okay";
++
++	partition@0 {
++		label = "u-boot";
++		reg = <0x00000000 0x000a0000>;
++		read-only;
++	};
++
++	partition@a0000 {
++		label = "u-boot environment";
++		reg = <0x000a0000 0x00020000>;
++		read-only;
++	};
++
++	partition@c0000 {
++		label = "kernel";
++		reg = <0x000c0000 0x00540000>;
++	};
++
++	partition@600000 {
++		label = "ubi";
++		reg = <0x00600000 0x1fa00000>;
++	};
++};
++
++&pinctrl {
++	pmx_led_health_r: pmx-led-health-r {
++		marvell,pins = "mpp45";
++		marvell,function = "gpio";
++	};
++
++	pmx_led_health_g: pmx-led-health-g {
++		marvell,pins = "mpp44";
++		marvell,function = "gpio";
++	};
++
++	pmx_led_health2_r: pmx-led-health2-r {
++		marvell,pins = "mpp47";
++		marvell,function = "gpio";
++	};
++
++	pmx_led_health2_g: pmx-led-health2-g {
++		marvell,pins = "mpp46";
++		marvell,function = "gpio";
++	};
++
++	pmx_btn_reset: pmx-led-reset {
++		marvell,pins = "mpp31";
++		marvell,function = "gpio";
++	};
++};
++
++&sdio {
++	status = "okay";
++};
++
++&uart0 {
++	status = "okay";
++};
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -206,6 +206,7 @@ dtb-$(CONFIG_MACH_KIRKWOOD) += \
+ 	kirkwood-nsa310b.dtb \
+ 	kirkwood-nsa310s.dtb \
+ 	kirkwood-nsa325.dtb \
++	kirkwood-on100.dtb \
+ 	kirkwood-openblocks_a6.dtb \
+ 	kirkwood-openblocks_a7.dtb \
+ 	kirkwood-openrd-base.dtb \


### PR DESCRIPTION
The Cisco ON100 device is a Kirkwood based router:

- SoC: Marvell 88F6282 1600Mhz
- SDRAM memory: 512MB DDR3 1333Mhz
- Gigabit ethernet: 2x Marvell 88E1310 (over RGMII)
- Flash memory: 512MB
- 2 bi-colour status LEDs (green/red)
- 1 Reset button
- 1 USB 2.0 port (on back)

This commit adds a target profile of "Cisco Systems ON100" under the target
system "Marvell Kirkwood".

The stock u-boot can read ubi and supports booting via tftp, once "dhcp"
command issued and device has a valid lease with tftp options set, flashing
is performed as follows:

tftpboot ${loadaddr} lede-kirkwood-ciscoon100-uImage ; nand erase 0x200000
 0x600000 ; nand write ${loadaddr} 0x200000 0x600000
nand erase 0x700000 0x1f900000
tftpboot ${loadaddr} lede-kirkwood-ciscoon100-squashfs-factory.bin; nand
 erase 0x700000 ${filesize} ; nand write ${loadaddr} 0x700000 ${filesize}

LEDE is now flashed, but some configuration of environment variables is
required:

setenv lede_bootargs_root ubi.mtd=2 root=/dev/mtdblock2
setenv lede_mtdparts mtdparts=nand_mtd:0x200000@0x0(u-boot),0x400000@0x200
000(uImage),-@0x700000(data)
setenv lede_boot nand read.e \${loadaddr} 0x200000 0x200000 \; setenv
 bootargs \$(console) \$(lede_mtdparts) \${lede_bootargs_root} \; bootm
 \${loadaddr}
setenv bootcmd run lede_boot saveenv

If u-boot has been replaced (there may not seem to be a need to do this,
the stock u-boot seemed to work fine on my target), you may wish to confirm
mac addresses are still present with printenv. If they are not present or
incorrect, write your MAC addresses back with the following (use your MACs
as per the label on your device, instead of the example)

setenv ethaddr 64:00:F1:00:00:00
setenv eth1addr 64:00:F1:00:00:01
saveenv

Signed-off-by: Makoto Takeuchi <mak0@lxsys.co.uk>