### PR TITLE
uboot-lantiq/spl: fixed uninitialized variable len in spl_uncompress_lzo

### DIFF
--- a/package/boot/uboot-lantiq/patches/0014-MIPS-add-support-for-Lantiq-XWAY-SoCs.patch
+++ b/package/boot/uboot-lantiq/patches/0014-MIPS-add-support-for-Lantiq-XWAY-SoCs.patch
@@ -1419,7 +1419,7 @@ Signed-off-by: Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
 +
 +static int spl_uncompress_lzo(struct spl_image *spl, unsigned long loadaddr)
 +{
-+	size_t len;
++	size_t len = CONFIG_SYS_LOAD_SIZE;
 +	int ret;
 +
 +	spl_puts("SPL: decompressing U-Boot with LZO\n");
@@ -3237,7 +3237,7 @@ Signed-off-by: Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
 +}
 --- /dev/null
 +++ b/arch/mips/include/asm/arch-danube/config.h
-@@ -0,0 +1,163 @@
+@@ -0,0 +1,164 @@
 +/*
 + * Copyright (C) 2007-2010 Lantiq Deutschland GmbH
 + * Copyright (C) 2011-2013 Daniel Schwierzeck, daniel.schwierzeck@gmail.com
@@ -3296,6 +3296,7 @@ Signed-off-by: Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
 +#define CONFIG_SYS_MEMTEST_START	0x81000000
 +#define CONFIG_SYS_MEMTEST_END		0x82000000
 +#define CONFIG_SYS_LOAD_ADDR		0x81000000
++#define CONFIG_SYS_LOAD_SIZE		(2 * 1024 * 1024)
 +#define CONFIG_SYS_INIT_SP_OFFSET	0x4000
 +
 +/* SRAM */
@@ -3475,7 +3476,7 @@ Signed-off-by: Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
 +#endif /* __DANUBE_SOC_H__ */
 --- /dev/null
 +++ b/arch/mips/include/asm/arch-vrx200/config.h
-@@ -0,0 +1,187 @@
+@@ -0,0 +1,188 @@
 +/*
 + * Copyright (C) 2010 Lantiq Deutschland GmbH
 + * Copyright (C) 2011-2013 Daniel Schwierzeck, daniel.schwierzeck@gmail.com
@@ -3546,6 +3547,7 @@ Signed-off-by: Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
 +#define CONFIG_SYS_MEMTEST_START	0x81000000
 +#define CONFIG_SYS_MEMTEST_END		0x82000000
 +#define CONFIG_SYS_LOAD_ADDR		0x81000000
++#define CONFIG_SYS_LOAD_SIZE		(2 * 1024 * 1024)
 +#define CONFIG_SYS_INIT_SP_OFFSET	(32 * 1024)
 +
 +/* SRAM */

--- a/package/boot/uboot-lantiq/patches/0015-MIPS-lantiq-add-support-for-Lantiq-XWAY-ARX100-SoC-f.patch
+++ b/package/boot/uboot-lantiq/patches/0015-MIPS-lantiq-add-support-for-Lantiq-XWAY-ARX100-SoC-f.patch
@@ -903,7 +903,7 @@ Signed-off-by: Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
  #define STATUS_LANTIQ		(STATUS_MIPS34K | STATUS_MIPS32_64)
 --- /dev/null
 +++ b/arch/mips/include/asm/arch-arx100/config.h
-@@ -0,0 +1,175 @@
+@@ -0,0 +1,176 @@
 +/*
 + * Copyright (C) 2007-2010 Lantiq Deutschland GmbH
 + * Copyright (C) 2011-2013 Daniel Schwierzeck, daniel.schwierzeck@gmail.com
@@ -967,6 +967,7 @@ Signed-off-by: Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
 +#define CONFIG_SYS_MEMTEST_START	0x81000000
 +#define CONFIG_SYS_MEMTEST_END		0x82000000
 +#define CONFIG_SYS_LOAD_ADDR		0x81000000
++#define CONFIG_SYS_LOAD_SIZE		(2 * 1024 * 1024)
 +#define CONFIG_SYS_INIT_SP_OFFSET	(32 * 1024)
 +
 +/* SRAM */


### PR DESCRIPTION
This fix is taken from uboot-lantiq v2014.07 (Daniel Schwierzeck)

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
