### PR TITLE
ar71xx: lzma loader

### DIFF
--- a/target/linux/ar71xx/image/lzma-loader/src/Makefile
+++ b/target/linux/ar71xx/image/lzma-loader/src/Makefile
@@ -37,11 +37,13 @@ CFLAGS		= -D__KERNEL__ -Wall -Wstrict-prototypes -Wno-trigraphs -Os \
 		  -mabi=32 -march=mips32r2 \
 		  -Wa,-32 -Wa,-march=mips32r2 -Wa,-mips32r2 -Wa,--trap
 CFLAGS		+= -D_LZMA_PROB32
+CFLAGS		+= -flto
 
 ASFLAGS		= $(CFLAGS) -D__ASSEMBLY__
 
-LDFLAGS		= -static --gc-sections -no-warn-mismatch
-LDFLAGS		+= -e startup -T loader.lds -Ttext $(LZMA_TEXT_START)
+LDFLAGS		= -static -Wl,--gc-sections -Wl,-no-warn-mismatch
+LDFLAGS		+= -Wl,-e,startup -T loader.lds -Wl,-Ttext,$(LZMA_TEXT_START)
+LDFLAGS		+= -flto -fwhole-program
 
 O_FORMAT 	= $(shell $(OBJDUMP) -i | head -2 | grep elf32)
 
@@ -86,7 +88,7 @@ data.o: $(LOADER_DATA)
 	$(LD) -r -b binary --oformat $(O_FORMAT) -T lzma-data.lds -o $@ $<
 
 loader: $(OBJECTS)
-	$(LD) $(LDFLAGS) -o $@ $(OBJECTS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJECTS)
 
 loader.bin: loader
 	$(OBJCOPY) $(BIN_FLAGS) $< $@

--- a/target/linux/ar71xx/image/lzma-loader/src/head.S
+++ b/target/linux/ar71xx/image/lzma-loader/src/head.S
@@ -42,6 +42,19 @@ LEAF(startup)
 	mtc0	t0, CP0_STATUS
 	ehb
 
+	/*
+	 * Some bootloaders set the 'Kseg0 coherency algorithm' to
+	 * 'Cacheable, noncoherent, write-through, no write allocate'
+	 * and this cause performance issues. Let's go and change it to
+	 * 'Cacheable, noncoherent, write-back, write allocate'
+	 */
+	mfc0	t0, CP0_CONFIG
+	li	t1, ~7			#~CONF_CM_CMASK
+	and	t0, t1
+	ori	t0, 3			#CONF_CM_CACHABLE_NONCOHERENT
+	mtc0	t0, CP0_CONFIG
+	nop
+
 	mtc0	zero, CP0_COUNT
 	mtc0	zero, CP0_COMPARE
 	ehb


### PR DESCRIPTION
Two commits for lzma loader of ar71xx:

- The first one: speed up boot time on some boards. On my board, u-boot leaves caches in a very (very very very) slow mode. Kernel decompression takes 33 seconds on mips 74kc@775Mhz. Good cache coherency reduce it to less than 1 second. Code is taken from linux kernel (https://github.com/torvalds/linux/blob/5924bbecd0267d87c24110cbe2041b5075173a25/arch/mips/include/asm/mach-ath79/kernel-entry-init.h)
- The second: Use LTO when building. You may not want to merge it, as it only saves 270 bytes, but the changes are only in Makefile. Code optimisation might be better too. To handle LTO: use gcc for linking instead of ld, and change all ld flags to gcc flags.