### PR TITLE
brcm63xx: DTS: fix AV4202N flash layout

### DIFF
--- a/target/linux/brcm63xx/dts/av4202n.dts
+++ b/target/linux/brcm63xx/dts/av4202n.dts
@@ -80,7 +80,7 @@
 
 	linux@20000 {
 		label = "linux";
-		reg = <0x010000 0xfe0000>;
+		reg = <0x020000 0xfc0000>;
 	};
 
 	nvram@fe0000 {


### PR DESCRIPTION
@KanjiMonster 

With commit [1], a manual flash layout has been introduced for several boards.
The AV4202N is broken since then:

> `bcm63xxpart: CFE boot tag CRC invalid (expected 00000000, actual ff989263)`
> `3 bcm63xxpart partitions found on MTD device 18000000.nor`
> `Creating 3 MTD partitions on "18000000.nor":`
> `0x000000000000-0x000000020000 : "CFE"`
> `0x000000010000-0x000000ff0000 : "linux"`
> `0x000000fe0000-0x000001000000 : "nvram"`
> `(...)`
> `jffs2: Too few erase blocks (1)`
> `List of all partitions:`
> `1f00             128 mtdblock0  (driver?)`
> `1f01           16256 mtdblock1  (driver?)`
> `1f02             128 mtdblock2  (driver?)`
> `No filesystem could mount root, tried:  squashfs jffs2`
> `Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(31,2)`
> `Rebooting in 1 seconds..`

The introduced flash layout has the _linux_ parition overlapping with both the CFE and NVRAM.
The partition's geometry should be: start = 0x020000, size = 0xfc0000

As the board (correctly) auto-detects the partitions with the bcm63xxpart part-probe, the manual
layout is removed. Do we need to have it set manually?
This is the (excerpt of) bootlog with auto-detection:
> `bcm63xxpart: CFE boot tag found with version 6 and board type 96368_Swiss_S1`
> `bcm63xxpart: Partition 0 is CFE offset 0 and length 20000`
> `bcm63xxpart: Partition 1 is kernel offset 20100 and length 15bb68`
> `bcm63xxpart: Partition 2 is rootfs offset 17bc68 and length e64398`
> `bcm63xxpart: Partition 3 is nvram offset fe0000 and length 20000`
> `bcm63xxpart: Partition 4 is linux offset 20000 and length fc0000`
> `5 bcm63xxpart partitions found on MTD device 18000000.nor`
> `Creating 5 MTD partitions on "18000000.nor":`
> `0x000000000000-0x000000020000 : "CFE"`
> `0x000000020100-0x00000017bc68 : "kernel"`
> `0x00000017bc68-0x000000fe0000 : "rootfs"`
> `mtd: device 2 (rootfs) set to be root filesystem`
> `1 squashfs-split partitions found on MTD device rootfs`
> `0x000000380000-0x000000fe0000 : "rootfs_data"`
> `0x000000fe0000-0x000001000000 : "nvram"`
> `0x000000020000-0x000000fe0000 : "linux"`

The only issue, I'm having on this device right now: when doing `sysupgrade` with the `-n` option,
the rootfs_data partition is _not_ cleared, the overlay is preserved and everything's still there.
When doing it manually with `mtd erase rootfs_data` it works as expected.
But I'm having sysupgrade issues with trunk on other boards as well...

[1]:
https://github.com/lede-project/source/commit/97b36aca09da7a1b214f4616a8549e99ff2d92aa
