### PR TITLE
ramips: DIR-860L-B1 fix switch port numbering

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -157,7 +157,6 @@ ramips_setup_interfaces()
 	c20i|\
 	c50|\
 	dir-645|\
-	dir-860l-b1|\
 	f5d8235-v2|\
 	gl-mt300a|\
 	gl-mt300n|\
@@ -182,6 +181,10 @@ ramips_setup_interfaces()
 	zbt-wa05)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
+		;;
+	dir-860l-b1)
+		ucidef_add_switch "switch0" \
+			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;
 	gl-mt300n-v2)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
Luci shows switch ports in inverted order on that device.
This patch fixes switch port numbering and matches them to the device
silkscreen.

Signed-off-by: Thibaut VARENE <hacks@slashdirt.org>