### PR TITLE
ramips: fix PCI init on MT7620 with Linux 4.9+

### DIFF
--- a/target/linux/ramips/patches-4.9/999-fix-pci-init-mt7620.patch
+++ b/target/linux/ramips/patches-4.9/999-fix-pci-init-mt7620.patch
@@ -1,0 +1,23 @@
+Index: linux-4.9.34/arch/mips/pci/pci-mt7620.c
+===================================================================
+--- linux-4.9.34.orig/arch/mips/pci/pci-mt7620.c
++++ linux-4.9.34/arch/mips/pci/pci-mt7620.c
+@@ -35,6 +35,7 @@
+ #define PPLL_CFG1			0x9c
+ 
+ #define PPLL_DRV			0xa0
++#define PPLL_LD			(1<<23)
+ #define PDRV_SW_SET			(1<<31)
+ #define LC_CKDRVPD			(1<<19)
+ #define LC_CKDRVOHZ			(1<<18)
+@@ -242,8 +243,8 @@ static int mt7620_pci_hw_init(struct pla
+ 	rt_sysc_m32(0, RALINK_PCIE0_CLK_EN, RALINK_CLKCFG1);
+ 	mdelay(100);
+ 
+-	if (!(rt_sysc_r32(PPLL_CFG1) & PDRV_SW_SET)) {
+-		dev_err(&pdev->dev, "MT7620 PPLL unlock\n");
++	if (!(rt_sysc_r32(PPLL_CFG1) & PPLL_LD)) {
++		dev_err(&pdev->dev, "MT7620 PPLL is unlocked, aborting init\n");
+ 		reset_control_assert(rstpcie0);
+ 		rt_sysc_m32(RALINK_PCIE0_CLK_EN, 0, RALINK_CLKCFG1);
+ 		return -1;


### PR DESCRIPTION
So, this is kind of complicated. This has been upstream for a while,
imported from OpenWRT/LEDE with some cleanups. LEDE ramips has stayed
on linux-4.4 this whole time, with the old(er) version of the patch
that had correct behavior[0], while upstream got changed[1].

When LEDE updated to kernel 4.9, the older version of the code from
the patch got replaced with the upstream version containing the bug.

The original behavior, however, seems to be correct here, as the
official programming guide[2] indicates that bit 31 (PDRV_SW_SET)
in register PPLL_CFG1 is reserved, but bit 23 (added as PPLL_LD)
is the PPLL lock state (which also happens to line up with the
error message).

The original confusion probably comes from the double definition
of PDRV_SW_SET[3, 4] in the upstream code, with one correct definition
(31) and one incorrect one (23).

I've also used the opportunity to clean up the error message a bit -
it's still not really helpful to anyone who doesn't already know what
the PPLL is, but at least it's slightly more readable now.

This will probably need to be upstreamed as well, since with the way
it's currently set up, it's unlikely PCI ever worked for anyone who's
running an upstream kernel on that SoC.

[0]: https://github.com/lede-project/source/blob/05d6e92594c507dcd1f4be6c1bcb2282fe1abe1f/target/linux/ramips/patches-4.4/0009-PCI-MIPS-adds-mt7620a-pcie-driver.patch#L259
[1]: https://github.com/torvalds/linux/blob/026d15f6b9878794fae1f794cae881ccd65052e5/arch/mips/pci/pci-mt7620.c#L246
[2]: http://www.anz.ru/files/mediatek/MT7620_ProgrammingGuide.pdf
[3]: https://github.com/torvalds/linux/blob/026d15f6b9878794fae1f794cae881ccd65052e5/arch/mips/pci/pci-mt7620.c#L36
[4]: https://github.com/torvalds/linux/blob/026d15f6b9878794fae1f794cae881ccd65052e5/arch/mips/pci/pci-mt7620.c#L39

Signed-off-by: Ilya Katsnelson <me@0upti.me>

---

This is my first contribution, so please tell me where I messed up :)
The patch has been tested on my Xiaomi Mi WiFi mini, and everything works fine (the PCIe 5GHz wireless module goes up and is functional, unlike on LEDE master).