### PR TITLE
base-files: Allow bridge w/o physical ifname

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -65,12 +65,12 @@ generate_network() {
 		json_select ..
 	json_select ..
 
-	[ -n "$ifname" ] || return
-
 	# force bridge for multi-interface devices (and lan)
 	case "$1:$ifname" in
 		*\ * | lan:*) type="bridge" ;;
 	esac
+
+	[ -n "$ifname" -o "$type" = "bridge" ] || return
 
 	uci -q batch <<-EOF
 		delete network.$1


### PR DESCRIPTION
It's possible to configure a bridged interface without physical interface
on a running LEDE box. This is useful for devices with only one eth0 port
(and wlan0): eth0 is used as wan, and wlan0 is bridged into the empty
br-lan.

However, the `/bin/config_generate` will stop generating configuration
for an interface without physical name. This prevent users creating custom
image which will act like a out of box only-one-wired-wan to wireless-lan
gateway using imagebuilder.

It will be better, allowing generate configuration for a bridged interface
even if no wired physical ifname is attached to it. :)

A common use case is to write something like
`    ucidef_set_interfaces_lan_wan "" "eth0"`
inside `/etc/board.d/some_customization` .

Signed-off-by: Adoal Xu <adoalxu@gmail.com>
