### PR TITLE
dnsmasq: add dhcp-range tags configuration

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.77
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -440,6 +440,7 @@ dhcp_add() {
 	local cfg="$1"
 	local dhcp6range="::"
 	local nettag
+	local tags
 
 	config_get net "$cfg" interface
 	[ -n "$net" ] || return 0
@@ -491,6 +492,12 @@ dhcp_add() {
 	dhcp_this_host_add "$net" "$ifname" "$ADD_LOCAL_FQDN"
 
 	start="$( dhcp_calc "$start" )"
+
+	add_tag() {
+		tags="${tags}tag:$1,"
+	}
+	config_list_foreach "$cfg" tag add_tag
+
 	nettag="${networkid:+set:${networkid},}"
 
 	if [ "$limit" -gt 0 ] ; then
@@ -508,7 +515,7 @@ dhcp_add() {
 
 
 	if [ "$dhcpv4" != "disabled" ] ; then
-		xappend "--dhcp-range=$nettag$START,$END,$NETMASK,$leasetime${options:+ $options}"
+		xappend "--dhcp-range=$tags$nettag$START,$END,$NETMASK,$leasetime${options:+ $options}"
 	fi
 
 


### PR DESCRIPTION
dnsmasq can match tags in its dhcp-range configuration, this commit adds the option to configure it in the dhcp section

uci configuration:
```
config dhcp 'lan'
        option interface 'lan'
        list tag 'blue'
        list tag '!red'
        option start '10'
        option limit '150'
        option leasetime '12h'
```

generated dnsmasq configuration:
```
dhcp-range=tag:blue,tag:!red,set:lan,192.168.1.10,192.168.1.159,255.255.255.0,12h
```