### PR TITLE
dnsmasq: make dhcp-script configurable

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -832,7 +832,8 @@ dnsmasq_start()
 	config_get_bool readethers "$cfg" readethers
 	[ "$readethers" = "1" -a \! -e "/etc/ethers" ] && touch /etc/ethers
 
-	xappend "--dhcp-script=$DHCPSCRIPT"
+	config_get_bool enable_dhcpscript "$cfg" enable_dhcpscript 0
+	[ "$enable_dhcpscript" -gt 0 ] && xappend "--dhcp-script=$DHCPSCRIPT"
 	config_get user_dhcpscript $cfg dhcpscript
 
 	config_get leasefile $cfg leasefile "/tmp/dhcp.leases"


### PR DESCRIPTION
make latest dhcp-script commit (b32689afd6a661339861086c669e15c936293cf8) configurable with new option "enable_dhcpscript", disabled by default to save resources.

Signed-off-by: Dirk Brenken <dev@brenken.org>
