### PR TITLE
ramips: add a compatible string to MT7621 dts files

### DIFF
--- a/target/linux/ramips/dts/11ACNAS.dts
+++ b/target/linux/ramips/dts/11ACNAS.dts
@@ -3,6 +3,7 @@
 #include "W2914NSV2.dtsi"
 
 / {
+	compatible = "wevo,11acnas", "mediatek,mt7621-soc";
 	model = "WeVO 11AC NAS Router";
 
 	memory@0 {

--- a/target/linux/ramips/dts/DIR-860L-B1.dts
+++ b/target/linux/ramips/dts/DIR-860L-B1.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "dlink,dir-860l-b", "mediatek,mt7621-soc";
 	model = "D-Link DIR-860L B1";
 
 	memory@0 {

--- a/target/linux/ramips/dts/EW1200.dts
+++ b/target/linux/ramips/dts/EW1200.dts
@@ -6,6 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "afoundry,ew1200", "mediatek,mt7621-soc";
 	model = "EW1200";
 
 	memory@0 {

--- a/target/linux/ramips/dts/FIREWRT.dts
+++ b/target/linux/ramips/dts/FIREWRT.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "firefly,firewrt", "mediatek,mt7621-soc";
 	model = "Firefly FireWRT";
 
 	memory@0 {

--- a/target/linux/ramips/dts/HC5962.dts
+++ b/target/linux/ramips/dts/HC5962.dts
@@ -6,6 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "hiwifi,hc5962", "mediatek,mt7621-soc";
 	model = "HiWiFi HC5962";
 
 	memory@0 {

--- a/target/linux/ramips/dts/Newifi-D1.dts
+++ b/target/linux/ramips/dts/Newifi-D1.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "lenovo,newifi-d1", "mediatek,mt7621-soc";
 	model = "Newifi-D1";
 
 	memory@0 {

--- a/target/linux/ramips/dts/PBR-M1.dts
+++ b/target/linux/ramips/dts/PBR-M1.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "pandorabox,pbr-m1", "mediatek,mt7621-soc";
 	model = "PBR-M1";
 
 	memory@0 {

--- a/target/linux/ramips/dts/R6220.dts
+++ b/target/linux/ramips/dts/R6220.dts
@@ -6,6 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "netgear,r6220", "mediatek,mt7621-soc";
 	model = "Netgear R6220";
 
 	memory@0 {

--- a/target/linux/ramips/dts/RB750Gr3.dts
+++ b/target/linux/ramips/dts/RB750Gr3.dts
@@ -6,6 +6,7 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	compatible = "mikrotik,rb750gr3", "mediatek,mt7621-soc";
 	model = "MikroTik RB750Gr3";
 
 	memory@0 {

--- a/target/linux/ramips/dts/RE6500.dts
+++ b/target/linux/ramips/dts/RE6500.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "linksys,re6500", "mediatek,mt7621-soc";
 	model = "Linksys RE6500";
 
 	memory@0 {

--- a/target/linux/ramips/dts/SAP-G3200U3.dts
+++ b/target/linux/ramips/dts/SAP-G3200U3.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "storylink,sap-g3200u3", "mediatek,mt7621-soc";
 	model = "STORYLiNK SAP-G3200U3";
 
 	memory@0 {

--- a/target/linux/ramips/dts/SK-WB8.dts
+++ b/target/linux/ramips/dts/SK-WB8.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
+	compatible = "samknows,sk-wb", "mediatek,mt7621-soc";
 	model = "SamKnows Whitebox 8";
 
 	memory@0 {

--- a/target/linux/ramips/dts/Timecloud.dts
+++ b/target/linux/ramips/dts/Timecloud.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "thunder,timecloud", "mediatek,mt7621-soc";
 	model = "Thunder Timecloud";
 
 	memory@0 {

--- a/target/linux/ramips/dts/VR500.dts
+++ b/target/linux/ramips/dts/VR500.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "planex,vr500", "mediatek,mt7621-soc";
 	model = "Planex VR500";
 
 	memory@0 {

--- a/target/linux/ramips/dts/W2914NSV2.dts
+++ b/target/linux/ramips/dts/W2914NSV2.dts
@@ -3,6 +3,7 @@
 #include "W2914NSV2.dtsi"
 
 / {
+	compatible = "wevo,w2914nsv2", "mediatek,mt7621-soc";
 	model = "WeVO W2914NS v2";
 
 	memory@0 {

--- a/target/linux/ramips/dts/WF-2881.dts
+++ b/target/linux/ramips/dts/WF-2881.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "netis,wf-2881", "mediatek,mt7621-soc";
 	model = "NETIS WF-2881";
 
 	memory@0 {

--- a/target/linux/ramips/dts/WITI.dts
+++ b/target/linux/ramips/dts/WITI.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "mqmaker,witi", "mediatek,mt7621-soc";
 	model = "MQmaker WiTi";
 
 	memory@0 {

--- a/target/linux/ramips/dts/WNDR3700V5.dts
+++ b/target/linux/ramips/dts/WNDR3700V5.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "netgear,wndr3700v5", "mediatek,mt7621-soc";
 	model = "Netgear WNDR3700v5";
 
 	memory@0 {

--- a/target/linux/ramips/dts/WSR-1166.dts
+++ b/target/linux/ramips/dts/WSR-1166.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "buffalo,wsr-1166", "mediatek,mt7621-soc";
 	model = "Buffalo WSR-1166DHP";
 
 	memory@0 {

--- a/target/linux/ramips/dts/WSR-600.dts
+++ b/target/linux/ramips/dts/WSR-600.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "buffalo,wsr-600", "mediatek,mt7621-soc";
 	model = "Buffalo WSR-600DHP";
 
 	memory@0 {

--- a/target/linux/ramips/dts/ZBT-WE1326.dts
+++ b/target/linux/ramips/dts/ZBT-WE1326.dts
@@ -6,6 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "zbt,zbt-we1326", "mediatek,mt7621-soc";
 	model = "ZBT-WE1326";
 
 	chosen {

--- a/target/linux/ramips/dts/ZBT-WG2626.dts
+++ b/target/linux/ramips/dts/ZBT-WG2626.dts
@@ -5,6 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "zbt,zbt-wg2626", "mediatek,mt7621-soc";
 	model = "ZBT-WG2626";
 
 	memory@0 {

--- a/target/linux/ramips/dts/ZBT-WG3526-16M.dts
+++ b/target/linux/ramips/dts/ZBT-WG3526-16M.dts
@@ -3,6 +3,7 @@
 #include "ZBT-WG3526.dtsi"
 
 / {
+	compatible = "zbt,zbt-wg3526", "mediatek,mt7621-soc";
 	model = "ZBT-WG3526 (16M)";
 };
 

--- a/target/linux/ramips/dts/ZBT-WG3526-32M.dts
+++ b/target/linux/ramips/dts/ZBT-WG3526-32M.dts
@@ -3,6 +3,7 @@
 #include "ZBT-WG3526.dtsi"
 
 / {
+	compatible = "zbt,zbt-wg3526", "mediatek,mt7621-soc";
 	model = "ZBT-WG3526 (32M)";
 };
 


### PR DESCRIPTION
    Add a missing compatible string to the MT7621 dts files without one.
    
    Signed-off-by: L. D. Pinney <ldpinney@gmail.com>
