### PR TITLE
Lantiq: make possible to tweak DSL SRN from UCI

### DIFF
--- a/package/network/config/ltq-vdsl-app/files/dsl_control
+++ b/package/network/config/ltq-vdsl-app/files/dsl_control
@@ -96,6 +96,22 @@ tone_vdsl_b="0x1" # B43
 tone_adsl_bv="0x81" # B43 + B43c
 tone_vdsl_bv="0x5" # B43 + V43
 
+# create ADSL autoboot script. Used for SNR margin tweak
+autoboot_script() {
+    echo "[WaitForConfiguration]={
+locs 0 $1
+}
+
+[WaitForLinkActivate]={
+}
+
+[WaitForRestart]={
+}
+
+[Common]={
+}" > /tmp/adsl.scr
+}
+
 lowlevel_cfg() {
 	echo "# VRX Low Level Configuration File
 #
@@ -166,6 +182,7 @@ start_service() {
 	local line_mode
 	local mode
 	local lowlevel
+	local snr
 
 	config_load network
 	config_get tone dsl tone
@@ -173,6 +190,7 @@ start_service() {
 	config_get firmware dsl firmware
 	config_get xfer_mode dsl xfer_mode
 	config_get line_mode dsl line_mode
+	config_get snr dsl ds_snr_offset
 
 	eval "xtse=\"\${xtse_xdsl_$annex}\""
 
@@ -262,13 +280,20 @@ start_service() {
 		lowlevel="-l /tmp/lowlevel.cfg"
 	}
 
+	[ -z "${snr}" ] || {
+	    # for SNR offset setting
+	    autoboot_script "$snr"
+	    autoboot="-a /tmp/adsl.scr"
+	}
+
 	procd_open_instance
 	procd_set_param command /sbin/vdsl_cpe_control_wrapper \
 			-i$xtse \
 			-n /sbin/dsl_notify.sh \
 			-f ${firmware} \
 			$lowlevel \
-			-M ${mode}
+			-M ${mode} \
+			$autoboot
 	procd_append_param env "LOAD=$LOAD" "UNLOAD=$UNLOAD"
 	procd_close_instance
 }


### PR DESCRIPTION
This patch makes possible to tweak the downstream SNR margin on
Lantiq DSL devices.

The UCI parameter 'network.dsl.ds_snr_offset' is used to set the SNR
margin offset. It accepts values in range -50 to +50 in 0.1 dB units.

The SNR margin can thus be modified in range -5.0 to +5.0 dB in 0.1 dB
steps.

Currently this should only affect ADSL (not VDSL). It should be very
easy to make this work also on VDSL lines, but since I couldn't test
on VDSL lines this patch does not do that yet.

I have also a patch for LUCI about this, that I could submit.

Tested on FB3370 (Lantiq VR9) and Telecom Italia ADSL2+ line.

Signed-off-by: Andrea Merello <andrea.merello@gmail.com>