### PR TITLE
samba36: reduce logical interface name expansion

### DIFF
--- a/package/network/services/samba36/Makefile
+++ b/package/network/services/samba36/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=3.6.25
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_URL:=https://download.samba.org/pub/samba \
 		https://download.samba.org/pub/samba/stable

--- a/package/network/services/samba36/files/samba.init
+++ b/package/network/services/samba36/files/samba.init
@@ -15,11 +15,7 @@ smb_header() {
 		for net in $samba_iface; do
 			local device
 			network_is_up $net || continue
-			network_get_device device "$net" && {
-				local subnet
-				network_get_subnet  subnet "$net" && echo -n "$subnet "
-				network_get_subnet6 subnet "$net" && echo -n "$subnet "
-			}
+			network_get_device device "$net"
 
 			echo -n "${device:-$net} "
 		done


### PR DESCRIPTION
The startup script expands logical 'interface' names (loopback lan) into
physical interface and CIDR pairs, e.g. "eth0 192.168.1.1/24".  Samba is
quite capable of determining an interface's address itself, e.g. "eth0"
is worked out as "192.168.1.1/24" and a listener is started on that
interface as determined by 'netstat -anp'

The startup script interface expansion exposes a bug in
lib/functions/network.sh network_get_subnet6 - namely that it doesn't
work, hence samba never saw any ipv6 interfaces.

This change removes the unnecessary 'CIDR' expansion simply expanding
out 'logical' interfaces to 'physical' interfaces.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
