### PR TITLE
dropbear: make ssh compression support configurable

### DIFF
--- a/package/network/services/dropbear/Config.in
+++ b/package/network/services/dropbear/Config.in
@@ -32,6 +32,15 @@ config DROPBEAR_ECC
 
 		Increases binary size by about 23 kB (MIPS).
 
+config DROPBEAR_ZLIB
+	bool "Enable compression"
+	default n
+	help
+		Enables compression using shared zlib library.
+
+		Increases binary size by about 0.1 kB (MIPS) and requires additional 62 kB (MIPS)
+		for a shared zlib library.
+
 config DROPBEAR_UTMP
 	bool "Utmp support"
 	default n

--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2017.75
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
@@ -23,7 +23,7 @@ PKG_LICENSE_FILES:=LICENSE libtomcrypt/LICENSE libtommath/LICENSE
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
-PKG_CONFIG_DEPENDS:=CONFIG_TARGET_INIT_PATH CONFIG_DROPBEAR_ECC CONFIG_DROPBEAR_CURVE25519
+PKG_CONFIG_DEPENDS:=CONFIG_TARGET_INIT_PATH CONFIG_DROPBEAR_ECC CONFIG_DROPBEAR_CURVE25519 CONFIG_DROPBEAR_ZLIB
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -44,6 +44,7 @@ define Package/dropbear
   SECTION:=net
   CATEGORY:=Base system
   TITLE:=Small SSH2 client/server
+  DEPENDS:= +DROPBEAR_ZLIB:zlib
 endef
 
 define Package/dropbear/description
@@ -74,7 +75,7 @@ CONFIGURE_ARGS += \
 	--disable-loginfunc \
 	$(if $(CONFIG_DROPBEAR_PUTUTLINE),,--disable-pututline) \
 	--disable-pututxline \
-	--disable-zlib \
+	$(if $(CONFIG_DROPBEAR_ZLIB),,--disable-zlib) \
 	--enable-bundled-libtom
 
 TARGET_CFLAGS += -DARGTYPE=3 -ffunction-sections -fdata-sections


### PR DESCRIPTION
Adds config option to enable compression support. Impact on binary
size is negligible but additional 60 kB (uncompressed) is needed for
a shared zlib library.
