### PR TITLE
ar71xx: migrate Arduino Yùn from legacy.mk to generic.mk

### DIFF
--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -790,6 +790,19 @@ define Device/bhr-4grv2
 endef
 TARGET_DEVICES += bhr-4grv2
 
+define Device/yun
+  DEVICE_TITLE := Arduino Yun
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-storage kmod-spi-gpio kmod-serial-8250 kmod-ath9k
+  BOARDNAME := Yun
+  KERNEL_SIZE = 1280k
+  IMAGE_SIZE = 16000k
+  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,14656k(rootfs),1280k(kernel),64k(nvram),64k(art)ro,15936k@0x50000(firmware)
+  IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  CONSOLE := ttyATH0,250000
+endef
+
+TARGET_DEVICES += yun
+
 define Device/wpj342
   DEVICE_TITLE := Compex WPJ342 (16MB flash)
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -790,19 +790,6 @@ define Device/bhr-4grv2
 endef
 TARGET_DEVICES += bhr-4grv2
 
-define Device/yun
-  DEVICE_TITLE := Arduino Yun
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-storage kmod-spi-gpio kmod-serial-8250 kmod-ath9k
-  BOARDNAME := Yun
-  KERNEL_SIZE = 1280k
-  IMAGE_SIZE = 16000k
-  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,14656k(rootfs),1280k(kernel),64k(nvram),64k(art)ro,15936k@0x50000(firmware)
-  IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
-  CONSOLE := ttyATH0,250000
-endef
-
-TARGET_DEVICES += yun
-
 define Device/wpj342
   DEVICE_TITLE := Compex WPJ342 (16MB flash)
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport
@@ -847,6 +834,15 @@ define Device/wpj563
   IMAGE_SIZE := 16128k
 endef
 TARGET_DEVICES += wpj563
+
+define Device/yun-16m
+  BOARDNAME := Yun
+  DEVICE_TITLE := Arduino Yun (16MB flash)
+  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,15936k(firmware),64k(nvram)ro,64k(art)ro
+  CONSOLE = ttyATH0,250000
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += yun-16m
 
 define Device/zbt-we1526
   DEVICE_TITLE := Zbtlink ZBT-WE1526

--- a/target/linux/ar71xx/image/legacy-devices.mk
+++ b/target/linux/ar71xx/image/legacy-devices.mk
@@ -178,6 +178,12 @@ define LegacyDevice/WRTNODE2Q
 endef
 LEGACY_DEVICES += WRTNODE2Q
 
+define LegacyDevice/YUN_8M
+  DEVICE_TITLE := Arduino Yun based on Atheros AR9331 (8MB flash)
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2
+endef
+LEGACY_DEVICES += YUN_8M
+
 define LegacyDevice/F9K1115V2
   DEVICE_TITLE := Belkin AC1750DB (F9K1115V2)
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb3 kmod-usb-ledtrig-usbport \

--- a/target/linux/ar71xx/image/legacy-devices.mk
+++ b/target/linux/ar71xx/image/legacy-devices.mk
@@ -178,18 +178,6 @@ define LegacyDevice/WRTNODE2Q
 endef
 LEGACY_DEVICES += WRTNODE2Q
 
-define LegacyDevice/YUN_8M
-  DEVICE_TITLE := Arduino Yun based on Atheros AR9331 (8MB flash)
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2
-endef
-LEGACY_DEVICES += YUN_8M
-
-define LegacyDevice/YUN_16M
-  DEVICE_TITLE := Arduino Yun based on Atheros AR9331 (16MB flash)
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2
-endef
-LEGACY_DEVICES += YUN_16M
-
 define LegacyDevice/F9K1115V2
   DEVICE_TITLE := Belkin AC1750DB (F9K1115V2)
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb3 kmod-usb-ledtrig-usbport \

--- a/target/linux/ar71xx/image/legacy.mk
+++ b/target/linux/ar71xx/image/legacy.mk
@@ -281,6 +281,7 @@ wndr4300_mtdlayout=mtdparts=ar934x-nfc:256k(u-boot)ro,256k(u-boot-env)ro,256k(ca
 zcn1523h_mtdlayout=mtdparts=spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,6208k(rootfs),1472k(kernel),64k(configure)ro,64k(mfg)ro,64k(art)ro,7680k@0x50000(firmware)
 mynet_rext_mtdlayout=mtdparts=spi0.0:256k(u-boot)ro,7808k(firmware),64k(nvram)ro,64k(ART)ro
 zyx_nbg6716_mtdlayout=mtdparts=spi0.0:256k(u-boot)ro,64k(env)ro,64k(RFdata)ro,-(nbu);ar934x-nfc:2048k(zyxel_rfsd),2048k(romd),1024k(header),2048k(kernel),-(ubi)
+yun_mtdlayout_8M=mtdparts=spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,6464k(rootfs),1280k(kernel),64k(nvram),64k(art)ro,7744k@0x50000(firmware)
 wrtnode2q_mtdlayout=mtdparts=spi0.0:192k(u-boot)ro,64k(u-boot-env),64k(art)ro,1472k(kernel),14592k(rootfs),16064k@0x50000(firmware),16384k@0x0(fullflash)
 
 define Image/BuildKernel
@@ -905,6 +906,7 @@ $(eval $(call SingleProfile,AthLzma,64k,TUBE2H16M,tube2h-16M,TUBE2H,ttyATH0,1152
 $(eval $(call SingleProfile,AthLzma,64k,WLR8100,wlr8100,WLR8100,ttyS0,115200,$$(wlr8100_mtdlayout),KRuImage))
 $(eval $(call SingleProfile,AthLzma,64k,DR344,dr344,DR344,ttyS0,115200,$$(dr344_mtdlayout),RKuImage))
 $(eval $(call SingleProfile,AthLzma,64k,WRTNODE2Q,wrtnode2q,WRTNODE2Q,ttyS0,115200,$$(wrtnode2q_mtdlayout),KRuImage))
+$(eval $(call SingleProfile,AthLzma,64k,YUN_8M,yun-8M,Yun,ttyATH0,250000,$$(yun_mtdlayout_8M),RKuImage))
 
 $(eval $(call SingleProfile,Belkin,64k,F9K1115V2,f9k1115v2,F9K1115V2,ttyS0,115200,$$(f9k1115v2_mtdlayout),BR-6679BAC))
 

--- a/target/linux/ar71xx/image/legacy.mk
+++ b/target/linux/ar71xx/image/legacy.mk
@@ -281,8 +281,6 @@ wndr4300_mtdlayout=mtdparts=ar934x-nfc:256k(u-boot)ro,256k(u-boot-env)ro,256k(ca
 zcn1523h_mtdlayout=mtdparts=spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,6208k(rootfs),1472k(kernel),64k(configure)ro,64k(mfg)ro,64k(art)ro,7680k@0x50000(firmware)
 mynet_rext_mtdlayout=mtdparts=spi0.0:256k(u-boot)ro,7808k(firmware),64k(nvram)ro,64k(ART)ro
 zyx_nbg6716_mtdlayout=mtdparts=spi0.0:256k(u-boot)ro,64k(env)ro,64k(RFdata)ro,-(nbu);ar934x-nfc:2048k(zyxel_rfsd),2048k(romd),1024k(header),2048k(kernel),-(ubi)
-yun_mtdlayout_8M=mtdparts=spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,6464k(rootfs),1280k(kernel),64k(nvram),64k(art)ro,7744k@0x50000(firmware)
-yun_mtdlayout_16M=mtdparts=spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,14656k(rootfs),1280k(kernel),64k(nvram),64k(art)ro,15936k@0x50000(firmware)
 wrtnode2q_mtdlayout=mtdparts=spi0.0:192k(u-boot)ro,64k(u-boot-env),64k(art)ro,1472k(kernel),14592k(rootfs),16064k@0x50000(firmware),16384k@0x0(fullflash)
 
 define Image/BuildKernel
@@ -907,8 +905,6 @@ $(eval $(call SingleProfile,AthLzma,64k,TUBE2H16M,tube2h-16M,TUBE2H,ttyATH0,1152
 $(eval $(call SingleProfile,AthLzma,64k,WLR8100,wlr8100,WLR8100,ttyS0,115200,$$(wlr8100_mtdlayout),KRuImage))
 $(eval $(call SingleProfile,AthLzma,64k,DR344,dr344,DR344,ttyS0,115200,$$(dr344_mtdlayout),RKuImage))
 $(eval $(call SingleProfile,AthLzma,64k,WRTNODE2Q,wrtnode2q,WRTNODE2Q,ttyS0,115200,$$(wrtnode2q_mtdlayout),KRuImage))
-$(eval $(call SingleProfile,AthLzma,64k,YUN_8M,yun-8M,Yun,ttyATH0,250000,$$(yun_mtdlayout_8M),RKuImage))
-$(eval $(call SingleProfile,AthLzma,64k,YUN_16M,yun-16M,Yun,ttyATH0,250000,$$(yun_mtdlayout_16M),RKuImage))
 
 $(eval $(call SingleProfile,Belkin,64k,F9K1115V2,f9k1115v2,F9K1115V2,ttyS0,115200,$$(f9k1115v2_mtdlayout),BR-6679BAC))
 


### PR DESCRIPTION
Migrate Arduino Yùn data from ar71xx/image/legacy.mk to ar71xx/image/generik.mk
Dismiss the 8MB version of Arduino Yùn which was only uses during its development.

Signed-off-by: Camille Bilodeau <camille.bilodeau@protonmail.com>