### PR TITLE
ar71xx: wpj344: fix MAC address/disable eth1

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -526,6 +526,9 @@ ar71xx_setup_macs()
 	mynet-n750)
 		wan_mac=$(mtd_get_mac_ascii devdata "wanmac")
 		;;
+	wpj344)
+		wan_mac=$(mtd_get_mac_binary u-boot 0x2e018)
+		;;
 	esac
 
 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-wpj344.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-wpj344.c
@@ -48,8 +48,8 @@
 #define WPJ344_KEYS_POLL_INTERVAL	20	/* msecs */
 #define WPJ344_KEYS_DEBOUNCE_INTERVAL	(3 * WPJ344_KEYS_POLL_INTERVAL)
 
-#define WPJ344_MAC0_OFFSET		0
-#define WPJ344_MAC1_OFFSET		6
+#define WPJ344_MAC0_OFFSET		0x10
+#define WPJ344_MAC1_OFFSET		0x18
 #define WPJ344_WMAC_CALDATA_OFFSET	0x1000
 #define WPJ344_PCIE_CALDATA_OFFSET	0x5000
 
@@ -132,6 +132,7 @@ static struct mdio_board_info wpj344_mdio0_info[] = {
 static void __init wpj344_setup(void)
 {
 	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
+	u8 *mac = (u8 *) KSEG1ADDR(0x1f02e000);
 
 	ath79_register_m25p80(NULL);
 	ath79_register_leds_gpio(-1, ARRAY_SIZE(wpj344_leds_gpio),
@@ -152,8 +153,8 @@ static void __init wpj344_setup(void)
 	ath79_register_mdio(1, 0x0);
 	ath79_register_mdio(0, 0x0);
 
-	ath79_init_mac(ath79_eth0_data.mac_addr, art + WPJ344_MAC0_OFFSET, 0);
-	ath79_init_mac(ath79_eth1_data.mac_addr, art + WPJ344_MAC1_OFFSET, 0);
+	ath79_init_mac(ath79_eth0_data.mac_addr, mac + WPJ344_MAC0_OFFSET, 0);
+	ath79_init_mac(ath79_eth1_data.mac_addr, mac + WPJ344_MAC1_OFFSET, 0);
 
 	ath79_setup_ar934x_eth_cfg(AR934X_ETH_CFG_RGMII_GMAC0 |
 				   AR934X_ETH_CFG_SW_ONLY_MODE);

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-wpj344.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-wpj344.c
@@ -150,11 +150,9 @@ static void __init wpj344_setup(void)
 	mdiobus_register_board_info(wpj344_mdio0_info,
 					ARRAY_SIZE(wpj344_mdio0_info));
 
-	ath79_register_mdio(1, 0x0);
 	ath79_register_mdio(0, 0x0);
 
 	ath79_init_mac(ath79_eth0_data.mac_addr, mac + WPJ344_MAC0_OFFSET, 0);
-	ath79_init_mac(ath79_eth1_data.mac_addr, mac + WPJ344_MAC1_OFFSET, 0);
 
 	ath79_setup_ar934x_eth_cfg(AR934X_ETH_CFG_RGMII_GMAC0 |
 				   AR934X_ETH_CFG_SW_ONLY_MODE);
@@ -165,13 +163,7 @@ static void __init wpj344_setup(void)
 	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
 	ath79_eth0_pll_data.pll_1000 = 0x06000000;
 
-	/* GMAC1 is connected to the internal switch */
-	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
-	ath79_eth1_data.speed = SPEED_1000;
-	ath79_eth1_data.duplex = DUPLEX_FULL;
-
 	ath79_register_eth(0);
-	ath79_register_eth(1);
 }
 
 MIPS_MACHINE(ATH79_MACH_WPJ344, "WPJ344", "Compex WPJ344", wpj344_setup);


### PR DESCRIPTION
This way, the assigned addresses match those on the barcode labels.
Otherwise, the addresses appear to vary on boot.
```
0002e010  04 f0 21 1a 32 0e 12 1e  04 f0 21 1a 32 0f 30 30  |..!.2.....!.2.00|
0002e020  04 f0 21 1a 32 10 ec 81  04 f0 21 1a 32 11 15 c0  |..!.2.....!.2...|
```

without patch:
```
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether 8e:12:da:a3:a2:45 brd ff:ff:ff:ff:ff:ff
3: eth1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether 1e:b4:09:7c:98:71 brd ff:ff:ff:ff:ff:ff
```
