### PR TITLE
ramips: add support for TRENDnet TEW-638APB V2

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -276,6 +276,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "8@eth0"
 		;;
+	tew-638apb-v2)
+		ucidef_add_switch "switch0" \
+			"4:lan" "6@eth0"
+		;;
 	tew-691gr|\
 	tew-692gr|\
 	wlr-6000)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -212,6 +212,7 @@ get_status_led() {
 		;;
 	mzk-ex300np|\
 	rt-n10-plus|\
+	tew-638apb-v2|\
 	tew-691gr|\
 	tew-692gr|\
 	ur-326n4g|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -472,6 +472,9 @@ ramips_board_detect() {
 	*"SL-R7205"*)
 		name="sl-r7205"
 		;;
+	*"TEW-638APB v2")
+		name="tew-638apb-v2"
+		;;
 	*"TEW-691GR")
 		name="tew-691gr"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -139,6 +139,7 @@ platform_check_image() {
 	sap-g3200u3|\
 	sk-wb8|\
 	sl-r7205|\
+	tew-638apb-v2|\
 	tew-691gr|\
 	tew-692gr|\
 	tew-714tru|\

--- a/target/linux/ramips/dts/TEW-638APB-V2.dts
+++ b/target/linux/ramips/dts/TEW-638APB-V2.dts
@@ -1,0 +1,97 @@
+/dts-v1/;
+
+#include "rt3050.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "TEW-638APB-V2", "ralink,rt3050-soc";
+	model = "TRENDnet TEW-638APB v2";
+
+	cfi@1f000000 {
+		compatible = "cfi-flash";
+		reg = <0x1f000000 0x400000>;
+		bank-width = <2>;
+		device-width = <2>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x3b0000>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "tew-638apb-v2:orange:wps";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wps2 {
+			label = "tew-638apb-v2:green:wps";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -651,6 +651,16 @@ define Device/sl-r7205
 endef
 TARGET_DEVICES += sl-r7205
 
+define Device/tew-638apb-v2
+  DTS := TEW-638APB-V2
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE/sysupgrade.bin := $$(sysupgrade_bin) | umedia-header 0x026382 | \
+        append-metadata | check-size $$$$(IMAGE_SIZE)
+  DEVICE_TITLE := TRENDnet TEW-638APB v2
+endef
+TARGET_DEVICES += tew-638apb-v2
+
 define Device/tew-714tru
   DTS := TEW-714TRU
   DEVICE_TITLE := TRENDnet TEW-714TRU


### PR DESCRIPTION
This patch add support for the TRENDnet TEW-638APB V2.

Specification:
- SoC: Ralink SoC RT3052F
- Flash: 4MB
- RAM: 32MB
- Ethernet: 1x LAN (100 Mbps)
- Wireless: 2.4GHz b/g/n, 2x external antenna
- Buttons: 1x Reset, 1x WPS
- LEDs: Power (green), Ethernet (green), WPS (green and orange),
Wireless (green)
- UART: 1x UART on PCB (3.3V, GND, RX, TX) - 57600 8N1

Doesn't work:
* sysupgrade.bin (Only factory.bin boot propertly. U-boot checks board-id)

Installation

via vendor firmware:
- upload factory.bin image

via TFTP:
- stop uboot into tftp-load into option "2"
- upload factory.bin image

Signed-off-by: Pavlo Samko <bulldozerbsg@gmail.com>

