### PR TITLE
dropbear: runtime limit maximum authentication attempts

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2017.75
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \

--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2017.75
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
@@ -77,7 +77,7 @@ CONFIGURE_ARGS += \
 	--disable-zlib \
 	--enable-bundled-libtom
 
-TARGET_CFLAGS += -DARGTYPE=3 -ffunction-sections -fdata-sections
+TARGET_CFLAGS += -DARGTYPE=3 -DDEFAULT_AUTH_TRIES=3 -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections
 
 define Build/Configure

--- a/package/network/services/dropbear/patches/010-runtime-maxauthtries.patch
+++ b/package/network/services/dropbear/patches/010-runtime-maxauthtries.patch
@@ -1,0 +1,130 @@
+From 46b22e57d91e33a591d0fba97da52672af4d6ed2 Mon Sep 17 00:00:00 2001
+From: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
+Date: Mon, 29 May 2017 10:25:09 +0100
+Subject: [PATCH] dropbear server: support -T max auth tries
+
+Add support for '-T n' for a run-time specification for maximum number
+of authentication attempts where 'n' is between 1 and compile time
+option MAX_AUTH_TRIES.
+
+A default number of tries can be specified at compile time using
+'DEFAULT_AUTH_TRIES' which itself defaults to MAX_AUTH_TRIES for
+backwards compatibility.
+
+Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
+---
+ options.h     |  7 +++++++
+ runopts.h     |  1 +
+ svr-auth.c    |  2 +-
+ svr-runopts.c | 17 +++++++++++++++++
+ 4 files changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/options.h b/options.h
+index 0c51bb1..4d22704 100644
+--- a/options.h
++++ b/options.h
+@@ -284,6 +284,13 @@ Homedir is prepended unless path begins with / */
+ #define MAX_AUTH_TRIES 10
+ #endif
+ 
++/* Default maximum number of failed authentication tries.
++ * defaults to MAX_AUTH_TRIES */
++
++#ifndef DEFAULT_AUTH_TRIES
++#define DEFAULT_AUTH_TRIES MAX_AUTH_TRIES
++#endif
++
+ /* The default file to store the daemon's process ID, for shutdown
+    scripts etc. This can be overridden with the -P flag */
+ #ifndef DROPBEAR_PIDFILE
+diff --git a/runopts.h b/runopts.h
+index f7c869d..2f7da63 100644
+--- a/runopts.h
++++ b/runopts.h
+@@ -96,6 +96,7 @@ typedef struct svr_runopts {
+ 	int noauthpass;
+ 	int norootpass;
+ 	int allowblankpass;
++	unsigned int maxauthtries;
+ 
+ #ifdef ENABLE_SVR_REMOTETCPFWD
+ 	int noremotetcp;
+diff --git a/svr-auth.c b/svr-auth.c
+index 577ea88..6a7ce0b 100644
+--- a/svr-auth.c
++++ b/svr-auth.c
+@@ -362,7 +362,7 @@ void send_msg_userauth_failure(int partial, int incrfail) {
+ 		ses.authstate.failcount++;
+ 	}
+ 
+-	if (ses.authstate.failcount >= MAX_AUTH_TRIES) {
++	if (ses.authstate.failcount >= svr_opts.maxauthtries) {
+ 		char * userstr;
+ 		/* XXX - send disconnect ? */
+ 		TRACE(("Max auth tries reached, exiting"))
+diff --git a/svr-runopts.c b/svr-runopts.c
+index 8f60059..1e7440f 100644
+--- a/svr-runopts.c
++++ b/svr-runopts.c
+@@ -73,6 +73,7 @@ static void printhelp(const char * progname) {
+ 					"-g		Disable password logins for root\n"
+ 					"-B		Allow blank password logins\n"
+ #endif
++					"-T <1 to %d> 	Maximum authentication tries (default %d)\n"
+ #ifdef ENABLE_SVR_LOCALTCPFWD
+ 					"-j		Disable local port forwarding\n"
+ #endif
+@@ -106,6 +107,7 @@ static void printhelp(const char * progname) {
+ #ifdef DROPBEAR_ECDSA
+ 					ECDSA_PRIV_FILENAME,
+ #endif
++					MAX_AUTH_TRIES, DEFAULT_AUTH_TRIES,
+ 					DROPBEAR_MAX_PORTS, DROPBEAR_DEFPORT, DROPBEAR_PIDFILE,
+ 					DEFAULT_RECV_WINDOW, DEFAULT_KEEPALIVE, DEFAULT_IDLE_TIMEOUT);
+ }
+@@ -118,6 +120,7 @@ void svr_getopts(int argc, char ** argv) {
+ 	char* recv_window_arg = NULL;
+ 	char* keepalive_arg = NULL;
+ 	char* idle_timeout_arg = NULL;
++	char* maxauthtries_arg = NULL;
+ 	char* keyfile = NULL;
+ 	char c;
+ 
+@@ -130,6 +133,7 @@ void svr_getopts(int argc, char ** argv) {
+ 	svr_opts.noauthpass = 0;
+ 	svr_opts.norootpass = 0;
+ 	svr_opts.allowblankpass = 0;
++	svr_opts.maxauthtries = DEFAULT_AUTH_TRIES;
+ 	svr_opts.inetdmode = 0;
+ 	svr_opts.portcount = 0;
+ 	svr_opts.hostkey = NULL;
+@@ -234,6 +238,9 @@ void svr_getopts(int argc, char ** argv) {
+ 				case 'I':
+ 					next = &idle_timeout_arg;
+ 					break;
++				case 'T':
++					next = &maxauthtries_arg;
++					break;
+ #if defined(ENABLE_SVR_PASSWORD_AUTH) || defined(ENABLE_SVR_PAM_AUTH)
+ 				case 's':
+ 					svr_opts.noauthpass = 1;
+@@ -330,6 +337,16 @@ void svr_getopts(int argc, char ** argv) {
+ 			dropbear_exit("Bad recv window '%s'", recv_window_arg);
+ 		}
+ 	}
++
++	if (maxauthtries_arg) {
++		unsigned int val = 0;
++		if (m_str_to_uint(maxauthtries_arg, &val) == DROPBEAR_FAILURE ||
++			val == 0 || val > MAX_AUTH_TRIES) {
++			dropbear_exit("Bad maxauthtries '%s'", maxauthtries_arg);
++		}
++		svr_opts.maxauthtries = val;
++	}
++
+ 	
+ 	if (keepalive_arg) {
+ 		unsigned int val;
+-- 
+2.7.4
+

--- a/package/network/services/dropbear/patches/610-skip-default-keys-in-custom-runs.patch
+++ b/package/network/services/dropbear/patches/610-skip-default-keys-in-custom-runs.patch
@@ -1,6 +1,6 @@
 --- a/svr-runopts.c
 +++ b/svr-runopts.c
-@@ -488,6 +488,7 @@ void load_all_hostkeys() {
+@@ -505,6 +505,7 @@ void load_all_hostkeys() {
  		m_free(hostkey_file);
  	}
  
@@ -8,7 +8,7 @@
  #ifdef DROPBEAR_RSA
  	loadhostkey(RSA_PRIV_FILENAME, 0);
  #endif
-@@ -499,6 +500,7 @@ void load_all_hostkeys() {
+@@ -516,6 +517,7 @@ void load_all_hostkeys() {
  #ifdef DROPBEAR_ECDSA
  	loadhostkey(ECDSA_PRIV_FILENAME, 0);
  #endif


### PR DESCRIPTION
Two patches here:  First introduces a new '-T' runtime option to limit the maximum number of authentication attempts per connection.  This defaults to a new compile time option DEFAULT_AUTH_TRIES which itself defaults to compile time MAX_AUTH_TRIES for backwards compatibility.   This patch has been submitted upstream.

The next patch takes makes use of the DEFAULT_AUTH_TRIES compile time option and sets it to 3.

These patches lay the groundwork necessary for implementing a uci/luci interface for run time setting of maximum authentication attempts per connection.
