### PR TITLE
ramips:Add support for Phicomm K2P

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -83,6 +83,7 @@ ramips_setup_interfaces()
 	hc5661a|\
 	hc5962|\
 	hlk-rm04|\
+	k2p|\
 	kn|\
 	kn_rc|\
 	mac1200rv2|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -157,16 +157,17 @@ get_status_led() {
 	hc5962)
 		status_led="$board:white:status"
 		;;
+	k2p|\
+	m3|\
+	miwifi-nano)
+		status_led="$board:blue:status"
+		;;
 	linkits7688| \
 	linkits7688d)
 		[ "$1" = "upgrade" ] && status_led="mediatek:orange:wifi"
 		;;
 	m2m)
 		status_led="$board:blue:wifi"
-		;;
-	m3|\
-	miwifi-nano)
-		status_led="$board:blue:status"
 		;;
 	gl-mt300n-v2)
 		status_led="$board:red:wlan"

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -262,6 +262,9 @@ ramips_board_detect() {
 	*"JHR-N926R")
 		name="jhr-n926r"
 		;;
+	*"K2P")
+		name="k2p"
+		;;
 	*"M3")
 		name="m3"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -74,6 +74,7 @@ platform_check_image() {
 	jhr-n805r|\
 	jhr-n825r|\
 	jhr-n926r|\
+	k2p|\
 	kn|\
 	kn_rc|\
 	kn_rf|\

--- a/target/linux/ramips/dts/K2P.dts
+++ b/target/linux/ramips/dts/K2P.dts
@@ -1,0 +1,120 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "phicomm,k2p", "mediatek,mt7621-soc";
+	model = "Phicomm K2P";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		stat_r {
+			label = "k2p:red:status";
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		stat_y {
+			label = "k2p:yellow:status";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+
+		stat_b {
+			label = "k2p:blue:status";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "permanent_config";
+			reg = <0x50000 0x50000>;
+			read-only;
+		};
+
+		partition@a0000 {
+			label = "firmware";
+			reg = <0xa0000 0xf60000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x0>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "jtag";
+			ralink,function = "gpio";
+		};
+	};
+};
+

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -88,6 +88,13 @@ define Device/hc5962
 endef
 TARGET_DEVICES += hc5962
 
+define Device/k2p
+  DTS := K2P
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Phicomm K2P
+endef
+TARGET_DEVICES += k2p
+
 define Device/mt7621
   DTS := MT7621
   BLOCKSIZE := 64k


### PR DESCRIPTION
This commit adds device support for Phicomm K2P which uses MT7621A SoC.
It uses one MT7615D radio chip with DBDC mode enabled(This mode allow this single chip act as an 2x2 11n radio and an 2x2 11ac radio at the same time.)
However mt76 doesn't support it currently so there is no default packages defined.