### PR TITLE
libs/lzo: Reenable unaligned access on ARM, PPC, ...

### DIFF
--- a/package/libs/lzo/Makefile
+++ b/package/libs/lzo/Makefile
@@ -45,10 +45,6 @@ endef
 TARGET_CFLAGS += $(FPIC)
 MAKE_FLAGS += CFLAGS_O="$(TARGET_CFLAGS)"
 
-ifeq ($(CONFIG_i386)$(CONFIG_x86_64),)
-  TARGET_CFLAGS += -DLZO_CFG_NO_UNALIGNED=1
-endif
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/lzo $(1)/usr/include/


### PR DESCRIPTION
Due a compiler bug
 ( https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64516 )
unaligned access was disabled on targets other than i386 and x86_64.

A fix has been added to lzo-2.09 so it is not necessary to disable
unaligned access within the Makefile anymore.