### PR TITLE
fix MT7620A throughput problems

### DIFF
--- a/package/kernel/mac80211/patches/020-21-rt2800-fix-LNA-gain-assignment-for-MT7620.patch
+++ b/package/kernel/mac80211/patches/020-21-rt2800-fix-LNA-gain-assignment-for-MT7620.patch
@@ -14,12 +14,12 @@ well as the LNA calibration values for HT20.
 Reported-by: Tom Psyborg <pozega.tomislav@gmail.com>
 Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 ---
- drivers/net/wireless/ralink/rt2x00/rt2800lib.c | 18 ++++++++++++++++--
- 1 file changed, 16 insertions(+), 2 deletions(-)
+ drivers/net/wireless/ralink/rt2x00/rt2800lib.c | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
 
 --- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
 +++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
-@@ -3806,11 +3806,25 @@ static void rt2800_config_channel(struct
+@@ -3806,11 +3806,22 @@ static void rt2800_config_channel(struct
  	}
  
  	if (rt2x00_rt(rt2x00dev, RT5592) || rt2x00_rt(rt2x00dev, RT6352)) {
@@ -38,10 +38,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  		/* AGC init */
 -		reg = (rf->channel <= 14 ? 0x1c : 0x24) + 2 * rt2x00dev->lna_gain;
-+		if (rt2x00_rt(rt2x00dev, RT6352))
-+			reg = 0x04;
-+		else
-+			reg = rf->channel <= 14 ? 0x1c : 0x24;
++		reg = rf->channel <= 14 ? 0x1c : 0x24;
 +
 +		reg += 2 * rt2x00dev->lna_gain;
  		rt2800_bbp_write_with_rx_chain(rt2x00dev, 66, reg);

--- a/package/kernel/mac80211/patches/020-25-rt2x00-reduce-power-consumption-on-mt7620.patch
+++ b/package/kernel/mac80211/patches/020-25-rt2x00-reduce-power-consumption-on-mt7620.patch
@@ -1,0 +1,38 @@
+From: Tomislav Požega <pozega.tomislav@gmail.com>
+
+Add back registers required for reducing power consumption.
+This helps devices to sync at better TX/RX rates and improves overall
+performance.
+
+Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>
+---
+ drivers/net/wireless/ralink/rt2x00/rt2800lib.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletions(-)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -8711,6 +8711,24 @@ static void rt2800_init_rfcsr_6352(struc
+ 	rt2800_rfcsr_write_chanreg(rt2x00dev, 58, 0x02);
+ 	rt2800_rfcsr_write_chanreg(rt2x00dev, 60, 0xC7);
+ 
++	/* reduce power consumption */
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 43, 0x53);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 44, 0x53);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 45, 0x53);
++	rt2800_rfcsr_write_bank(rt2x00dev, 4, 47, 0x24);
++	rt2800_rfcsr_write_bank(rt2x00dev, 6, 47, 0x64);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 48, 0x4F);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 49, 0x02);
++	rt2800_rfcsr_write_bank(rt2x00dev, 4, 55, 0x24);
++	rt2800_rfcsr_write_bank(rt2x00dev, 6, 55, 0x64);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 56, 0x4F);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 57, 0x02);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 58, 0x27);
++	rt2800_rfcsr_write_bank(rt2x00dev, 4, 59, 0x24);
++	rt2800_rfcsr_write_bank(rt2x00dev, 6, 59, 0x64);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 60, 0x4F);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 61, 0x02);
++
+ 	/* Initialize RF DC calibration register to default value */
+ 	rt2800_rfcsr_write_dccal(rt2x00dev, 0, 0x47);
+ 	rt2800_rfcsr_write_dccal(rt2x00dev, 1, 0x00);


### PR DESCRIPTION
revert AGC reg for MT7620 and re-introduce power consumption registers


solves the problem described in https://forum.lede-project.org/t/slow-2-4ghz-wireless-network-after-upgrading-to-17-01-2/5207/1


Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>
