### PR TITLE
firmware-utils: tplink-safeloader: add support for Archer C5v2 JP and US

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -420,9 +420,9 @@ static struct device_info boards[] = {
 		.vendor = "",
 		.support_list =
 			"SupportList:\r\n"
-			"{product_name:ArcherC5,"
-			"product_ver:2.0.0,"
-			"special_id:00000000}\r\n",
+			"{product_name:ArcherC5,product_ver:2.0.0,special_id:00000000}\r\n"
+			"{product_name:ArcherC5,product_ver:2.0.0,special_id:55530000}\r\n"
+			"{product_name:ArcherC5,product_ver:2.0.0,special_id:4A500000}\r\n", /* JP version */
 		.support_trail = '\x00',
 		.soft_ver = NULL,
 


### PR DESCRIPTION
Add support to Japan and US variant version of TP-Link Archer C5 v2

Testers: guidoa (US) and ssnake (JP)

Signed-off-by: Jean-Pierre St-Yves <jpstyves@gmail.com>