### PR TITLE
[RFC] package/base-files: force sysupgrade file location to tmp

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -247,6 +247,12 @@ else
 	rm -f /tmp/sysupgrade.always.overwrite.bootdisk.partmap
 fi
 
+IMAGE_FILE=$(readlink -f ${ARGV})
+if [ "${IMAGE_FILE:1:3}" != "tmp" ]; then
+	echo "Image file must be flashed with absolute path from '/tmp' folder"
+	exit 1
+fi
+
 run_hooks "" $sysupgrade_pre_upgrade
 
 install_bin /sbin/upgraded


### PR DESCRIPTION
If the `sysupgrade` is started with a file which is not located in the RAM a sysupgrade will brick the device.
Force user to start a `sysupgrade` with a file which is located in the `/tmp` folder