### PR TITLE
Netgear DM200 port

### DIFF
--- a/target/linux/lantiq/dts/DM200.dts
+++ b/target/linux/lantiq/dts/DM200.dts
@@ -1,0 +1,11 @@
+/dts-v1/;
+
+#include "EASY220.dtsi"
+
+/ {
+	model = "Netgear DM200";
+
+	chosen {
+		bootargs = "root=/dev/mtdblock4 ro rootfstype=squashfs,jffs2 mem=62M vpe1_load_addr=0x83e00000 vpe1_mem=2M maxvpes=1 maxtcs=1 nosmp";
+	};
+};

--- a/target/linux/lantiq/dts/EASY220.dtsi
+++ b/target/linux/lantiq/dts/EASY220.dtsi
@@ -1,0 +1,295 @@
+#include "vr9.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+
+	compatible = "lantiq,xway", "lantiq,vr9", "lantiq,xrx220";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &power_g;
+		led-failsafe = &power_a;
+		led-running = &power_g;
+
+		led-dsl = &dsl;
+		led-internet = &lan_g;
+	};
+
+	memory@0 {
+		reg = <0x0 0x3f00000>;
+	};
+
+	ltq_swreset {
+		compatible = "lantiq,ltq_swreset";
+		swreset_pin = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		swreset_bit = <1>;
+		status = "ok";
+	};
+
+	gphy-xrx200 {
+		compatible = "lantiq,phy-xrx200";
+		firmware = "lantiq/vr9_phy22f_a2x.bin";
+		phys = [ 00 01 ];
+	};
+
+//	gpio-keys-polled {
+//		compatible = "gpio-keys-polled";
+//		#address-cells = <1>;
+//		#size-cells = <0>;
+//		poll-interval = <100>;
+/*		reset {
+			label = "reset";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+			linux,code = <0x198>;
+		};*/
+//	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power_a: power_amber {
+			label = "power_amber";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+		power_g: power_green {
+			label = "power_green";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+		lan_amber {
+			label = "lan_amber";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+		lan_g: lan_green {
+			label = "lan_green";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+		dsl_amber {
+			label = "dsl_amber";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+		dsl: dsl_green {
+			label = "dsl_green";
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		mdio {
+			lantiq,groups = "mdio";
+			lantiq,function = "mdio";
+		};
+		phy-rst {
+			lantiq,pins = "io42";
+			lantiq,pull = <0>;
+			lantiq,open-drain = <0>;
+			lantiq,output = <1>;
+		};
+		exin {
+			lantiq,groups = "exin3";
+			lantiq,function = "exin";
+		};
+		/*stp {
+			lantiq,groups = "stp";
+			lantiq,function = "stp";
+		};*/
+		/*nand {
+			lantiq,groups = "nand cle", "nand ale",
+					"nand rd", "nand rdy";
+			lantiq,function = "ebu";
+		};*/
+		/*pci {
+			lantiq,groups = "gnt1", "req1";
+			lantiq,function = "pci";
+		};*/
+		/*led {
+			lantiq,groups = "led";
+			lantiq,function = "led";
+		};*/
+		conf_in {
+			lantiq,pins = "io39"; /* exin3 */
+			lantiq,pull = <2>;
+		};
+		conf_out {
+			lantiq,pins =  // "io21", "io38", /* pcie */
+//					"io12", "io15", /* annexa, annexb */
+					"io0", "io1", "io8", "io11", "io33", "io36"; /* led io34, io35 */
+			lantiq,open-drain = <0>;
+			lantiq,pull = <0>;
+			lantiq,output = <1>;
+		};
+	};
+	pins_spi_default: pins_spi_default {
+		spi_in {
+			lantiq,groups = "spi_di";
+			lantiq,function = "spi";
+		};
+		spi_out {
+			lantiq,groups = "spi_do", "spi_clk", "spi_cs4";
+			lantiq,function = "spi";
+			lantiq,output = <1>;
+		};
+	};
+};
+
+&spi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pins_spi_default>;
+
+	status = "ok";
+
+	m25p80@4 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "winbond,w25q64", "jedec,spi-nor";
+		reg = <4 0>;
+		linux,modalias = "m25p80", "w25q64";
+		linux,mtd-name = "ltq_sflash";
+		spi-max-frequency = <10000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x20000>;
+				label = "uboot";
+				read-only;
+			};
+
+			partition@20000 {
+				reg = <0x20000 0x10000>;
+				label = "gphyfirmware";
+				read-only;
+			};
+
+			partition@30000 {
+				reg = <0x30000 0x190000>;
+				label = "kernel";
+				read-only;
+			};
+
+			partition@1c0000 {
+				reg = <0x1c0000 0x80000>;
+				label = "firmware";
+				read-only;
+			};
+
+			partition@240000 {
+				reg = <0x240000 0x500000>;
+				label = "rootfs";
+				read-only;
+			};
+
+			partition@imgalias {
+				reg = <0x30000 0x710000>;
+				label = "image";
+				read-only;
+			};
+
+			partition@0x740000 {
+				reg = <0x740000 0x10000>;
+				label = "dniconfig";
+				read-only;
+			};
+
+			partition@0x750000 {
+				reg = <0x750000 0x10000>;
+				label = "log";
+				read-only;
+			};
+
+			partition@0x760000 {
+				reg = <0x760000 0x80000>;
+				label = "language";
+				read-only;
+			};
+
+			partition@0x7e0000 {
+				reg = <0x7e0000 0x10000>;
+				label = "sysconfig";
+				read-only;
+			};
+
+			partition@0x7f0000 {
+				reg = <0x7f0000 0x2000>;
+				label = "ubootconfig";
+				read-only;
+			};
+
+			partition@0x7f2000 {
+				reg = <0x7f2000 0x1000>;
+				label = "ART";
+				read-only;
+			};
+
+			partition@0x7f3000 {
+				reg = <0x7f3000 0x1000>;
+				label = "pot";
+				read-only;
+			};
+
+			partition@0x7f4000 {
+				reg = <0x7f4000 0xc000>;
+				label = "ret";
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "disabled";
+};
+
+&eth0 {
+//	interrupts = <73 72 95 96>;
+
+	lan: interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+//		reg = <2>;
+		mtd-mac-address = [ 00 11 22 33 44 55 ];
+//		mtd-mac-address = [ 00 11 22 33 44 57 ];
+//		mtd-mac-address = <&romfile 0xf100>;
+		lantiq,switch;
+
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phynmode0 = "gmii";
+			phy-handle = <&phy13>;
+		};
+	};
+
+	mdio@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
+		};
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -512,6 +512,9 @@ define Device/BTHOMEHUBV5A
 endef
 TARGET_DEVICES += BTHOMEHUBV5A
 
+# Netgear DM200
+include netgear.mk
+
 define Device/EASY80920NAND
   $(Device/lantiqFullImage)
   IMAGE_SIZE := 64512k

--- a/target/linux/lantiq/image/netgear.mk
+++ b/target/linux/lantiq/image/netgear.mk
@@ -10,10 +10,18 @@ include $(INCLUDE_DIR)/image.mk
 
 DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_REGION NETGEAR_HW_ID
 
+define Build/append-hdr-rootfs
+  mkimage -A mips -O linux -C lzma -T filesystem -a 0x00 -e 0x00 \
+          -n 'LEDE RootFS' \
+          -d $(IMAGE_ROOTFS) $@.tmp
+  cat $@.tmp >> $@
+  rm $@.tmp
+endef
+
 define Device/lantiqNetgear
-  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | pad-offset 4 0
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | pad-offset 4 0 | pad-to 2162624
   IMAGES := sysupgrade.bin factory.img
-  IMAGE/default := append-kernel | append-rootfs | pad-rootfs | append-metadata
+  IMAGE/default := append-kernel | append-hdr-rootfs | pad-rootfs | append-metadata
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
 endef

--- a/target/linux/lantiq/image/netgear.mk
+++ b/target/linux/lantiq/image/netgear.mk
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2017 LEDE & Edward O'Callaghan
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/image.mk
+
+DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_REGION NETGEAR_HW_ID
+
+define Device/lantiqNetgear
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | pad-offset 4 0
+  IMAGES := sysupgrade.bin factory.img
+  IMAGE/default := append-kernel | append-rootfs | pad-rootfs | append-metadata
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
+endef
+
+define Device/DM200
+  $(Device/lantiqNetgear)
+  DEVICE_TITLE := Netgear DM200
+  DEVICE_PACKAGES := kmod-spi-lantiq-ssc
+
+  NETGEAR_BOARD_ID := DM200
+  NETGEAR_HW_ID := 29765233+8+0+64+0+0
+  IMAGE_SIZE := 8192k
+endef
+TARGET_DEVICES += DM200


### PR DESCRIPTION
Hi,

The following patches add support for the Netgear DM200 ADSL2/VDSL2 modem. Essentially everything works, ENJOY! :)

Cheers,
Edward.