### PR TITLE
otrx: remove unnecessary dependency on bcm

### DIFF
--- a/package/utils/otrx/Makefile
+++ b/package/utils/otrx/Makefile
@@ -19,7 +19,6 @@ define Package/otrx
   CATEGORY:=Base system
   TITLE:=Utility for opening (analyzing) TRX firmware images
   MAINTAINER:=Rafał Miłecki <zajec5@gmail.com>
-  DEPENDS:=@TARGET_brcm47xx||@TARGET_bcm53xx
 endef
 
 define Package/otrx/description


### PR DESCRIPTION
it should be possible to build otrx utility for custom bcm targets. Thus it does not make sense that this package is only visible for stock openwrt bcm targets.

Signed-off-by: Martin Schröder <mkschreder.uk@gmail.com>

Thanks for your contribution to the LEDE project!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
