### PR TITLE
rpcd: delay brute force attacks on login failure

### DIFF
--- a/package/system/rpcd/patches/0001-delay-brute-force-attacks.patch
+++ b/package/system/rpcd/patches/0001-delay-brute-force-attacks.patch
@@ -1,0 +1,10 @@
+--- a/session.c
++++ b/session.c
+@@ -1115,6 +1115,7 @@ rpc_handle_login(struct ubus_context *ct
+ 	                                  blobmsg_get_string(tb[RPC_L_PASSWORD]));
+ 
+ 	if (!login) {
++		sleep(3);
+ 		rv = UBUS_STATUS_PERMISSION_DENIED;
+ 		goto out;
+ 	}


### PR DESCRIPTION
delay rpcd session brute force attacks by 3 second
