### PR TITLE
Fix ipq806x: adjust to mtd changes in generic

### DIFF
--- a/target/linux/ipq806x/patches-4.9/0031-mtd-add-SMEM-parser-for-QCOM-platforms.patch
+++ b/target/linux/ipq806x/patches-4.9/0031-mtd-add-SMEM-parser-for-QCOM-platforms.patch
@@ -18,7 +18,7 @@ Signed-off-by: Ram Chandra Jangir <rjangi@codeaurora.org>
 
 --- a/drivers/mtd/Kconfig
 +++ b/drivers/mtd/Kconfig
-@@ -190,6 +190,13 @@ config MTD_MYLOADER_PARTS
+@@ -194,6 +194,13 @@ config MTD_MYLOADER_PARTS
  	  You will still need the parsing functions to be called by the driver
  	  for your particular device. It won't happen automatically.
  
@@ -265,10 +265,10 @@ Signed-off-by: Ram Chandra Jangir <rjangi@codeaurora.org>
 +MODULE_DESCRIPTION("Parsing code for SMEM based partition tables");
 --- a/drivers/mtd/Makefile
 +++ b/drivers/mtd/Makefile
-@@ -16,6 +16,7 @@ obj-$(CONFIG_MTD_AR7_PARTS)	+= ar7part.o
- obj-$(CONFIG_MTD_BCM63XX_PARTS)	+= bcm63xxpart.o
+@@ -17,6 +17,7 @@ obj-$(CONFIG_MTD_BCM63XX_PARTS)	+= bcm63
  obj-$(CONFIG_MTD_BCM47XX_PARTS)	+= bcm47xxpart.o
  obj-$(CONFIG_MTD_MYLOADER_PARTS) += myloader.o
+ obj-y				+= parsers/
 +obj-$(CONFIG_MTD_QCOM_SMEM_PARTS) += qcom_smem_part.o
  
  # 'Users' - code which presents functionality to userspace.


### PR DESCRIPTION
Unbreak ipq806x builds after f5f1d40b broke mtd for ipq806x

http://phase1.builds.lede-project.org/builders/ipq806x%2Fgeneric
http://phase1.builds.lede-project.org/builders/ipq806x%2Fgeneric/builds/224/steps/kmods/logs/stdio

Adjust ipq806x patch 0031-mtd-add-SMEM-parser-for-QCOM-platforms.patch to changes made by f5f1d40b to mtd in the generic patch 065-v4.13-0008-mtd-extract-TRX-parser-out-of-bcm47xxpart-into-a-sep.patch

Compile-tested with R7800 in ipq806x.

cc @rmilecki  @blogic 