### PR TITLE
    ramips: add support for the GnuBee Personal Cloud One

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -183,6 +183,10 @@ fonera20n)
 	set_usb_led "$board:orange:usb"
 	set_wifi_led "$board:orange:wifi"
 	;;
+gb-pc1)
+	ucidef_set_led_netdev "lan1" "lan1" "$board:green:lan1" "eth0.1"
+	ucidef_set_led_netdev "lan2" "lan2" "$board:green:lan2" "eth0.2"
+	;;
 gl-mt300a|\
 gl-mt300n|\
 gl-mt750)

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -183,6 +183,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
+	gb-pc1)
+		ucidef_add_switch "switch0" \
+			"0:lan" "4:lan" "6@eth0"
+		;;
 	gl-mt300n-v2)
 		ucidef_add_switch "switch0" \
 			"1:lan" "0:wan" "6@eth0"

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -77,6 +77,7 @@ get_status_led() {
 	dir-620-a1|\
 	dir-620-d1|\
 	dwr-512-b|\
+	gb-pc1|\
 	hpm|\
 	hw550-3g|\
 	mac1200rv2|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -208,6 +208,9 @@ ramips_board_detect() {
 	*"FreeStation5")
 		name="freestation5"
 		;;
+	*"GB-PC1")
+		name="gb-pc1"
+		;;
 	*"GL-MT300A")
 		name="gl-mt300a"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -59,6 +59,7 @@ platform_check_image() {
 	firewrt|\
 	fonera20n|\
 	freestation5|\
+	gb-pc1|\
 	gl-mt300a|\
 	gl-mt300n|\
 	gl-mt750|\

--- a/target/linux/ramips/dts/GB-PC1.dts
+++ b/target/linux/ramips/dts/GB-PC1.dts
@@ -1,0 +1,120 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "gnubee,gb-pc1", "mediatek,mt7621-soc";
+	model = "GB-PC1";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	palmbus: palmbus@1E000000 {
+		i2c@900 {
+			status = "okay";
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		system {
+			label = "gb-pc1:green:system";
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+		};
+
+		status {
+			label = "gb-pc1:green:status";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "gb-pc1:green:lan";
+			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "gb-pc1:green:wan";
+			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x1fb0000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt", "rgmii2", "uart3", "ge2";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -73,6 +73,14 @@ define Device/firewrt
 endef
 TARGET_DEVICES += firewrt
 
+define Device/gb-pc1
+  DTS := GB-PC1
+  DEVICE_TITLE := GnuBee Personal Cloud One
+  DEVICE_PACKAGES := kmod-ata-core kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+endef
+TARGET_DEVICES += gb-pc1
+
 define Device/hc5962
   DTS := HC5962
   BLOCKSIZE := 128k


### PR DESCRIPTION
    The GnuBee Personal Cloud One crowdfunded on https://www.crowdsupply.com
    It is a low-cost, low-power, network-attached storage device.

    Specifications:

    - SoC: MediaTek MT7621AT
    - RAM: DDR3 512 MB
    - Flash: 32 MB
    - Six SATA ports for 2.5" Drives
    - One micro SDcard
    - One USB 3.0
    - Two USB 2.0
    - Gigabit Ethernet: 1 x WAN and 1 x LAN
    - UART 3.5mm Audio Jack or 3 pin header - 57600 8N1
    - Four GPIOs available on a pin header

    Flash instructions:

    The GnuBee Personal Cloud One ships with libreCMC installed.
    libreCMC is a Free Software Foundation approved fork of LEDE/OpenWrt.
    As such one can upgrade using the webinterface or sysupgrade.

    Das U-Boot has multiple options for recovery or updates including :

    - USB
    - http
    - tftp

Signed-off-by: L. D. Pinney <ldpinney@gmail.com>

Thanks for your contribution to the LEDE project!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
