### PR TITLE
procd: hotplug.json consistency for 0660

### DIFF
--- a/package/system/procd/files/hotplug.json
+++ b/package/system/procd/files/hotplug.json
@@ -17,12 +17,13 @@
 						]
 					],
 					[ "if",
-						[ "regex", "DEVNAME", "^snd" ],
-						[ "makedev", "/dev/%DEVNAME%", "0660", "audio" ],
-					],
-					[ "if",
-						[ "regex", "DEVNAME", "^tty" ],
-						[ "makedev", "/dev/%DEVNAME%", "0660", "tty" ],
+					 	[ "eq", "DEVNAME",
+							[ "audio", "tty" ],
+						],
+						[
+							[ "makedev", "/dev/%DEVNAME%", "0660" ],
+							[ "return" ],
+						]
 					],
 					[ "if",
 						[ "has", "DEVNAME" ],


### PR DESCRIPTION
Change the 0660 group to be the same as the 0666 group.

I have no idea what "return" does. Seems to work just fine without it.