### PR TITLE
ath10k & qca99xx & ipq806x: fix OTP calibration

### DIFF
--- a/package/firmware/ath10k-firmware/Makefile
+++ b/package/firmware/ath10k-firmware/Makefile
@@ -319,9 +319,6 @@ endef
 
 define Package/ath10k-firmware-qca9984/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9984/hw1.0
-	ln -s \
-		../../cal-pci-0000:01:00.0.bin \
-		$(1)/lib/firmware/ath10k/QCA9984/hw1.0/board.bin
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/QCA9984/hw1.0/board-2.bin \
 		$(1)/lib/firmware/ath10k/QCA9984/hw1.0/board-2.bin
@@ -332,9 +329,6 @@ endef
 
 define Package/ath10k-firmware-qca9984-ct/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9984/hw1.0
-	ln -s \
-		../../cal-pci-0000:01:00.0.bin \
-		$(1)/lib/firmware/ath10k/QCA9984/hw1.0/board.bin
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/QCA9984/hw1.0/board-2.bin \
 		$(1)/lib/firmware/ath10k/QCA9984/hw1.0/board-2.bin

--- a/package/kernel/mac80211/patches/012-increase-bmi-timeout.patch
+++ b/package/kernel/mac80211/patches/012-increase-bmi-timeout.patch
@@ -1,0 +1,38 @@
+From 13c3b26a71dfed57152ccfdb8fb5fb29584ded7c Mon Sep 17 00:00:00 2001
+From: Ben Greear <greearb@candelatech.com>
+Date: Wed, 31 May 2017 14:21:19 +0300
+Subject: ath10k: increase BMI timeout
+
+When testing a 9888 chipset NIC, I notice it often takes
+almost 2 seconds, and then many times OTP fails, probably due
+to the two-second timeout.
+
+[ 2269.841842] ath10k_pci 0000:05:00.0: bmi cmd took: 1984 jiffies (HZ: 1000), rv: 0
+[ 2273.608185] ath10k_pci 0000:05:00.0: bmi cmd took: 1986 jiffies (HZ: 1000), rv: 0
+[ 2277.294732] ath10k_pci 0000:05:00.0: bmi cmd took: 1989 jiffies (HZ: 1000), rv: 0
+
+So, increase the BMI timeout to 3 seconds.
+
+Signed-off-by: Ben Greear <greearb@candelatech.com>
+Signed-off-by: Kalle Valo <kvalo@qca.qualcomm.com>
+---
+ drivers/net/wireless/ath/ath10k/bmi.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/bmi.h b/drivers/net/wireless/ath/ath10k/bmi.h
+index 0342073..ff97e0e 100644
+--- a/drivers/net/wireless/ath/ath10k/bmi.h
++++ b/drivers/net/wireless/ath/ath10k/bmi.h
+@@ -188,8 +188,8 @@ struct bmi_target_info {
+ 	u32 type;
+ };
+ 
+-/* in msec */
+-#define BMI_COMMUNICATION_TIMEOUT_HZ (2 * HZ)
++/* in jiffies */
++#define BMI_COMMUNICATION_TIMEOUT_HZ (3 * HZ)
+ 
+ #define BMI_CE_NUM_TO_TARG 0
+ #define BMI_CE_NUM_TO_HOST 1
+-- 
+cgit v1.1

--- a/package/kernel/mac80211/patches/013-log-when-longer-bmi-cmds-happen.patch
+++ b/package/kernel/mac80211/patches/013-log-when-longer-bmi-cmds-happen.patch
@@ -1,0 +1,81 @@
+From 6bb099b088c70f76b5f34672a83d4452b1e3af36 Mon Sep 17 00:00:00 2001
+From: Ben Greear <greearb@candelatech.com>
+Date: Wed, 31 May 2017 14:21:21 +0300
+Subject: ath10k: log when longer bmi cmds happen
+
+This lets one have a clue that maybe timeouts are happening
+when we just aren't waiting long enough.
+
+Signed-off-by: Ben Greear <greearb@candelatech.com>
+Signed-off-by: Kalle Valo <kvalo@qca.qualcomm.com>
+---
+ drivers/net/wireless/ath/ath10k/pci.c | 27 +++++++++++++++++++++------
+ 1 file changed, 21 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/pci.c b/drivers/net/wireless/ath/ath10k/pci.c
+index 1e9806f..4f3f513 100644
+--- a/drivers/net/wireless/ath/ath10k/pci.c
++++ b/drivers/net/wireless/ath/ath10k/pci.c
+@@ -101,7 +101,8 @@ static int ath10k_pci_init_irq(struct ath10k *ar);
+ static int ath10k_pci_deinit_irq(struct ath10k *ar);
+ static int ath10k_pci_request_irq(struct ath10k *ar);
+ static void ath10k_pci_free_irq(struct ath10k *ar);
+-static int ath10k_pci_bmi_wait(struct ath10k_ce_pipe *tx_pipe,
++static int ath10k_pci_bmi_wait(struct ath10k *ar,
++			       struct ath10k_ce_pipe *tx_pipe,
+ 			       struct ath10k_ce_pipe *rx_pipe,
+ 			       struct bmi_xfer *xfer);
+ static int ath10k_pci_qca99x0_chip_reset(struct ath10k *ar);
+@@ -1846,7 +1847,7 @@ int ath10k_pci_hif_exchange_bmi_msg(struct ath10k *ar,
+ 	if (ret)
+ 		goto err_resp;
+ 
+-	ret = ath10k_pci_bmi_wait(ce_tx, ce_rx, &xfer);
++	ret = ath10k_pci_bmi_wait(ar, ce_tx, ce_rx, &xfer);
+ 	if (ret) {
+ 		u32 unused_buffer;
+ 		unsigned int unused_nbytes;
+@@ -1913,23 +1914,37 @@ static void ath10k_pci_bmi_recv_data(struct ath10k_ce_pipe *ce_state)
+ 	xfer->rx_done = true;
+ }
+ 
+-static int ath10k_pci_bmi_wait(struct ath10k_ce_pipe *tx_pipe,
++static int ath10k_pci_bmi_wait(struct ath10k *ar,
++			       struct ath10k_ce_pipe *tx_pipe,
+ 			       struct ath10k_ce_pipe *rx_pipe,
+ 			       struct bmi_xfer *xfer)
+ {
+ 	unsigned long timeout = jiffies + BMI_COMMUNICATION_TIMEOUT_HZ;
++	unsigned long started = jiffies;
++	unsigned long dur;
++	int ret;
+ 
+ 	while (time_before_eq(jiffies, timeout)) {
+ 		ath10k_pci_bmi_send_done(tx_pipe);
+ 		ath10k_pci_bmi_recv_data(rx_pipe);
+ 
+-		if (xfer->tx_done && (xfer->rx_done == xfer->wait_for_resp))
+-			return 0;
++		if (xfer->tx_done && (xfer->rx_done == xfer->wait_for_resp)) {
++			ret = 0;
++			goto out;
++		}
+ 
+ 		schedule();
+ 	}
+ 
+-	return -ETIMEDOUT;
++	ret = -ETIMEDOUT;
++
++out:
++	dur = jiffies - started;
++	if (dur > HZ)
++		ath10k_dbg(ar, ATH10K_DBG_BMI,
++			   "bmi cmd took %lu jiffies hz %d ret %d\n",
++			   dur, HZ, ret);
++	return ret;
+ }
+ 
+ /*
+-- 
+cgit v1.1

--- a/package/kernel/mac80211/patches/014-add-BMI-parameters-to-fix-calibration-from-DT-pre-cal.patch
+++ b/package/kernel/mac80211/patches/014-add-BMI-parameters-to-fix-calibration-from-DT-pre-cal.patch
@@ -1,0 +1,89 @@
+From a9f5f287fa1d47d61dfa8b60f94831174b2ea4d0 Mon Sep 17 00:00:00 2001
+From: Anilkumar Kolli <akolli@qti.qualcomm.com>
+Date: Wed, 31 May 2017 14:21:27 +0300
+Subject: ath10k: add BMI parameters to fix calibration from DT/pre-cal
+
+QCA99X0, QCA9888, QCA9984 supports calibration data in
+either OTP or DT/pre-cal file. Current ath10k supports
+Calibration data from OTP only.
+
+If caldata is loaded from DT/pre-cal file, fetching board id
+and applying calibration parameters like tx power gets failed.
+
+error log:
+[   15.733663] ath10k_pci 0000:01:00.0: failed to fetch board file: -2
+[   15.741474] ath10k_pci 0000:01:00.0: could not probe fw (-2)
+
+This patch adds calibration data support from DT/pre-cal
+file.  Below parameters are used to get board id and
+applying calibration parameters from cal data.
+
+		EEPROM[OTP]	FLASH[DT/pre-cal file]
+Cal param	0x700		0x10000
+Board id	0x10		0x8000
+
+Tested on QCA9888 with pre-cal file.
+
+Signed-off-by: Anilkumar Kolli <akolli@qti.qualcomm.com>
+Signed-off-by: Kalle Valo <kvalo@qca.qualcomm.com>
+---
+ drivers/net/wireless/ath/ath10k/bmi.h  |  2 ++
+ drivers/net/wireless/ath/ath10k/core.c | 16 +++++++++++++---
+ 2 files changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/bmi.h b/drivers/net/wireless/ath/ath10k/bmi.h
+index ff97e0e..9c0839b 100644
+--- a/drivers/net/wireless/ath/ath10k/bmi.h
++++ b/drivers/net/wireless/ath/ath10k/bmi.h
+@@ -83,6 +83,8 @@ enum bmi_cmd_id {
+ #define BMI_NVRAM_SEG_NAME_SZ 16
+ 
+ #define BMI_PARAM_GET_EEPROM_BOARD_ID 0x10
++#define BMI_PARAM_GET_FLASH_BOARD_ID 0x8000
++#define BMI_PARAM_FLASH_SECTION_ALL 0x10000
+ 
+ #define ATH10K_BMI_BOARD_ID_FROM_OTP_MASK   0x7c00
+ #define ATH10K_BMI_BOARD_ID_FROM_OTP_LSB    10
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index eea111d..ce79a2e 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -691,7 +691,7 @@ static int ath10k_core_get_board_id_from_otp(struct ath10k *ar)
+ {
+ 	u32 result, address;
+ 	u8 board_id, chip_id;
+-	int ret;
++	int ret, bmi_board_id_param;
+ 
+ 	address = ar->hw_params.patch_load_addr;
+ 
+@@ -715,8 +715,13 @@ static int ath10k_core_get_board_id_from_otp(struct ath10k *ar)
+ 		return ret;
+ 	}
+ 
+-	ret = ath10k_bmi_execute(ar, address, BMI_PARAM_GET_EEPROM_BOARD_ID,
+-				 &result);
++	if (ar->cal_mode == ATH10K_PRE_CAL_MODE_DT ||
++	    ar->cal_mode == ATH10K_PRE_CAL_MODE_FILE)
++		bmi_board_id_param = BMI_PARAM_GET_FLASH_BOARD_ID;
++	else
++		bmi_board_id_param = BMI_PARAM_GET_EEPROM_BOARD_ID;
++
++	ret = ath10k_bmi_execute(ar, address, bmi_board_id_param, &result);
+ 	if (ret) {
+ 		ath10k_err(ar, "could not execute otp for board id check: %d\n",
+ 			   ret);
+@@ -845,6 +850,11 @@ static int ath10k_download_and_run_otp(struct ath10k *ar)
+ 		return ret;
+ 	}
+ 
++	/* As of now pre-cal is valid for 10_4 variants */
++	if (ar->cal_mode == ATH10K_PRE_CAL_MODE_DT ||
++	    ar->cal_mode == ATH10K_PRE_CAL_MODE_FILE)
++		bmi_otp_exe_param = BMI_PARAM_FLASH_SECTION_ALL;
++
+ 	ret = ath10k_bmi_execute(ar, address, bmi_otp_exe_param, &result);
+ 	if (ret) {
+ 		ath10k_err(ar, "could not execute otp (%d)\n", ret);
+-- 
+cgit v1.1

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -61,7 +61,7 @@ case "$FIRMWARE" in
 	esac
 	;;
 
-"ath10k/cal-pci-0000:01:00.0.bin")
+"ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case $board in
 	c2600)
 		ath10kcal_extract "radio" 4096 12064
@@ -84,7 +84,7 @@ case "$FIRMWARE" in
 		;;
 	esac
 	;;
-"ath10k/cal-pci-0001:01:00.0.bin")
+"ath10k/pre-cal-pci-0001:01:00.0.bin")
 	case $board in
 	c2600)
 		ath10kcal_extract "radio" 20480 12064


### PR DESCRIPTION
With this PR we are increasing ath10k bmi commands timeout (upstream patches backported), so boards where it takes longer could initialize OTP properly.

And as of now OTP is being correctly parsed so the driver requires to parse pre-caldata to follow corresponding routine.

Rename cal file into pre-calfile for ipq806x so the board is initialized correctly with API 2 board data (board-2.bin).

Also remove the now unneeded for qca9984 board.bin symlink to 5GHz calfile.
@nbd168 

@mkresin I suppose now we can try patching MAC address again, could you pass that xor patch please?

@chunkeey @hnyman @heinzek 