### PR TITLE
ramips: DTS: VoCore2

### DIFF
--- a/target/linux/ramips/dts/VOCORE2.dts
+++ b/target/linux/ramips/dts/VOCORE2.dts
@@ -15,7 +15,7 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x0 0x4000000>;
+		reg = <0x0 0x8000000>;
 	};
 
 	gpio-leds {
@@ -23,7 +23,7 @@
 
 		status {
 			label = "vocore2:fuchsia:status";
-			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };
@@ -31,27 +31,8 @@
 &pinctrl {
 	state_default: pinctrl0 {
 		gpio {
-			ralink,group = "refclk", "gpio";
+			ralink,group = "wled_an", "perst", "wdt";
 			ralink,function = "gpio";
-		};
-
-		agpio {
-			ralink,group = "agpio";
-			ralink,function = "uart2";
-		};
-	};
-
-	uart1_pins: uart1 {
-		uart1 {
-			ralink,group = "uart1";
-			ralink,function = "uart1";
-		};
-	};
-
-	uart2_pins: uart2 {
-		uart2 {
-			ralink,group = "spis";
-			ralink,function = "pwm";
 		};
 	};
 };


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: ramips/mt7628/VoCore2
Run tested: ramips/mt7628/VoCore2

The VoCore2 features 128MB of DDR RAM, like seen in the first commit [1],
the manufacturer's website [2] and the relevant file in the manufacturer's source code [3]
Currently, only 64MB are active/enabled, so change 0x4000000 to 0x8000000 in the memory
section of the DTS. This makes all 128MB available.

Further, the only LED this board is equipped with, is connected between the GPIO and GND.
Schematic at [4]. Therefore flag this LED as ACTIVE_HIGH.

The device's serial console is configured for ttyS2, which also shares pins with PWM.
If the pinmux configuration is left like it is now, kernel 4.9 shows:
`of_serial: probe of 10000e00.uart2 failed with error -22`
The serial console doesn't work with kernel 4.9, which is quite a pain for a device like the VoCore.
This thing, however, is fine with kernel 4.4 !
With the proposed change in the pinmux, I get:
`10000e00.uart2: ttyS2 at MMIO 0x10000e00 (irq = 30, base_baud = 2500000) is a 16550A`
`console [ttyS2] enabled`
and the console is finally working as expected.

This PR is split in two commits:
* fix memory and LED: intended for trunk and 17.01
* fix serial console: just for trunk (kernel 4.9), as it is fine on 17.01 (kernel 4.4)

---

Further things to mention / discuss:
* sysupgrade does not work with trunk (after instantly finishing the sysupgrade command, the device just reboots without having changed anything)
* Do we really need to specify the pinmux configuration for UART pins in VOCORE2.dts. For me, it looks like this configuration is redundant, as it's already done in the mt7628an.dtsi include file.
* The only LED is triggered by netdev/wlan0 _and_ used as the status LED in diag.sh at the same time. Can this be a problem?
* WiFi is heavily unstable, but that's really another issue


[1]:
https://git.lede-project.org/?p=source.git;a=commit;h=3f31029b190417e12f4d19d9999cd52ec76d0f85

[2]:
http://vocore.io/v2.html

[3]:
http://vonger.cn/misc/vocore2/openwrt.tar.bz2

[4]:
http://vonger.cn/misc/vocore2/source.zip
