### PR TITLE
ramips: fixed wps gpio in DWR-512

### DIFF
--- a/target/linux/ramips/dts/DWR-512-B.dts
+++ b/target/linux/ramips/dts/DWR-512-B.dts
@@ -17,7 +17,7 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 


### PR DESCRIPTION
this patch fix the gpio pin number in the DWR-512 device tree

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>
