### PR TITLE
scripts/dl_cleanup.py: add support for version format xxx-v1.2.3

### DIFF
--- a/scripts/dl_cleanup.py
+++ b/scripts/dl_cleanup.py
@@ -93,6 +93,7 @@ versionRegex = (
 	(re.compile(r"(.+)[-_](\d\d\d\d)-?(\d\d)-?(\d\d)"), parseVer_ymd),	# xxx-YYYY-MM-DD
 	(re.compile(r"(.+)[-_]([0-9a-fA-F]{40,40})"), parseVer_GIT),		# xxx-GIT_SHASUM
 	(re.compile(r"(.+)[-_](\d+)\.(\d+)\.(\d+)(\w?)"), parseVer_123),	# xxx-1.2.3a
+	(re.compile(r"(.+)[-_]v(\d+)\.(\d+)\.(\d+)"), parseVer_123),		# xxx-v1.2.3
 	(re.compile(r"(.+)[-_](\d+)_(\d+)_(\d+)"), parseVer_123),		# xxx-1_2_3
 	(re.compile(r"(.+)[-_](\d+)\.(\d+)(\w?)"), parseVer_12),		# xxx-1.2a
 	(re.compile(r"(.+)[-_]r?(\d+)"), parseVer_r),				# xxx-r1111


### PR DESCRIPTION
dl_cleanup.py: add support for version format xxx-v1.2.3 which is used for example by btrfs-progs

Signed-off-by: Daniel Albers <daniel.albers@public-files.de>