### PR TITLE
ipset: split libipset as a subpackage

### DIFF
--- a/package/network/utils/ipset/Makefile
+++ b/package/network/utils/ipset/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ipset
 PKG_VERSION:=6.32
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://ipset.netfilter.org
@@ -24,12 +24,21 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/ipset
+define Package/ipset/Default
   SECTION:=net
   CATEGORY:=Network
   DEPENDS+= +kmod-ipt-ipset +libmnl
   TITLE:=IPset administration utility
   URL:=http://ipset.netfilter.org/
+endef
+
+define Package/ipset
+$(call Package/ipset/Default)
+  DEPENDS+= +libipset
+endef
+
+define Package/libipset
+$(call Package/ipset/Default)
 endef
 
 CONFIGURE_ARGS += \
@@ -38,10 +47,6 @@ CONFIGURE_ARGS += \
 MAKE_FLAGS += \
 	ARCH="$(LINUX_KARCH)" \
 	SHELL="$(BASH)"
-
-define Build/Compile
-	$(call Build/Compile/Default)
-endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib $(1)/usr/lib/pkgconfig
@@ -53,8 +58,12 @@ endef
 define Package/ipset/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/ipset $(1)/usr/sbin/
+endef
+
+define Package/libipset/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libipset*.so* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,ipset))
+$(eval $(call BuildPackage,libipset))


### PR DESCRIPTION
Intent is to link against it, and have the option to
not install the ipset utility (if needed).

One example/use-case is keepalived (from package)
feeds, where it would be nice to just depend on a
`libipset` (sub)package.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>