### PR TITLE
Archer c50v1: support both EU and US versions

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -42,15 +42,17 @@ define Device/ArcherC20i
 endef
 TARGET_DEVICES += ArcherC20i
 
-define Device/ArcherC50
+define Device/ArcherC50v1
   $(Device/Archer)
   DTS := ArcherC50
   SUPPORTED_DEVICES := c50
   TPLINK_BOARD_ID := ArcherC50
-  IMAGES += factory.bin
-  DEVICE_TITLE := TP-Link ArcherC50
+  IMAGES += factory-us.bin factory-eu.bin
+  IMAGE/factory-us.bin := tplink-v2-image -w 0
+  IMAGE/factory-eu.bin := tplink-v2-image -w 2
+  DEVICE_TITLE := TP-Link ArcherC50v1
 endef
-TARGET_DEVICES += ArcherC50
+TARGET_DEVICES += ArcherC50v1
 
 define Device/ArcherMR200
   $(Device/Archer)

--- a/tools/firmware-utils/src/mktplinkfw2.c
+++ b/tools/firmware-utils/src/mktplinkfw2.c
@@ -424,16 +424,14 @@ static int check_options(void)
 
 		board->hw_id = strtoul(opt_hw_id, NULL, 0);
 
-		if (opt_hw_rev)
-			board->hw_rev = strtoul(opt_hw_rev, NULL, 0);
-		else
-			board->hw_rev = 1;
-
-		if (opt_hw_ver_add)
-			board->hw_ver_add = strtoul(opt_hw_ver_add, NULL, 0);
-		else
-			board->hw_ver_add = 0;
+		board->hw_rev = 1;
+		board->hw_ver_add = 0;
 	}
+
+	if (opt_hw_rev)
+		board->hw_rev = strtoul(opt_hw_rev, NULL, 0);
+	if (opt_hw_ver_add)
+		board->hw_ver_add = strtoul(opt_hw_ver_add, NULL, 0);
 
 	layout = find_layout(layout_id);
 	if (layout == NULL) {


### PR DESCRIPTION
This patch series enable support of both the US and EU versions of the Archer C50v1

mktplinkfw2 is modified to allow commandline override of two header fields.

The build makefile is modified to generate a US and EU factory image for both versions. The US factory image is identical to the current "factory.bin" image. the EU factory image has the correct field to pass validation on EU hardware.

The device is renamed "Archer C50v1" to differentiate from the currently unsupported v2 and v3 hardware.

The factory-eu.bin has been successfully tested on EU hardware.

Furthermore, board.d/02_network is updated so that switch port numbering matches device physical order.

The DTS is also fixed with correct GPIO levels for the LEDs.