### PR TITLE
fix sysctl stop processing when IO error happens

### DIFF
--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -19,7 +19,5 @@ set_vm_min_free() {
 
 start() {
 	set_vm_min_free
-	for CONF in /etc/sysctl.conf /etc/sysctl.d/*.conf; do
-		[ -f "$CONF" ] && sysctl -p "$CONF" -e >&-
-	done
+	cat /etc/sysctl.conf /etc/sysctl.d/*.conf | grep -v "^#" | while read line; do sysctl -qw $line; done
 }


### PR DESCRIPTION
this fix how to probe with sysctl
sysctl -p /path/to/file.conf will stop processing after meeting IO error line
example: xx.conf
net.core.default_qdisc=fq  #<--this line cause IO error and sysctl would stop
net.ipv4.tcp_congestion_control=htcp #<--this line would never be processed

Signed-off-by: Chen Minqiang <ptpt52@gmail.com>
