### PR TITLE
Add organization related subject attributes to certificate and key generation

### DIFF
--- a/package/network/services/uhttpd/files/uhttpd.config
+++ b/package/network/services/uhttpd/files/uhttpd.config
@@ -113,18 +113,22 @@ config uhttpd main
 config cert defaults
 
 	# Validity time
-	option days		730
+	option days			730
 
 	# RSA key size
-	option bits		2048
+	option bits			2048
 
 	# Location
-	option country		ZZ
-	option state		Somewhere
-	option location		Unknown
+	option country			ZZ
+	option state			Somewhere
+	option location			Unknown
+	
+	# Organization
+	option organization		Institution
+	option organizationalunit	Department
 
 	# Common name
-	option commonname	'%D'
+	option commonname		'%D'
 
 # config httpauth prefix_user
 #	option prefix /protected/url/path

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -35,14 +35,16 @@ generate_keys() {
 	local cfg="$1"
 	local key="$2"
 	local crt="$3"
-	local days bits country state location commonname
+	local days bits country state location organization organizationalunit commonname
 
-	config_get days       "$cfg" days
-	config_get bits       "$cfg" bits
-	config_get country    "$cfg" country
-	config_get state      "$cfg" state
-	config_get location   "$cfg" location
-	config_get commonname "$cfg" commonname
+	config_get days       		"$cfg" days
+	config_get bits       		"$cfg" bits
+	config_get country    		"$cfg" country
+	config_get state      		"$cfg" state
+	config_get location   		"$cfg" location
+	config_get organization   	"$cfg" organization
+	config_get organizationalunit   "$cfg" organizationalunit
+	config_get commonname 		"$cfg" commonname
 
 	# Prefer px5g for certificate generation (existence evaluated last)
 	local GENKEY_CMD=""
@@ -52,7 +54,7 @@ generate_keys() {
 	[ -n "$GENKEY_CMD" ] && {
 		$GENKEY_CMD \
 			-days ${days:-730} -newkey rsa:${bits:-2048} -keyout "${UHTTPD_KEY}.new" -out "${UHTTPD_CERT}.new" \
-			-subj /C="${country:-DE}"/ST="${state:-Saxony}"/L="${location:-Leipzig}"/O="${commonname:-Lede}$UNIQUEID"/CN="${commonname:-Lede}"
+			-subj /C="${country:-DE}"/ST="${state:-Saxony}"/L="${location:-Leipzig}"/O="${organization:-Lede-Project}"/OU="${organizationalunit:-Lede-}$UNIQUEID"/CN="${commonname:-lede.lan}"
 		sync
 		mv "${UHTTPD_KEY}.new" "${UHTTPD_KEY}"
 		mv "${UHTTPD_CERT}.new" "${UHTTPD_CERT}"


### PR DESCRIPTION
Add organization and organizationalunit subject attributes to uhttpd config for automatic x.509 certificate and key generation.

Signed-off-by: Robert LaRocca robberize@icloud.com