### PR TITLE
ramips: DTS: VoCore2

### DIFF
--- a/target/linux/ramips/dts/VOCORE2.dts
+++ b/target/linux/ramips/dts/VOCORE2.dts
@@ -15,7 +15,7 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x0 0x4000000>;
+		reg = <0x0 0x8000000>;
 	};
 
 	gpio-leds {
@@ -23,7 +23,7 @@
 
 		status {
 			label = "vocore2:fuchsia:status";
-			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/VOCORE2.dts
+++ b/target/linux/ramips/dts/VOCORE2.dts
@@ -50,8 +50,8 @@
 
 	uart2_pins: uart2 {
 		uart2 {
-			ralink,group = "spis";
-			ralink,function = "pwm";
+			ralink,group = "uart2";
+			ralink,function = "uart2";
 		};
 	};
 };


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: ramips/mt7628/VoCore2
Run tested: ramips/mt7628/VoCore2

The VoCore2 features 128MB of DDR RAM, like seen in the first commit [1],
the manufacturer's website [2] and the relevant file in the manufacturer's source code [3]



[1]:
https://git.lede-project.org/?p=source.git;a=commit;h=3f31029b190417e12f4d19d9999cd52ec76d0f85

[2]:
http://vocore.io/v2.html

[3]:


Switch to kernel 4.9 for kirkwood. (Based on 4.9.20)
A bit more detailed description + bootlog of dockstar is avai