### PR TITLE
hostapd: add support for chanlist option

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -66,6 +66,8 @@ hostapd_common_add_device_config() {
 	config_add_string require_mode
 	config_add_boolean legacy_rates
 
+	config_add_string chanlist
+
 	hostapd_add_log_config
 }
 
@@ -76,7 +78,7 @@ hostapd_prepare_device_config() {
 	local base="${config%%.conf}"
 	local base_cfg=
 
-	json_get_vars country country_ie beacon_int:100 doth require_mode legacy_rates
+	json_get_vars country country_ie beacon_int:100 doth require_mode legacy_rates chanlist
 
 	hostapd_set_log_options base_cfg
 
@@ -92,6 +94,8 @@ hostapd_prepare_device_config() {
 		[ "$country_ie" -gt 0 ] && append base_cfg "ieee80211d=1" "$N"
 		[ "$hwmode" = "a" -a "$doth" -gt 0 ] && append base_cfg "ieee80211h=1" "$N"
 	}
+	
+	[ -n "$chanlist" ] && append base_cfg "chanlist=$chanlist" "$N"
 
 	local brlist= br
 	json_get_values basic_rate_list basic_rate


### PR DESCRIPTION
Add support for the hostapd chanlist option to the wireless configuration file.

The chanlist option is necessary to restrict the auto selection of the wlan channel to defined subset.

Signed-off-by: Daniel Albers <daniel.albers@public-files.de>