### PR TITLE
lantiq: add Netgear DM200 support

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/base-files/etc/board.d/01_leds
@@ -50,6 +50,9 @@ ARV7519RW22)
 BTHOMEHUBV5A)
 	ucidef_set_led_default "dimmed" "dimmed" "dimmed" "0"
 	;;
+DM200)
+	ucidef_set_led_netdev "lan" "lan" "dm200:green:lan" "eth0"
+	;;
 FRITZ7320)
 	ucidef_set_led_netdev "wifi" "wifi" "fritz7320:green:wlan" "wlan0"
 	;;

--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -100,6 +100,12 @@ DGN3500*)
 		"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5t@eth0"
 	;;
 
+DM200)
+	lan_mac=$(mtd_get_mac_binary ART 0)
+	wan_mac=$(macaddr_add "$lan_mac" 1)
+	ucidef_set_interface_lan 'eth0'
+	;;
+
 EASY80920NAND|EASY80920NOR)
 	lan_mac=$(mtd_get_mac_ascii uboot_env ethaddr)
 	wan_mac=$(macaddr_add "$lan_mac" 1)

--- a/target/linux/lantiq/dts/DM200.dts
+++ b/target/linux/lantiq/dts/DM200.dts
@@ -1,0 +1,204 @@
+/dts-v1/;
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "DM200 - Netgear DM200";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_amber;
+		led-running = &power_green;
+
+		led-dsl = &dsl_green;
+	};
+
+	memory@0 {
+		reg = <0x0 0x4000000>;
+	};
+
+	fpi@10000000 {
+		gpio: pinmux@E100B10 {
+			pinctrl-names = "default";
+			pinctrl-0 = <&state_default>;
+
+			state_default: pinmux {
+				mdio {
+					lantiq,groups = "mdio";
+					lantiq,function = "mdio";
+				};
+				conf_out {
+					lantiq,pins = "io12", "io15";  // annexa, annexb
+					lantiq,open-drain;
+					lantiq,pull = <0>;
+					lantiq,output = <1>;
+				};
+			};
+
+			pins_spi_default: pins_spi_default {
+				spi_in {
+					lantiq,groups = "spi_di";
+					lantiq,function = "spi";
+				};
+				spi_out {
+					lantiq,groups = "spi_do", "spi_clk", "spi_cs4";
+					lantiq,function = "spi";
+					lantiq,output = <1>;
+				};
+			};
+		};
+
+		pcie@d900000 {
+			status = "disabled";
+		};
+	};
+
+	gphy-xrx200 {
+		compatible = "lantiq,phy-xrx200";
+		firmware = "lantiq/vr9_phy11g_a2x.bin";
+		phys = [ 01 ];
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <100>;
+		reset {
+			label = "reset";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power_amber: power_amber {
+			label = "dm200:amber:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+		power_green: power_green {
+			label = "dm200:green:power";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan_amber {
+			label = "dm200:amber:lan";
+			gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
+		};
+		lan_green {
+			label = "dm200:green:lan";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		dsl_amber {
+			label = "dm200:amber:dsl";
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		};
+		dsl_green: dsl_green {
+			label = "dm200:green:dsl";
+			gpios = <&gpio 36 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pins_spi_default>;
+
+	status = "ok";
+
+	m25p80@4 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <4 0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x20000>;
+				label = "uboot";
+				read-only;
+			};
+
+			partition@20000 {
+				reg = <0x20000 0x10000>;
+				label = "gphyfirmware";
+				read-only;
+			};
+
+			partition@30000 {
+				reg = <0x30000 0x7b0000>;
+				label = "firmware";
+			};
+
+			partition@7e0000 {
+				reg = <0x7e0000 0x10000>;
+				label = "sysconfig";
+				read-only;
+			};
+
+			partition@7f0000 {
+				reg = <0x7f0000 0x2000>;
+				label = "ubootconfig";
+				read-only;
+			};
+
+			partition@7f2000 {
+				reg = <0x7f2000 0x1000>;
+				label = "ART";
+				read-only;
+			};
+
+			partition@7f3000 {
+				reg = <0x7f3000 0x1000>;
+				label = "pot";
+				read-only;
+			};
+
+			partition@7f4000 {
+				reg = <0x7f4000 0xc000>;
+				label = "ret";
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	lan: interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phynmode0 = "gmii";
+			phy-handle = <&phy13>;
+		};
+	};
+
+	mdio@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -513,6 +513,17 @@ define Device/BTHOMEHUBV5A
 endef
 TARGET_DEVICES += BTHOMEHUBV5A
 
+define Device/DM200
+  IMAGES := sysupgrade.bin factory.img
+  IMAGE/factory.img := $$(IMAGE/sysupgrade.bin) | netgear-dni
+  IMAGE_SIZE := 7872k
+  DEVICE_TITLE := Netgear DM200
+  NETGEAR_BOARD_ID := DM200
+  NETGEAR_HW_ID := 29765233+8+0+64+0+0
+endef
+DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
+TARGET_DEVICES += DM200
+
 define Device/EASY80920NAND
   $(Device/lantiqFullImage)
   IMAGE_SIZE := 64512k


### PR DESCRIPTION
Add support for Netgear DM200; see commit for details.

This was prompted by #1163; I believe this patch addresses all the issues raised in that PR, though of course there may be additional issues spotted. Sorry for not submitting this sooner...

As mentioned in #1163, I have had issues with the flash chip on my device, which has made it hard to test. It seems to run fine, though, so I don't expect any issues.

Thanks,

Tom