### PR TITLE
ramips: Correct WAN/LAN MAC address for GL-inet GL-MT300N-V2

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -381,6 +381,9 @@ ramips_setup_macs()
 	e1700)
 		wan_mac=$(mtd_get_mac_ascii config WAN_MAC_ADDR)
 		;;
+	gl-mt300n-v2)
+		wan_mac=$(mtd_get_mac_binary factory 4)
+		;;
 	hc5*61|\
 	hc5661a|\
 	hc5962)

--- a/target/linux/ramips/dts/GL-MT300N-V2.dts
+++ b/target/linux/ramips/dts/GL-MT300N-V2.dts
@@ -80,7 +80,7 @@
 };
 
 &ethernet {
-	mtd-mac-address = <&factory 0x4000>;
+	mtd-mac-address = <&factory 0x4>;
 };
 
 &wmac {


### PR DESCRIPTION
Corrects MAC address lookup based on vendor source
https://github.com/domino-team/lede-1701/commit/efb05185ab14e0f1538c3f263b660f21a4a7b0a9

Signed-off-by: John Marrett <johnf@zioncluster.ca>