### PR TITLE
ar71xx: add metadata to some TP-Link images, fix Archer C60 factory image

### DIFF
--- a/target/linux/ar71xx/image/tp-link.mk
+++ b/target/linux/ar71xx/image/tp-link.mk
@@ -121,7 +121,8 @@ endef
 define Device/archer-cxx
   KERNEL := kernel-bin | patch-cmdline | lzma | uImageArcher lzma
   IMAGES := sysupgrade.bin factory.bin
-  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
+  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
+	append-metadata | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
 endef
 
@@ -135,6 +136,7 @@ define Device/archer-c25-v1
   IMAGE_SIZE := 7808k
   LOADER_TYPE := elf
   MTDPARTS := spi0.0:128k(factory-uboot)ro,64k(u-boot)ro,1536k(kernel),6272k(rootfs),128k(config)ro,64k(art)ro,7808k@0x30000(firmware)
+  SUPPORTED_DEVICES := archer-c25-v1
 endef
 
 define Device/archer-c58-v1
@@ -146,6 +148,7 @@ define Device/archer-c58-v1
   DEVICE_PROFILE := ARCHERC58V1
   IMAGE_SIZE := 7936k
   MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1344k(kernel),6592k(rootfs),64k(tplink)ro,64k(art)ro,7936k@0x20000(firmware)
+  SUPPORTED_DEVICES := archer-c58-v1
 endef
 
 define Device/archer-c59-v1
@@ -157,6 +160,7 @@ define Device/archer-c59-v1
   DEVICE_PROFILE := ARCHERC59V1
   IMAGE_SIZE := 14528k
   MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1536k(kernel),12992k(rootfs),1664k(tplink)ro,64k(art)ro,14528k@0x20000(firmware)
+  SUPPORTED_DEVICES := archer-c59-v1
 endef
 
 define Device/archer-c60-v1
@@ -168,6 +172,7 @@ define Device/archer-c60-v1
   DEVICE_PROFILE := ARCHERC60V1
   IMAGE_SIZE := 7936k
   MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1344k(kernel),6592k(rootfs),64k(tplink)ro,64k(art)ro,7936k@0x20000(firmware)
+  SUPPORTED_DEVICES := archer-c60-v1
 endef
 TARGET_DEVICES += archer-c25-v1 archer-c58-v1 archer-c59-v1 archer-c60-v1
 
@@ -1093,8 +1098,10 @@ define Device/tl-wr942n-v1
   IMAGE_SIZE := 14464k
   KERNEL := kernel-bin | patch-cmdline | lzma | uImageArcher lzma
   IMAGES := sysupgrade.bin factory.bin
-  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
+  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
+	append-metadata | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
   MTDPARTS := spi0.0:128k(u-boot)ro,1344k(kernel),13120k(rootfs),64k(product-info)ro,64k(partition-table)ro,256k(oem-config)ro,1344k(oem-vars)ro,64k(ART)ro,14464k@0x20000(firmware)
+  SUPPORTED_DEVICES := tl-wr942n-v1
 endef
 TARGET_DEVICES += tl-wr940n-v4 tl-wr941nd-v2 tl-wr941nd-v3 tl-wr941nd-v4 tl-wr941nd-v5 tl-wr941nd-v6 tl-wr941nd-v6-cn tl-wr942n-v1

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -423,8 +423,6 @@ static struct device_info boards[] = {
 			"SupportList:\r\n"
 			"{product_name:Archer C60,product_ver:1.0.0,special_id:00000000}\r\n"
 			"{product_name:Archer C60,product_ver:1.0.0,special_id:45550000}\r\n"
-			"{product_name:Archer C60,product_ver:1.0.1,special_id:45550000}\r\n"
-			"{product_name:Archer C60,product_ver:1.0.0,special_id:52550000}\r\n"
 			"{product_name:Archer C60,product_ver:1.0.0,special_id:55530000}\r\n",
 		.support_trail = '\x00',
 		.soft_ver = "soft_ver:1.0.0\n",


### PR DESCRIPTION
First commit add metadata to TP-Link sysupgrade images created by tplink-safeloader with "magic" 2705.

Second commit fix build factory firmware TP-Link Archer C60v1. Size of partition "SupportList" is only 256 bytes, and can contain only 3 entries.
