### PR TITLE
bcm53xx: add basic support for Phicomm K3

### DIFF
--- a/target/linux/bcm53xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm53xx/base-files/etc/board.d/02_network
@@ -24,6 +24,12 @@ buffalo,wzr-1750dhp)
 	board_config_flush
 	exit 0
 	;;
+phicomm,k3)
+	ucidef_add_switch "switch0" \
+		"0:lan:2" "1:lan:1" "2:lan:3" "3:wan:4" "5t@eth0"
+	board_config_flush
+	exit 0
+	;;
 esac
 
 wan_macaddr="$(nvram get wan_hwaddr)"

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -248,6 +248,13 @@ define Device/linksys-ea9500
 endef
 # TARGET_DEVICES += linksys-ea9500
 
+define Device/phicomm-k3
+  DEVICE_TITLE := Phicomm K3
+  DEVICE_PACKAGES := $(BRCMFMAC_4366C0) $(USB3_PACKAGES)
+  IMAGES := trx
+endef
+TARGET_DEVICES += phicomm-k3
+
 define Device/netgear
   IMAGES := chk
   IMAGE/chk := append-ubi | trx-nand | netgear-chk

--- a/target/linux/bcm53xx/patches-4.9/033-0022-ARM-dts-BCM5301X-Add-basic-DT-for-Phicomm-K3.patch
+++ b/target/linux/bcm53xx/patches-4.9/033-0022-ARM-dts-BCM5301X-Add-basic-DT-for-Phicomm-K3.patch
@@ -1,0 +1,79 @@
+From bf793950827142bc464eb2fd4059e1db24cc3517 Mon Sep 17 00:00:00 2001
+From: Tian Hao <haotia@gmail.com>
+Date: Sun, 2 Apr 2017 00:03:40 +0800
+Subject: [PATCH] ARM: dts: BCM5301X: Add basic DT for PHICOMM K3
+
+This router has BCM4709C0, 128MB NAND flash (MX30LF1G18AC-TI),
+and 512MB memory, with 3 x LAN and 1 x WAN. WL chips are
+BCM4366C0 x 2. The router has a small LCD and 3 capactive keys
+driven by a PIC microcontroller, which is in turn wired to
+UART1 of main board.
+
+Everything except the LCD and wireless works.
+
+Signed-Off-By: Tian Hao <haotia@gmail.com>
+---
+ arch/arm/boot/dts/Makefile                |  1 +
+ arch/arm/boot/dts/bcm47094-phicomm-k3.dts | 34 +++++++++++++++++++++++++++++++
+ 2 files changed, 35 insertions(+)
+ create mode 100644 arch/arm/boot/dts/bcm47094-phicomm-k3.dts
+
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index 0f2e27a0..a5237028 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -95,6 +95,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm4709-tplink-archer-c9-v1.dtb \
+ 	bcm47094-dlink-dir-885l.dtb \
+ 	bcm47094-linksys-panamera.dtb \
++	bcm47094-phicomm-k3.dtb \
+ 	bcm47094-luxul-xwr-3100.dtb \
+ 	bcm47094-netgear-r8500.dtb \
+ 	bcm94708.dtb \
+diff --git a/arch/arm/boot/dts/bcm47094-phicomm-k3.dts b/arch/arm/boot/dts/bcm47094-phicomm-k3.dts
+new file mode 100644
+index 00000000..ec2f9b27
+--- /dev/null
++++ b/arch/arm/boot/dts/bcm47094-phicomm-k3.dts
+@@ -0,0 +1,38 @@
++/*
++ * Copyright (C) 2017 Hamster Tian <haotia@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "bcm47094.dtsi"
++#include "bcm5301x-nand-cs0-bch4.dtsi"
++
++/ {
++	compatible = "phicomm,k3", "brcm,bcm47094", "brcm,bcm4708";
++	model = "PHICOMM K3";
++
++	chosen {
++		bootargs = "console=ttyS0,115200";
++	};
++
++	memory {
++		reg = <0x00000000 0x08000000
++		       0x88000000 0x18000000>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		restart {
++			label = "Reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&chipcommon 17 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&uart1 {
++	status = "okay";
++};
+--
+2.11.0
+

--- a/target/linux/bcm53xx/patches-4.9/901-mtd-bcm47xxpart-add-partition-workaround-for-Phicomm-K3.patch
+++ b/target/linux/bcm53xx/patches-4.9/901-mtd-bcm47xxpart-add-partition-workaround-for-Phicomm-K3.patch
@@ -1,0 +1,32 @@
+From 60ef93a073b06876b06fb40b08663ad33895a3d3 Mon Sep 17 00:00:00 2001
+From: Tian Hao <haotia@gmail.com>
+Date: Sun, 2 Apr 2017 00:09:10 +0800
+Subject: [PATCH] mtd: bcm47xxpart: add partition workaround for PHICOMM K3
+
+Signed-off-by: Tian Hao <haotia@gmail.com>
+---
+ drivers/mtd/bcm47xxpart.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/mtd/bcm47xxpart.c b/drivers/mtd/bcm47xxpart.c
+index e796a804..64c6858f 100644
+--- a/drivers/mtd/bcm47xxpart.c
++++ b/drivers/mtd/bcm47xxpart.c
+@@ -270,6 +270,14 @@ static int bcm47xxpart_parse(struct mtd_info *master,
+ 			 */
+ 			bcm47xxpart_add_part(&parts[curr_part++], "tplink", offset, MTD_WRITEABLE);
+ 			continue;
++		} else if (of_machine_is_compatible("phicomm,k3") && offset == 0x180000) {
++			/*
++			* This device has nvram_back, res_info, pro_info and dev_info from
++			* 0x180000 (end of nvram) to 0x400000 (start of linux). These partitions
++			* has essential information for original firwamre. We do not want these.
++			*/
++			bcm47xxpart_add_part(&parts[curr_part++], "phicomm", offset, MTD_WRITEABLE);
++			continue;
+ 		}
+
+ 		/* Read beginning of the block */
+--
+2.11.0
+


### PR DESCRIPTION
Phicomm K3 is a very popular router device in China, and many K3 users want to use LEDE system.
Some information about Phicomm K3
[http://jacobjensendesign.com/case/phicomm](http://jacobjensendesign.com/case/phicomm)


Hardware specifications:

CPU: Broadcom BCM4709C0 @1.4GHz (Dual-Core ARM)
RAM: 512 MB (DDR3)
Flash: 128 MB (NAND)
LAN ports: 3, LAN speed: 10/100/1000
WAN ports: 1, WAN speed: 10/100/1000
2.4G: BCM4366 4x4 MIMO 1000Mbps --  Skyworks SE2623L 2.4GHz Power Amplifier (x4)
5G: BCM4366 4x4 MIMO 2167Mbps -- RFMD RFPA5542 5GHz Power Amplifier Module (x4)
USB: 1x USB 3.0 port
1x LED, 1x reset button, 1x power switch
1x system status touch screen

The following URL can view the disassemble picture:
[http://www.acwifi.net/1243.html](http://www.acwifi.net/1243.html)
