### PR TITLE
toolchain/gcc: fix --with-isl path

### DIFF
--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -91,9 +91,9 @@ ifdef CONFIG_INSTALL_GCCGO
 endif
 
 ifdef CONFIG_GCC_USE_GRAPHITE
-  GRAPHITE_CONFIGURE=--with-isl=$(HOST_BUILD_PREFIX)
+  GRAPHITE_CONFIGURE:= --with-isl=$(TOPDIR)/staging_dir/host
 else
-  GRAPHITE_CONFIGURE=--without-isl --without-cloog
+  GRAPHITE_CONFIGURE:= --without-isl --without-cloog
 endif
 
 GCC_CONFIGURE:= \


### PR DESCRIPTION
This fixes GCC 7 compilation when GRAPHITE is selected.
The path is replaced with $(TOOLCHAIN_DIR), while it should be
$(STAGING_DIR_HOST). To keep in sync with the path of gmp,
mpfr and mpc, I'm using $(TOPDIR)/staging_dir/host.

Fixes: https://github.com/lede-project/source/commit/f62f4b3c5c9d059a2e6a1e80ce7b4267ef0c236b

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>