### PR TITLE
netfilter: move tftp tag to nf-nathelper-extra

### DIFF
--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -361,7 +361,6 @@ define KernelPackage/nf-nathelper/description
  Includes:
  - ftp
  - irc
- - tftp
 endef
 
 $(eval $(call KernelPackage,nf-nathelper))
@@ -386,6 +385,7 @@ define KernelPackage/nf-nathelper-extra/description
  - proto_gre
  - sip
  - snmp_basic
+ - tftp
  - broadcast
 endef
 


### PR DESCRIPTION
The tftp netfilter module is located in nf-nathelper-extra and not in nf-nathelper.

Signed-off-by: Uwe Arnold <donvipre@gmail.com>