### PR TITLE
ipq806x: usb: a portion of QSDK fixes

### DIFF
--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064.dtsi
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064.dtsi
@@ -968,7 +968,7 @@
 			ranges;
 
 			resets = <&gcc USB30_0_MASTER_RESET>;
-			reset-names = "usb30_mstr_rst";
+			reset-names = "usb30_0_mstr_rst";
 
 			status = "disabled";
 
@@ -991,6 +991,9 @@
 			clock-names = "core";
 
 			ranges;
+
+			resets = <&gcc USB30_1_MASTER_RESET>;
+			reset-names = "usb30_1_mstr_rst";
 
 			status = "disabled";
 

--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064.dtsi
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064.dtsi
@@ -967,6 +967,9 @@
 
 			ranges;
 
+			resets = <&gcc USB30_0_MASTER_RESET>;
+			reset-names = "usb30_mstr_rst";
+
 			status = "disabled";
 
 			dwc3@11000000 {

--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8065.dtsi
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8065.dtsi
@@ -75,6 +75,17 @@
 			};
 		};
 
+		ss_phy_0: phy@110f8830 {
+			rx_eq = <2>;
+			tx_deamp_3_5db = <32>;
+			mpll = <0xa0>;
+		};
+		ss_phy_1: phy@100f8830 {
+			rx_eq = <2>;
+			tx_deamp_3_5db = <32>;
+			mpll = <0xa0>;
+		};
+
 		/* Temporary fixed regulator */
 		vsdcc_fixed: vsdcc-regulator {
 			compatible = "regulator-fixed";

--- a/target/linux/ipq806x/patches-4.9/0032-phy-add-qcom-dwc3-phy.patch
+++ b/target/linux/ipq806x/patches-4.9/0032-phy-add-qcom-dwc3-phy.patch
@@ -7,8 +7,8 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 ---
  drivers/phy/Kconfig         |  12 +
  drivers/phy/Makefile        |   1 +
- drivers/phy/phy-qcom-dwc3.c | 546 ++++++++++++++++++++++++++++++++++++++++++++
- 3 files changed, 559 insertions(+)
+ drivers/phy/phy-qcom-dwc3.c | 575 ++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 588 insertions(+)
  create mode 100644 drivers/phy/phy-qcom-dwc3.c
 
 --- a/drivers/phy/Kconfig
@@ -39,7 +39,7 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +obj-$(CONFIG_PHY_QCOM_DWC3)		+= phy-qcom-dwc3.o
 --- /dev/null
 +++ b/drivers/phy/phy-qcom-dwc3.c
-@@ -0,0 +1,546 @@
+@@ -0,0 +1,575 @@
 +/* Copyright (c) 2014-2015, Code Aurora Forum. All rights reserved.
 + *
 + * This program is free software; you can redistribute it and/or modify
@@ -299,36 +299,21 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +	return ret;
 +}
 +
-+static int qcom_dwc3_phy_power_on(struct phy *phy)
++static int qcom_dwc3_hs_phy_init(struct phy *phy)
 +{
-+	int ret;
 +	struct qcom_dwc3_usb_phy *phy_dwc3 = phy_get_drvdata(phy);
++	int ret;
++	u32 val;
 +
 +	ret = clk_prepare_enable(phy_dwc3->xo_clk);
 +	if (ret)
 +		return ret;
 +
 +	ret = clk_prepare_enable(phy_dwc3->ref_clk);
-+	if (ret)
++	if (ret) {
 +		clk_disable_unprepare(phy_dwc3->xo_clk);
-+
-+	return ret;
-+}
-+
-+static int qcom_dwc3_phy_power_off(struct phy *phy)
-+{
-+	struct qcom_dwc3_usb_phy *phy_dwc3 = phy_get_drvdata(phy);
-+
-+	clk_disable_unprepare(phy_dwc3->ref_clk);
-+	clk_disable_unprepare(phy_dwc3->xo_clk);
-+
-+	return 0;
-+}
-+
-+static int qcom_dwc3_hs_phy_init(struct phy *phy)
-+{
-+	struct qcom_dwc3_usb_phy *phy_dwc3 = phy_get_drvdata(phy);
-+	u32 val;
++		return ret;
++	}
 +
 +	/*
 +	 * HSPHY Initialization: Enable UTMI clock, select 19.2MHz fsel
@@ -353,11 +338,31 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +	return 0;
 +}
 +
++static int qcom_dwc3_hs_phy_exit(struct phy *phy)
++{
++	struct qcom_dwc3_usb_phy *phy_dwc3 = phy_get_drvdata(phy);
++
++	clk_disable_unprepare(phy_dwc3->ref_clk);
++	clk_disable_unprepare(phy_dwc3->xo_clk);
++
++	return 0;
++}
++
 +static int qcom_dwc3_ss_phy_init(struct phy *phy)
 +{
 +	struct qcom_dwc3_usb_phy *phy_dwc3 = phy_get_drvdata(phy);
 +	int ret;
 +	u32 data = 0;
++
++	ret = clk_prepare_enable(phy_dwc3->xo_clk);
++	if (ret)
++		return ret;
++
++	ret = clk_prepare_enable(phy_dwc3->ref_clk);
++	if (ret) {
++		clk_disable_unprepare(phy_dwc3->xo_clk);
++		return ret;
++	}
 +
 +	/* reset phy */
 +	data = readl(phy_dwc3->base + SSUSB_PHY_CTRL_REG);
@@ -379,6 +384,30 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +
 +	data |= SSUSB_CTRL_SS_PHY_EN | SSUSB_CTRL_LANE0_PWR_PRESENT;
 +	writel(data, phy_dwc3->base + SSUSB_PHY_CTRL_REG);
++
++	/*
++	 * WORKAROUND: There is SSPHY suspend bug due to which USB enumerates
++	 * in HS mode instead of SS mode. Workaround it by asserting
++	 * LANE0.TX_ALT_BLOCK.EN_ALT_BUS to enable TX to use alt bus mode
++	 */
++	ret = qcom_dwc3_ss_read_phycreg(phy_dwc3->base, 0x102D, &data);
++	if (ret)
++		goto err_phy_trans;
++
++	data |= (1 << 7);
++	ret = qcom_dwc3_ss_write_phycreg(phy_dwc3, 0x102D, data);
++	if (ret)
++		goto err_phy_trans;
++
++	ret = qcom_dwc3_ss_read_phycreg(phy_dwc3->base, 0x1010, &data);
++	if (ret)
++		goto err_phy_trans;
++
++	data &= ~0xff0;
++	data |= 0x20;
++	ret = qcom_dwc3_ss_write_phycreg(phy_dwc3, 0x1010, data);
++	if (ret)
++		goto err_phy_trans;
 +
 +	/*
 +	 * Fix RX Equalization setting as follows
@@ -462,7 +491,10 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +	qcom_dwc3_phy_write_readback(phy_dwc3, SSUSB_PHY_CTRL_REG,
 +		SSUSB_CTRL_REF_USE_PAD, 0x0);
 +	qcom_dwc3_phy_write_readback(phy_dwc3, SSUSB_PHY_CTRL_REG,
-+		0x0, SSUSB_CTRL_TEST_POWERDOWN);
++		SSUSB_CTRL_TEST_POWERDOWN, 0x0);
++
++	clk_disable_unprepare(phy_dwc3->ref_clk);
++	clk_disable_unprepare(phy_dwc3->xo_clk);
 +
 +	return 0;
 +}
@@ -470,8 +502,7 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +static const struct qcom_dwc3_phy_drvdata qcom_dwc3_hs_drvdata = {
 +	.ops = {
 +		.init		= qcom_dwc3_hs_phy_init,
-+		.power_on	= qcom_dwc3_phy_power_on,
-+		.power_off	= qcom_dwc3_phy_power_off,
++		.exit		= qcom_dwc3_hs_phy_exit,
 +		.owner		= THIS_MODULE,
 +	},
 +	.clk_rate = 60000000,
@@ -481,8 +512,6 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +	.ops = {
 +		.init		= qcom_dwc3_ss_phy_init,
 +		.exit		= qcom_dwc3_ss_phy_exit,
-+		.power_on	= qcom_dwc3_phy_power_on,
-+		.power_off	= qcom_dwc3_phy_power_off,
 +		.owner		= THIS_MODULE,
 +	},
 +	.clk_rate = 125000000,

--- a/target/linux/ipq806x/patches-4.9/0032-phy-add-qcom-dwc3-phy.patch
+++ b/target/linux/ipq806x/patches-4.9/0032-phy-add-qcom-dwc3-phy.patch
@@ -5,10 +5,10 @@ Subject: [PATCH 32/69] phy: add qcom dwc3 phy
 
 Signed-off-by: Andy Gross <agross@codeaurora.org>
 ---
- drivers/phy/Kconfig         |  12 ++
+ drivers/phy/Kconfig         |  12 +
  drivers/phy/Makefile        |   1 +
- drivers/phy/phy-qcom-dwc3.c | 484 ++++++++++++++++++++++++++++++++++++++++++++
- 3 files changed, 497 insertions(+)
+ drivers/phy/phy-qcom-dwc3.c | 546 ++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 559 insertions(+)
  create mode 100644 drivers/phy/phy-qcom-dwc3.c
 
 --- a/drivers/phy/Kconfig
@@ -32,14 +32,14 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
  endmenu
 --- a/drivers/phy/Makefile
 +++ b/drivers/phy/Makefile
-@@ -60,3 +60,4 @@ obj-$(CONFIG_PHY_PISTACHIO_USB)		+= phy-
+@@ -60,3 +60,4 @@ obj-$(CONFIG_PHY_PISTACHIO_USB)		+= phy-pistachio-usb.o
  obj-$(CONFIG_PHY_CYGNUS_PCIE)		+= phy-bcm-cygnus-pcie.o
  obj-$(CONFIG_ARCH_TEGRA) += tegra/
  obj-$(CONFIG_PHY_NS2_PCIE)		+= phy-bcm-ns2-pcie.o
 +obj-$(CONFIG_PHY_QCOM_DWC3)		+= phy-qcom-dwc3.o
 --- /dev/null
 +++ b/drivers/phy/phy-qcom-dwc3.c
-@@ -0,0 +1,484 @@
+@@ -0,0 +1,546 @@
 +/* Copyright (c) 2014-2015, Code Aurora Forum. All rights reserved.
 + *
 + * This program is free software; you can redistribute it and/or modify
@@ -108,6 +108,33 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +#define SSPHY_CTRL_RX_OVRD_IN_HI(lane)	(0x1006 + 0x100 * lane)
 +#define SSPHY_CTRL_TX_OVRD_DRV_LO(lane)	(0x1002 + 0x100 * lane)
 +
++/* SSPHY SoC version specific values */
++#define SSPHY_RX_EQ_VALUE		4	/* Override value for rx_eq */
++#define SSPHY_TX_DEEMPH_3_5DB		23	/* Override value for transmit
++						   preemphasis */
++#define SSPHY_MPLL_VALUE		0	/* Override value for mpll */
++
++/* QSCRATCH PHY_PARAM_CTRL1 fields */
++#define PHY_PARAM_CTRL1_TX_FULL_SWING_MASK	0x07f00000u
++#define PHY_PARAM_CTRL1_TX_DEEMPH_6DB_MASK	0x000fc000u
++#define PHY_PARAM_CTRL1_TX_DEEMPH_3_5DB_MASK	0x00003f00u
++#define PHY_PARAM_CTRL1_LOS_BIAS_MASK		0x000000f8u
++
++#define PHY_PARAM_CTRL1_MASK				\
++		(PHY_PARAM_CTRL1_TX_FULL_SWING_MASK |	\
++		 PHY_PARAM_CTRL1_TX_DEEMPH_6DB_MASK |	\
++		 PHY_PARAM_CTRL1_TX_DEEMPH_3_5DB_MASK |	\
++		 PHY_PARAM_CTRL1_LOS_BIAS_MASK)
++
++#define PHY_PARAM_CTRL1_TX_FULL_SWING(x)	\
++		(((x) << 20) & PHY_PARAM_CTRL1_TX_FULL_SWING_MASK)
++#define PHY_PARAM_CTRL1_TX_DEEMPH_6DB(x)	\
++		(((x) << 14) & PHY_PARAM_CTRL1_TX_DEEMPH_6DB_MASK)
++#define PHY_PARAM_CTRL1_TX_DEEMPH_3_5DB(x)	\
++		(((x) <<  8) & PHY_PARAM_CTRL1_TX_DEEMPH_3_5DB_MASK)
++#define PHY_PARAM_CTRL1_LOS_BIAS(x)	\
++		(((x) <<  3) & PHY_PARAM_CTRL1_LOS_BIAS_MASK)
++
 +/* RX OVRD IN HI bits */
 +#define RX_OVRD_IN_HI_RX_RESET_OVRD		BIT(13)
 +#define RX_OVRD_IN_HI_RX_RX_RESET		BIT(12)
@@ -138,6 +165,9 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +	struct device		*dev;
 +	struct clk		*xo_clk;
 +	struct clk		*ref_clk;
++	u32			rx_eq;
++	u32			tx_deamp_3_5db;
++	u32			mpll;
 +};
 +
 +struct qcom_dwc3_phy_drvdata {
@@ -354,7 +384,7 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +	 * Fix RX Equalization setting as follows
 +	 * LANE0.RX_OVRD_IN_HI. RX_EQ_EN set to 0
 +	 * LANE0.RX_OVRD_IN_HI.RX_EQ_EN_OVRD set to 1
-+	 * LANE0.RX_OVRD_IN_HI.RX_EQ set to 3
++	 * LANE0.RX_OVRD_IN_HI.RX_EQ set based on SoC version
 +	 * LANE0.RX_OVRD_IN_HI.RX_EQ_OVRD set to 1
 +	 */
 +	ret = qcom_dwc3_ss_read_phycreg(phy_dwc3->base,
@@ -365,7 +395,7 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +	data &= ~RX_OVRD_IN_HI_RX_EQ_EN;
 +	data |= RX_OVRD_IN_HI_RX_EQ_EN_OVRD;
 +	data &= ~RX_OVRD_IN_HI_RX_EQ_MASK;
-+	data |= 0x3 << RX_OVRD_IN_HI_RX_EQ_SHIFT;
++	data |= phy_dwc3->rx_eq << RX_OVRD_IN_HI_RX_EQ_SHIFT;
 +	data |= RX_OVRD_IN_HI_RX_EQ_OVRD;
 +	ret = qcom_dwc3_ss_write_phycreg(phy_dwc3,
 +		SSPHY_CTRL_RX_OVRD_IN_HI(0), data);
@@ -374,8 +404,8 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +
 +	/*
 +	 * Set EQ and TX launch amplitudes as follows
-+	 * LANE0.TX_OVRD_DRV_LO.PREEMPH set to 22
-+	 * LANE0.TX_OVRD_DRV_LO.AMPLITUDE set to 127
++	 * LANE0.TX_OVRD_DRV_LO.PREEMPH set based on SoC version
++	 * LANE0.TX_OVRD_DRV_LO.AMPLITUDE set to 110
 +	 * LANE0.TX_OVRD_DRV_LO.EN set to 1.
 +	 */
 +	ret = qcom_dwc3_ss_read_phycreg(phy_dwc3->base,
@@ -384,23 +414,35 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +		goto err_phy_trans;
 +
 +	data &= ~TX_OVRD_DRV_LO_PREEMPH_MASK;
-+	data |= 0x16 << TX_OVRD_DRV_LO_PREEMPH_SHIFT;
++	data |= phy_dwc3->tx_deamp_3_5db << TX_OVRD_DRV_LO_PREEMPH_SHIFT;
 +	data &= ~TX_OVRD_DRV_LO_AMPLITUDE_MASK;
-+	data |= 0x7f;
++	data |= 0x6E;
 +	data |= TX_OVRD_DRV_LO_EN;
 +	ret = qcom_dwc3_ss_write_phycreg(phy_dwc3,
 +		SSPHY_CTRL_TX_OVRD_DRV_LO(0), data);
 +	if (ret)
 +		goto err_phy_trans;
 +
++	qcom_dwc3_ss_write_phycreg(phy_dwc3, 0x30, phy_dwc3->mpll);
++
 +	/*
 +	 * Set the QSCRATCH PHY_PARAM_CTRL1 parameters as follows
-+	 * TX_FULL_SWING [26:20] amplitude to 127
-+	 * TX_DEEMPH_3_5DB [13:8] to 22
-+	 * LOS_BIAS [2:0] to 0x5
++	 * TX_FULL_SWING [26:20] amplitude to 110
++	 * TX_DEEMPH_6DB [19:14] to 32
++	 * TX_DEEMPH_3_5DB [13:8] set based on SoC version
++	 * LOS_BIAS [7:3] to 9
 +	 */
++	data = readl(phy_dwc3->base + SSUSB_PHY_PARAM_CTRL_1);
++
++	data &= ~PHY_PARAM_CTRL1_MASK;
++
++	data |= PHY_PARAM_CTRL1_TX_FULL_SWING(0x6e) |
++		PHY_PARAM_CTRL1_TX_DEEMPH_6DB(0x20) |
++		PHY_PARAM_CTRL1_TX_DEEMPH_3_5DB(phy_dwc3->tx_deamp_3_5db) |
++		PHY_PARAM_CTRL1_LOS_BIAS(0x9);
++
 +	qcom_dwc3_phy_write_readback(phy_dwc3, SSUSB_PHY_PARAM_CTRL_1,
-+				   0x07f03f07, 0x07f01605);
++				     PHY_PARAM_CTRL1_MASK, data);
 +
 +err_phy_trans:
 +	return ret;
@@ -461,6 +503,7 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +	struct resource			*res;
 +	const struct of_device_id *match;
 +	const struct qcom_dwc3_phy_drvdata *data;
++	struct device_node *np;
 +
 +	phy_dwc3 = devm_kzalloc(&pdev->dev, sizeof(*phy_dwc3), GFP_KERNEL);
 +	if (!phy_dwc3)
@@ -488,6 +531,25 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +	if (IS_ERR(phy_dwc3->xo_clk)) {
 +		dev_dbg(phy_dwc3->dev, "cannot get TCXO clock\n");
 +		phy_dwc3->xo_clk = NULL;
++	}
++
++	/* Parse device node to probe HSIO settings */
++	np = of_node_get(pdev->dev.of_node);
++	if (!of_compat_cmp(match->compatible, "qcom,dwc3-ss-usb-phy",
++			   strlen(match->compatible))) {
++
++		if (of_property_read_u32(np, "rx_eq", &phy_dwc3->rx_eq) ||
++		    of_property_read_u32(np, "tx_deamp_3_5db",
++					 &phy_dwc3->tx_deamp_3_5db) ||
++		    of_property_read_u32(np, "mpll", &phy_dwc3->mpll)) {
++
++			dev_err(phy_dwc3->dev, "cannot get HSIO settings from device node, using default values\n");
++
++			/* Default HSIO settings */
++			phy_dwc3->rx_eq = SSPHY_RX_EQ_VALUE;
++			phy_dwc3->tx_deamp_3_5db = SSPHY_TX_DEEMPH_3_5DB;
++			phy_dwc3->mpll = SSPHY_MPLL_VALUE;
++		}
 +	}
 +
 +	generic_phy = devm_phy_create(phy_dwc3->dev, pdev->dev.of_node,

--- a/target/linux/ipq806x/patches-4.9/0032-phy-add-qcom-dwc3-phy.patch
+++ b/target/linux/ipq806x/patches-4.9/0032-phy-add-qcom-dwc3-phy.patch
@@ -39,7 +39,7 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +obj-$(CONFIG_PHY_QCOM_DWC3)		+= phy-qcom-dwc3.o
 --- /dev/null
 +++ b/drivers/phy/phy-qcom-dwc3.c
-@@ -0,0 +1,492 @@
+@@ -0,0 +1,484 @@
 +/* Copyright (c) 2014-2015, Code Aurora Forum. All rights reserved.
 + *
 + * This program is free software; you can redistribute it and/or modify
@@ -99,7 +99,7 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +
 +/* PHY_CTRL_REG */
 +#define SSUSB_CTRL_REF_USE_PAD		BIT(28)
-+#define SSUSB_CTRL_TEST_POWERDOWN	BIT(26)
++#define SSUSB_CTRL_TEST_POWERDOWN	BIT(27)
 +#define SSUSB_CTRL_LANE0_PWR_PRESENT	BIT(24)
 +#define SSUSB_CTRL_SS_PHY_EN		BIT(8)
 +#define SSUSB_CTRL_SS_PHY_RESET		BIT(7)
@@ -331,14 +331,6 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +
 +	/* reset phy */
 +	data = readl(phy_dwc3->base + SSUSB_PHY_CTRL_REG);
-+
-+       /* Test and clear SSUSB_CTRL_TEST_POWERDOWN */
-+       if (data & SSUSB_CTRL_TEST_POWERDOWN) {
-+               qcom_dwc3_phy_write_readback(phy_dwc3, SSUSB_PHY_CTRL_REG,
-+                               SSUSB_CTRL_TEST_POWERDOWN, 0x0);
-+               data = readl(phy_dwc3->base + SSUSB_PHY_CTRL_REG);
-+       }
-+
 +	writel(data | SSUSB_CTRL_SS_PHY_RESET,
 +		phy_dwc3->base + SSUSB_PHY_CTRL_REG);
 +	usleep_range(2000, 2200);
@@ -428,7 +420,7 @@ Signed-off-by: Andy Gross <agross@codeaurora.org>
 +	qcom_dwc3_phy_write_readback(phy_dwc3, SSUSB_PHY_CTRL_REG,
 +		SSUSB_CTRL_REF_USE_PAD, 0x0);
 +	qcom_dwc3_phy_write_readback(phy_dwc3, SSUSB_PHY_CTRL_REG,
-+		SSUSB_CTRL_TEST_POWERDOWN, SSUSB_CTRL_TEST_POWERDOWN);
++		0x0, SSUSB_CTRL_TEST_POWERDOWN);
 +
 +	return 0;
 +}

--- a/target/linux/ipq806x/patches-4.9/0074-ipq806x-usb-Control-USB-master-reset.patch
+++ b/target/linux/ipq806x/patches-4.9/0074-ipq806x-usb-Control-USB-master-reset.patch
@@ -11,7 +11,7 @@ Change-Id: I537dc810f6cb2a46664ee674840145066432b957
 Signed-off-by: Vasudevan Murugesan <vmuruges@codeaurora.org>
 (cherry picked from commit 4611e13580a216812f85f0801b95442d02eeb836)
 ---
- drivers/usb/dwc3/dwc3-of-simple.c | 12 ++++++++++++
+ drivers/usb/dwc3/dwc3-of-simple.c | 22 ++++++++++++++++++++++
  1 file changed, 12 insertions(+)
 
 (limited to 'drivers/usb/dwc3/dwc3-of-simple.c')
@@ -28,34 +28,45 @@ index f9e92ef..49bf556 100644
  #include <linux/of.h>
  #include <linux/of_platform.h>
  #include <linux/pm_runtime.h>
-@@ -34,6 +35,7 @@ struct dwc3_of_simple {
+@@ -34,6 +35,8 @@ struct dwc3_of_simple {
  	struct device		*dev;
  	struct clk		**clks;
  	int			num_clocks;
-+	struct reset_control	*mstr_rst;
++	struct reset_control	*mstr_rst_30_0;
++	struct reset_control	*mstr_rst_30_1;
  };
  
  static int dwc3_of_simple_probe(struct platform_device *pdev)
-@@ -89,6 +91,13 @@ static int dwc3_of_simple_probe(struct platform_device *pdev)
+@@ -89,6 +92,20 @@ static int dwc3_of_simple_probe(struct platform_device *pdev)
  		simple->clks[i] = clk;
  	}
  
-+	simple->mstr_rst = devm_reset_control_get(dev, "usb30_mstr_rst");
++	simple->mstr_rst_30_0 = devm_reset_control_get(dev, "usb30_0_mstr_rst");
 +
-+	if (!IS_ERR(simple->mstr_rst))
-+		reset_control_deassert(simple->mstr_rst);
++	if (!IS_ERR(simple->mstr_rst_30_0))
++		reset_control_deassert(simple->mstr_rst_30_0);
 +	else
-+		dev_dbg(simple->dev, "cannot get handle for master reset control\n");
++		dev_dbg(simple->dev, "cannot get handle for USB PHY 0 master reset control\n");
++
++	simple->mstr_rst_30_1 = devm_reset_control_get(dev, "usb30_1_mstr_rst");
++
++	if (!IS_ERR(simple->mstr_rst_30_1))
++		reset_control_deassert(simple->mstr_rst_30_1);
++	else
++		dev_dbg(simple->dev, "cannot get handle for USB PHY 1 master reset control\n");
 +
  	ret = of_platform_populate(np, NULL, NULL, dev);
  	if (ret) {
  		for (i = 0; i < simple->num_clocks; i++) {
-@@ -117,6 +126,9 @@ static int dwc3_of_simple_remove(struct platform_device *pdev)
+@@ -117,6 +134,12 @@ static int dwc3_of_simple_remove(struct platform_device *pdev)
  		clk_put(simple->clks[i]);
  	}
  
-+	if (!IS_ERR(simple->mstr_rst))
-+		reset_control_assert(simple->mstr_rst);
++	if (!IS_ERR(simple->mstr_rst_30_0))
++		reset_control_assert(simple->mstr_rst_30_0);
++
++	if (!IS_ERR(simple->mstr_rst_30_1))
++		reset_control_assert(simple->mstr_rst_30_1);
 +
  	of_platform_depopulate(dev);
  

--- a/target/linux/ipq806x/patches-4.9/0074-ipq806x-usb-Control-USB-master-reset.patch
+++ b/target/linux/ipq806x/patches-4.9/0074-ipq806x-usb-Control-USB-master-reset.patch
@@ -1,0 +1,64 @@
+From a86bda9f8a7965f0cedd347a9c04800eb9f41ea3 Mon Sep 17 00:00:00 2001
+From: Vasudevan Murugesan <vmuruges@codeaurora.org>
+Date: Tue, 21 Jul 2015 10:22:38 +0530
+Subject: ipq806x: usb: Control USB master reset
+
+During removal of the glue layer(dwc3-of-simple),
+USB master reset is set to active and during insertion
+it is de-activated.
+
+Change-Id: I537dc810f6cb2a46664ee674840145066432b957
+Signed-off-by: Vasudevan Murugesan <vmuruges@codeaurora.org>
+(cherry picked from commit 4611e13580a216812f85f0801b95442d02eeb836)
+---
+ drivers/usb/dwc3/dwc3-of-simple.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+(limited to 'drivers/usb/dwc3/dwc3-of-simple.c')
+
+diff --git a/drivers/usb/dwc3/dwc3-of-simple.c b/drivers/usb/dwc3/dwc3-of-simple.c
+index f9e92ef..49bf556 100644
+--- a/drivers/usb/dwc3/dwc3-of-simple.c
++++ b/drivers/usb/dwc3/dwc3-of-simple.c
+@@ -26,6 +26,7 @@
+ #include <linux/dma-mapping.h>
+ #include <linux/clk.h>
+ #include <linux/clk-provider.h>
++#include <linux/reset.h>
+ #include <linux/of.h>
+ #include <linux/of_platform.h>
+ #include <linux/pm_runtime.h>
+@@ -34,6 +35,7 @@ struct dwc3_of_simple {
+ 	struct device		*dev;
+ 	struct clk		**clks;
+ 	int			num_clocks;
++	struct reset_control	*mstr_rst;
+ };
+ 
+ static int dwc3_of_simple_probe(struct platform_device *pdev)
+@@ -89,6 +91,13 @@ static int dwc3_of_simple_probe(struct platform_device *pdev)
+ 		simple->clks[i] = clk;
+ 	}
+ 
++	simple->mstr_rst = devm_reset_control_get(dev, "usb30_mstr_rst");
++
++	if (!IS_ERR(simple->mstr_rst))
++		reset_control_deassert(simple->mstr_rst);
++	else
++		dev_dbg(simple->dev, "cannot get handle for master reset control\n");
++
+ 	ret = of_platform_populate(np, NULL, NULL, dev);
+ 	if (ret) {
+ 		for (i = 0; i < simple->num_clocks; i++) {
+@@ -117,6 +126,9 @@ static int dwc3_of_simple_remove(struct platform_device *pdev)
+ 		clk_put(simple->clks[i]);
+ 	}
+ 
++	if (!IS_ERR(simple->mstr_rst))
++		reset_control_assert(simple->mstr_rst);
++
+ 	of_platform_depopulate(dev);
+ 
+ 	pm_runtime_put_sync(dev);
+-- 
+cgit v1.1


### PR DESCRIPTION
This series of commits is based on QSDK and addresses issues:
- kernel crash during dwc3 phy driver unload, that has been addressed before with commits https://github.com/lede-project/source/commit/8db079a9ff1756059250b801617a20baba214684 and https://github.com/lede-project/source/commit/c75f059b0c4d09dd0da60e14c4933a9f645266d1
- possibly FS#177 when some usb3.0 devices get stuck during boot if inserted

Not sure if reverted commit https://github.com/lede-project/source/commit/8db079a9ff1756059250b801617a20baba214684 is still applicable.

The PR also adjusts phy default power settings to the values recommended by QSDK.

Regarding last 2 commits that add reset control during probe and remove - to be honest I'm not sure what the net effect is.
 