### PR TITLE
dnsmasq: fix to make DHCP forcing of options work

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -587,7 +587,7 @@ dhcp_option_add() {
 	config_get list_len "$cfg" dhcp_option_LENGTH
 
 	if [ -n "$list_len" ]; then
-		config_list_foreach "$cfg" dhcp_option dhcp_option_append "$networkid" "$force"
+		config_list_foreach "$cfg" dhcp_option dhcp_option_append "$option" "$networkid" "$force"
 	else
 		config_get dhcp_option "$cfg" dhcp_option
 


### PR DESCRIPTION
A small error in commit 9412fc2 caused the ability to force the sending of dhcp options to a client to stop working. This patch fixes it.

Signed-of-by: Nigel J. Terry NigelTerry@SapphireWebServices.com