### PR TITLE
FB3370: fix hotplug script for ath9k eeprom extraction

### DIFF
--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -60,6 +60,14 @@ ath9k_eeprom_extract() {
 	ath9k_eeprom_extract_raw $mtd $offset $swap
 }
 
+fb3370_eeprom_fix()
+{
+    for offs in `seq 0 1089`; do
+	let in_offs=4091-$offs
+	dd if=/lib/firmware/$FIRMWARE of=/lib/firmware/$FIRMWARE_ORIG conv=notrunc bs=1 count=1 seek=$offs skip=$in_offs 2> /dev/null
+    done
+}
+
 ath9k_ubi_eeprom_extract() {
 	local part=$1
 	local offset=$2
@@ -138,7 +146,13 @@ case "$FIRMWARE" in
 				ath9k_eeprom_extract "calibration" 61440 0
 				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot-env ethaddr) +2) 524
 				;;
-			FRITZ3370|FRITZ7320|FRITZ7360SL)
+			FRITZ3370)
+				FIRMWARE_ORIG=$FIRMWARE
+				FIRMWARE=${FIRMWARE}.avm
+				ath9k_eeprom_extract "urlader" 2437 0
+				fb3370_eeprom_fix
+				;;
+			FRITZ7320|FRITZ7360SL)
 				ath9k_eeprom_extract "urlader" 2437 0
 				;;
 			TDW8970|TDW8980)


### PR DESCRIPTION
Currently, on FB3370 board, the script correctly extracts the eeprom 
from AVM EVA boot partition and it saves it as it is.

This is the format that the stock AVM firmware ath9k driver expects
(in fact /dev/wlan_eeprom1 in original AVM firmware is populated
with the same contents). On the other hand this is not the format
the in-kernel ath9k driver expects. In particular eeprom contents
are reversed (not byte-swapped, they are stored upside-down, from
last byte to the beginning).

This seems true for both a FB3370 "internation edition" and a
FB3370 for German market.

This patch makes the hotplug script still extract the verbatim
eeprom data, saving it as in a file with '.avm' suffix (e.g.
ath9k-eeprom-pci-0000:01:00.0.bin.avm) and then it fixes the eeprom
format generating the regular eeprom file e.g.
ath9k-eeprom-pci-0000:01:00.0.bin

There are a lot of hints that let me guess that this ends up in
the correct eeprom format.

- The customer data is now meaningful ("AVM3370_CAL1_V2") and
  consistent to the dmesg prints spitted out by the AVM firmware on
  boot:
  [   31.480000][1] [wlan_eeprom] Calibration data blocks found = 1
  [   31.490000][1] [wlan_eeprom] EEPROM #1, type "AR93xx/AR95xx":
  [   31.490000][1] [wlan_eeprom] Customer data="AVM3370_CAL1_V2"
  [   31.490000][1] [wlan_eeprom] Build with ART2 2.23

- The MAC address is right

- The TX and RX masks are consistent with my 3-antennas device
  (both 0b00000111)

- calFreqPier2G array contains values that are reasonable (ch 1,6,13)
  and following calibration data values have similar values on each
  chain. The same is true also for 5G calibration data.

- Some values in the 2G calibration data are equal or very close to
  those in the 5G calibration area.

  2G:
   Ant. Common Control : 0x00000110
  Ant. Common Control2 : 0x00022222
             Ant. Gain :          0
         Switch Settle :         44
            Volt Slope :          0
         txEndToXpaOff :          1
           txEndToRxOn :          2
        XPA Bias Level :          0
    txFrameToDataStart :         14
         txFrameToPaOn :         14
        txFrameToXpaOn :         14
                txClip :          3
      ADC Desired Size :        -30
              Thresh62 :         28

  5G:
   Ant. Common Control : 0x00000110
  Ant. Common Control2 : 0x00022222
             Ant. Gain :          0
         Switch Settle :         45
            Volt Slope :         15
         txEndToXpaOff :          0
           txEndToRxOn :          2
        XPA Bias Level :          0
    txFrameToDataStart :         14
         txFrameToPaOn :         14
        txFrameToXpaOn :         14
                txClip :          3
      ADC Desired Size :        -30
              Thresh62 :         28

- Some values are similar to values in other dumps found on the
  internet [1]

    Write Enable GPIO :          6
    WLAN Disable GPIO :          0
        WLAN LED GPIO :          8
  Rx Band Select GPIO :        255

[1] https://wikidevi.com/wiki/Foxconn_U98Z081.00_(HP)

Signed-off-by: Andrea Merello <andrea.merello@gmail.com>

