### PR TITLE
    ramips: rt305x: update device tree source files

### DIFF
--- a/target/linux/ramips/dts/3G-6200N.dts
+++ b/target/linux/ramips/dts/3G-6200N.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "3G-6200N", "ralink,rt3050-soc";
+	compatible = "edimax,3g-6200n", "ralink,rt3050-soc";
 	model = "Edimax 3g-6200n";
 
 	cfi@1f000000 {
@@ -51,17 +52,17 @@
 
 		power {
 			label = "3g-6200n:green:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
 			label = "3g-6200n:amber:wlan";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		3g {
 			label = "3g-6200n:blue:3g";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -73,13 +74,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		rfkill {
 			label = "wlanswitch";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
 		};
 	};

--- a/target/linux/ramips/dts/3G-6200NL.dts
+++ b/target/linux/ramips/dts/3G-6200NL.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "3G-6200NL", "ralink,rt3050-soc";
+	compatible = "edimax,3g-6200nl", "ralink,rt3050-soc";
 	model = "Edimax 3g-6200nl";
 
 	cfi@1f000000 {
@@ -51,12 +52,12 @@
 
 		internet {
 			label = "3g-6200nl:green:internet";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
 			label = "3g-6200nl:green:wlan";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -68,7 +69,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/3G150B.dts
+++ b/target/linux/ramips/dts/3G150B.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "3G150B", "ralink,rt5350-soc";
+	compatible = "tenda,3g150b", "ralink,rt5350-soc";
 	model = "Tenda 3G150B";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		ap {
 			label = "3g150b:blue:ap";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		3g {
 			label = "3g150b:blue:3g";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,7 +31,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/3G300M.dts
+++ b/target/linux/ramips/dts/3G300M.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "3G300M", "ralink,rt3052-soc";
+	compatible = "tenda,3g300m", "ralink,rt3052-soc";
 	model = "Tenda 3G300M";
 
 	gpio-leds {
@@ -13,32 +14,32 @@
 
 		3grouter {
 			label = "3g300m:blue:3grouter";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		ap {
 			label = "3g300m:blue:ap";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wisprouter {
 			label = "3g300m:blue:wisprouter";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wirelessrouter {
 			label = "3g300m:blue:wirelessrouter";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		3g {
 			label = "3g300m:blue:3g";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wpsreset {
 			label = "3g300m:blue:wpsreset";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -56,7 +57,7 @@
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/A5-V11.dts
+++ b/target/linux/ramips/dts/A5-V11.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "A5-V11", "ralink,rt5350-soc";
+	compatible = "generic,a5-v11", "ralink,rt5350-soc";
 	model = "A5-V11";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		system {
 			label = "a5-v11:blue:system";
-			gpios = <&gpio0 20 1>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "a5-v11:red:power";
-			gpios = <&gpio0 17 1>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,7 +31,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};
@@ -42,13 +43,13 @@
 		usb {
 			gpio-export,name = "usb";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 7 0>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		root_hub {
 			gpio-export,name = "root_hub";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 12 0>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/AIR3GII.dts
+++ b/target/linux/ramips/dts/AIR3GII.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "AIR3GII", "ralink,rt5350-soc";
+	compatible = "airlive,air3gII", "ralink,rt5350-soc";
 	model = "AirLive Air3GII";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		wlan {
 			label = "air3gii:green:wlan";
-			gpios = <&gpio0 8 0>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		mobile {
 			label = "air3gii:green:mobile";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,7 +31,7 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/ALL0256N-4M.dts
+++ b/target/linux/ramips/dts/ALL0256N-4M.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ALL0256N", "ralink,rt3050-soc";
+	compatible = "allnet,all0256n", "ralink,rt3050-soc";
 	model = "Allnet ALL0256N (4M)";
 
 	gpio-leds {
@@ -13,17 +14,17 @@
 
 		rssilow {
 			label = "all0256n:green:rssilow";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		rssimed {
 			label = "all0256n:green:rssimed";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		rssihigh {
 			label = "all0256n:green:rssihigh";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -35,7 +36,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/ALL0256N-8M.dts
+++ b/target/linux/ramips/dts/ALL0256N-8M.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ALL0256N", "ralink,rt3050-soc";
+	compatible = "allnet,all0256n", "ralink,rt3050-soc";
 	model = "Allnet ALL0256N (8M)";
 
 	gpio-leds {
@@ -13,17 +14,17 @@
 
 		rssilow {
 			label = "all0256n:green:rssilow";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		rssimed {
 			label = "all0256n:green:rssimed";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		rssihigh {
 			label = "all0256n:green:rssihigh";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -35,7 +36,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/ALL5002.dts
+++ b/target/linux/ramips/dts/ALL5002.dts
@@ -2,8 +2,11 @@
 
 #include "rt3352.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
 / {
-	compatible = "ALL5002", "ralink,rt3352-soc";
+	compatible = "allnet,all5002", "ralink,rt3352-soc";
 	model = "Allnet ALL5002";
 
 	i2c-gpio {
@@ -11,7 +14,7 @@
 		#size-cells = <0>;
 
 		compatible = "i2c-gpio";
-		gpios = <&gpio0 1 0 &gpio0 2 0>;
+		gpios = <&gpio0 1 GPIO_ACTIVE_HIGH &gpio0 2 GPIO_ACTIVE_HIGH>;
 		i2c-gpio,delay-us = <10>;
 
 		pcf0: iexp@38 {
@@ -32,12 +35,12 @@
 
 		ld1 {
 			label = "all5002:green:ld1";
-			gpios = <&pcf0 0 1>;
+			gpios = <&pcf0 0 GPIO_ACTIVE_LOW>;
 		};
 
 		ld2 {
 			label = "all5002:green:ld2";
-			gpios = <&pcf0 1 1>;
+			gpios = <&pcf0 1 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/ALL5003.dts
+++ b/target/linux/ramips/dts/ALL5003.dts
@@ -2,8 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
 / {
-	compatible = "ALL5003", "ralink,rt5350-soc";
+	compatible = "allnet,all5003", "ralink,rt5350-soc";
 	model = "Allnet ALL5003";
 
 	i2c-gpio {
@@ -11,7 +14,7 @@
 		#size-cells = <0>;
 
 		compatible = "i2c-gpio";
-		gpios = <&gpio0 1 0 &gpio0 2 0>;
+		gpios = <&gpio0 1 GPIO_ACTIVE_HIGH &gpio0 2 GPIO_ACTIVE_HIGH>;
 		i2c-gpio,delay-us = <10>;
 
 		pcf0: iexp@38 {
@@ -32,12 +35,12 @@
 
 		ld1 {
 			label = "all5003:green:ld1";
-			gpios = <&pcf0 0 1>;
+			gpios = <&pcf0 0 1GPIO_ACTIVE_LOW>;
 		};
 
 		ld2 {
 			label = "all5003:green:ld2";
-			gpios = <&pcf0 1 1>;
+			gpios = <&pcf0 1 1GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/ASL26555-8M.dts
+++ b/target/linux/ramips/dts/ASL26555-8M.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ASL26555", "ralink,rt3050-soc";
+	compatible = "alpha,asl26555", "ralink,rt3050-soc";
 	model = "Alpha ASL26555 (8M)";
 
 	gpio-keys-polled {
@@ -16,13 +17,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 0>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 12 0>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
@@ -32,7 +33,7 @@
 
 		eth {
 			label = "asl26555:green:eth";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wan-red {
@@ -42,32 +43,32 @@
 
 		wan-green {
 			label = "asl26555:green:wan";
-			gpios = <&gpio0 2 0>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 		};
 
 		wlan {
 			label = "asl26555:green:wlan";
-			gpios = <&gpio0 7 0>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		power-green {
 			label = "asl26555:green:power";
-			gpios = <&gpio0 8 0>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		power-red {
 			label = "asl26555:red:power";
-			gpios = <&gpio0 9 0>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		3g-green {
 			label = "asl26555:green:3g";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		3g-red {
 			label = "asl26555:red:3g";
-			gpios = <&gpio0 17 1>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/ATP-52B.dts
+++ b/target/linux/ramips/dts/ATP-52B.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ATP-52B", "ralink,rt3052-soc";
+	compatible = "argus,atp-52b", "ralink,rt3052-soc";
 	model = "Argus ATP-52B";
 
 	cfi@1f000000 {
@@ -43,12 +44,12 @@
 
 		run {
 			label = "atp-52b:green:run";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		net {
 			label = "atp-52b:amber:net";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -60,13 +61,13 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/AWAPN2403.dts
+++ b/target/linux/ramips/dts/AWAPN2403.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "AWAPN2403", "ralink,rt3052-soc";
+	compatible = "asiarf,awapn2403", "ralink,rt3052-soc";
 	model = "AsiaRF AWAPN2403";
 
 	gpio-leds {
@@ -13,7 +14,7 @@
 
 		link {
 			label = "awapn2403:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -25,7 +26,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/AWM002-EVB-4M.dts
+++ b/target/linux/ramips/dts/AWM002-EVB-4M.dts
@@ -2,6 +2,7 @@
 
 #include "AWM002-4M.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
@@ -12,17 +13,17 @@
 
 		tx {
 			label = "awm002-evb:green:tx";
-			gpios = <&gpio0 15 1>;
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
 		};
 
 		rx {
 			label = "awm002-evb:green:rx";
-			gpios = <&gpio0 16 1>;
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "awm002-evb:green:wps";
-			gpios = <&gpio0 21 1>;
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -34,13 +35,13 @@
 
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 20 1>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/AWM002-EVB-8M.dts
+++ b/target/linux/ramips/dts/AWM002-EVB-8M.dts
@@ -2,6 +2,7 @@
 
 #include "AWM002-8M.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
@@ -12,17 +13,17 @@
 
 		tx {
 			label = "awm002-evb:green:tx";
-			gpios = <&gpio0 15 1>;
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
 		};
 
 		rx {
 			label = "awm002-evb:green:rx";
-			gpios = <&gpio0 16 1>;
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "awm002-evb:green:wps";
-			gpios = <&gpio0 21 1>;
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -34,13 +35,13 @@
 
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 20 1>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/AWM002.dtsi
+++ b/target/linux/ramips/dts/AWM002.dtsi
@@ -1,7 +1,7 @@
 #include "rt5350.dtsi"
 
 / {
-	compatible = "AWM002", "ralink,rt5350-soc";
+	compatible = "asiarf,awm002", "ralink,rt5350-soc";
 	model = "AsiaRF AWM002";
 };
 

--- a/target/linux/ramips/dts/AWM003-EVB.dts
+++ b/target/linux/ramips/dts/AWM003-EVB.dts
@@ -2,6 +2,7 @@
 
 #include "AWM002-8M.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
@@ -18,17 +19,17 @@
 
 		tx {
 			label = "awm003-evb:green:tx";
-			gpios = <&gpio0 15 1>;
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
 		};
 
 		rx {
 			label = "awm003-evb:green:rx";
-			gpios = <&gpio0 16 1>;
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "awm003-evb:green:wps";
-			gpios = <&gpio0 21 1>;
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -40,13 +41,13 @@
 
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 20 1>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/BROADWAY.dts
+++ b/target/linux/ramips/dts/BROADWAY.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "BROADWAY", "ralink,rt3052-soc";
+	compatible = "hauppauge,broadway", "ralink,rt3052-soc";
 	model = "Hauppauge Broadway";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		diskmounted {
 			label = "broadway:red:diskmounted";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wps_active {
 			label = "broadway:red:wps_active";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,7 +63,7 @@
 
 		factory {
 			label = "Factory Reset button";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/CARAMBOLA.dts
+++ b/target/linux/ramips/dts/CARAMBOLA.dts
@@ -2,8 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
 / {
-	compatible = "CARAMBOLA", "ralink,rt3050-soc";
+	compatible = "8devices,carambola", "ralink,rt3050-soc";
 	model = "8devices Carambola";
 
 	chosen {
@@ -44,7 +47,7 @@
 
 	i2c-gpio {
 		compatible = "i2c-gpio";
-		gpios = <&gpio0 1 0 &gpio0 2 0>;
+		gpios = <&gpio0 1 GPIO_ACTIVE_HIGH &gpio0 2 GPIO_ACTIVE_HIGH>;
 		i2c-gpio,delay-us = <10>;
 	};
 };

--- a/target/linux/ramips/dts/D105.dts
+++ b/target/linux/ramips/dts/D105.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "D105", "ralink,rt3050-soc";
+	compatible = "huawei,d105", "ralink,rt3050-soc";
 	model = "Huawei D105";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		power {
 			label = "d105:red:power";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "d105:green:usb";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,7 +63,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/DAP-1350.dts
+++ b/target/linux/ramips/dts/DAP-1350.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DAP-1350", "ralink,rt3052-soc";
+	compatible = "dlink,dap-1350", "ralink,rt3052-soc";
 	model = "D-Link DAP-1350";
 
 	chosen {
@@ -55,17 +56,17 @@
 
 		power {
 			label = "dap-1350:blue:power";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		power2 {
 			label = "dap-1350:red:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dap-1350:blue:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -77,25 +78,25 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		rt {
 			label = "rt";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 
 		ap {
 			label = "ap";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_1>;
 		};
 	};

--- a/target/linux/ramips/dts/DIR-300-B1.dts
+++ b/target/linux/ramips/dts/DIR-300-B1.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DIR-300-B1", "ralink,rt3050-soc";
+	compatible = "dlink,dir-300-b1", "ralink,rt3050-soc";
 	model = "D-Link DIR-300 B1";
 
 	cfi@1f000000 {
@@ -48,13 +49,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
@@ -64,27 +65,27 @@
 
 		status {
 			label = "dir-300-b1:amber:status";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		status2 {
 			label = "dir-300-b1:green:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
 			label = "dir-300-b1:amber:wan";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		wan2 {
 			label = "dir-300-b1:green:wan";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dir-300-b1:blue:wps";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/DIR-300-B7.dts
+++ b/target/linux/ramips/dts/DIR-300-B7.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DIR-300-B7", "ralink,rt5350-soc";
+	compatible = "dlink,dir-300-b7", "ralink,rt5350-soc";
 	model = "D-Link DIR-300 B7";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		status {
 			label = "dir-300-b7:green:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dir-300-b7:blue:wps";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,13 +31,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/DIR-320-B1.dts
+++ b/target/linux/ramips/dts/DIR-320-B1.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DIR-320-B1", "ralink,rt5350-soc";
+	compatible = "dlink,dir-320-b1", "ralink,rt5350-soc";
 	model = "D-Link DIR-320 B1";
 
 	gpio-leds {
@@ -13,17 +14,17 @@
 
 		status {
 			label = "dir-320-b1:green:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
 			label = "dir-320-b1:green:usb";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dir-320-b1:green:wps";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -35,13 +36,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
@@ -53,13 +54,13 @@
 		usb {
 			gpio-export,name = "usb";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 7 0>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		root_hub {
 			gpio-export,name = "root_hub";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 12 0>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/DIR-600-B1.dts
+++ b/target/linux/ramips/dts/DIR-600-B1.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DIR-600-B1", "ralink,rt3050-soc";
+	compatible = "dlink,dir-600-b1", "ralink,rt3050-soc";
 	model = "D-Link DIR-600 B1";
 
 	cfi@1f000000 {
@@ -48,13 +49,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
@@ -64,27 +65,27 @@
 
 		status {
 			label = "dir-600-b1:amber:status";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		status2 {
 			label = "dir-600-b1:green:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
 			label = "dir-600-b1:amber:wan";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		wan2 {
 			label = "dir-600-b1:green:wan";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dir-600-b1:blue:wps";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/DIR-610-A1.dts
+++ b/target/linux/ramips/dts/DIR-610-A1.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DIR-610-A1", "ralink,rt5350-soc";
+	compatible = "dlink,dir-610-a1", "ralink,rt5350-soc";
 	model = "D-Link DIR-610 A1";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		status {
 			label = "dir-610-a1:green:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dir-610-a1:green:wps";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,13 +31,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/DIR-615-D.dts
+++ b/target/linux/ramips/dts/DIR-615-D.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DIR-615-D", "ralink,rt3050-soc";
+	compatible = "dlink,dir-615-d", "ralink,rt3050-soc";
 	model = "D-Link DIR-615 D";
 
 	cfi@1f000000 {
@@ -48,13 +49,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
@@ -64,27 +65,27 @@
 
 		status {
 			label = "dir-615-d:amber:status";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		status2 {
 			label = "dir-615-d:green:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
 			label = "dir-615-d:amber:wan";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		wan2 {
 			label = "dir-615-d:green:wan";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dir-615-d:blue:wps";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/DIR-615-H1.dts
+++ b/target/linux/ramips/dts/DIR-615-H1.dts
@@ -2,10 +2,11 @@
 
 #include "rt3352.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DIR-615-H1", "ralink,rt3352-soc";
+	compatible = "dlink,dir-615-h1", "ralink,rt3352-soc";
 	model = "D-Link DIR-615 H1";
 
 	gpio-leds {
@@ -13,27 +14,27 @@
 
 		status {
 			label = "dir-615-h1:amber:status";
-			gpios = <&gpio0 7 0>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		status2 {
 			label = "dir-615-h1:green:status";
-			gpios = <&gpio0 9 0>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		wan {
 			label = "dir-615-h1:amber:wan";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wan2 {
 			label = "dir-615-h1:green:wan";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dir-615-h1:blue:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -45,13 +46,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/DIR-620-A1.dts
+++ b/target/linux/ramips/dts/DIR-620-A1.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DIR-620-A1", "ralink,rt3050-soc";
+	compatible = "dlink,dir-620-a1", "ralink,rt3050-soc";
 	model = "D-Link DIR-620 A1";
 
 	cfi@1f000000 {
@@ -48,13 +49,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
@@ -64,32 +65,32 @@
 
 		status {
 			label = "dir-620-a1:amber:status";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		status2 {
 			label = "dir-620-a1:green:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
 			label = "dir-620-a1:amber:wan";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		wan2 {
 			label = "dir-620-a1:green:wan";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dir-620-a1:blue:wps";
-			gpios = <&gpio0 13 0>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
 		};
 
 		wps2 {
 			label = "dir-620-a1:amber:wps";
-			gpios = <&gpio0 11 0>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/DIR-620-D1.dts
+++ b/target/linux/ramips/dts/DIR-620-D1.dts
@@ -2,10 +2,11 @@
 
 #include "rt3352.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DIR-620-D1", "ralink,rt3352-soc";
+	compatible = "dlink,dir-620-d1", "ralink,rt3352-soc";
 	model = "D-Link DIR-620 D1";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		status {
 			label = "dir-620-d1:green:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wifi {
 			label = "dir-620-d1:green:wifi";
-			gpios = <&gpio0 17 1>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,7 +31,7 @@
 
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/DWR-512-B.dts
+++ b/target/linux/ramips/dts/DWR-512-B.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ralink,rt5350-soc";
+	compatible = "dlink,rt5350-soc";
 	model = "D-Link DWR-512 B";
 
 	gpio-keys-polled {

--- a/target/linux/ramips/dts/ESR-9753.dts
+++ b/target/linux/ramips/dts/ESR-9753.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ESR-9753", "ralink,rt3052-soc";
+	compatible = "engenius,esr-9753", "ralink,rt3052-soc";
 	model = "Senao / EnGenius ESR-9753";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		power {
 			label = "esr-9753:orange:power";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "esr-9753:orange:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,13 +63,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/F5D8235_V2.dts
+++ b/target/linux/ramips/dts/F5D8235_V2.dts
@@ -2,8 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
 / {
-	compatible = "F5D8235_V2", "ralink,rt3052-soc";
+	compatible = "belkin,f5d8235_v2", "ralink,rt3052-soc";
 	model = "Belkin F5D8235 v2";
 
 	cfi@1f000000 {
@@ -38,8 +41,8 @@
 
 	rtl8366rb {
 		compatible = "realtek,rtl8366rb";
-		gpio-sda = <&gpio0 1 0>;
-		gpio-sck = <&gpio0 2 0>;
+		gpio-sda = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 	};
 
 	gpio-leds {
@@ -47,47 +50,47 @@
 
 		internet {
 			label = "f5d8235-v2:blue:internet";
-			gpios = <&gpio0 5 1>;
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
 		};
 
 		internet2 {
 			label = "f5d8235-v2:amber:internet";
-			gpios = <&gpio0 6 1>;
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
 		};
 
 		modem {
 			label = "f5d8235-v2:blue:modem";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		modem2 {
 			label = "f5d8235-v2:amber:modem";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		router {
 			label = "f5d8235-v2:blue:router";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		storage {
 			label = "f5d8235-v2:blue:storage";
-			gpios = <&gpio0 23 1>;
+			gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		};
 
 		storage2 {
 			label = "f5d8235-v2:amber:storage";
-			gpios = <&gpio0 22 1>;
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		};
 
 		security {
 			label = "f5d8235-v2:blue:security";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		security2 {
 			label = "f5d8235-v2:amber:security";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/F7C027.dts
+++ b/target/linux/ramips/dts/F7C027.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "F7C027", "ralink,rt5350-soc";
+	compatible = "belkin,f7c027", "ralink,rt5350-soc";
 	model = "Belkin F7C027";
 
 	gpio-leds {
@@ -13,22 +14,22 @@
 
 		status {
 			label = "f7c027:blue:status";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "f7c027:blue:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		orange {
 			label = "f7c027:orange:status";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		relay {
 			label = "f7c027:device:relay";
-			gpios = <&gpio0 13 0>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
@@ -40,19 +41,19 @@
 
 		top {
 			label = "restore";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		power {
 			label = "power";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
 		};
 
 		sensor {
 			label = "sensor";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/FONERA20N.dts
+++ b/target/linux/ramips/dts/FONERA20N.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "FONERA20N", "ralink,rt3052-soc";
+	compatible = "fon,fonera20n", "ralink,rt3052-soc";
 	model = "La Fonera 2.0N";
 
 	cfi@1f000000 {
@@ -45,17 +46,17 @@
 
 		wifi {
 			label = "fonera20n:orange:wifi";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "fonera20n:green:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
 			label = "fonera20n:orange:usb";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -67,13 +68,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		switch {
 			label = "switch";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
 			linux,input-type = <EV_SW>;
 		};

--- a/target/linux/ramips/dts/FREESTATION5.dts
+++ b/target/linux/ramips/dts/FREESTATION5.dts
@@ -2,8 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
 / {
-	compatible = "FREESTATION5", "ralink,rt3050-soc";
+	compatible = "arc,freestation5", "ralink,rt3050-soc";
 	model = "ARC FreeStation5";
 
 	chosen {
@@ -50,7 +53,7 @@
 		poe {
 			gpio-export,name = "poe-passthrough";
 			gpio-export,output = <1>; // OUT_INIT_HIGH
-			gpios = <&gpio0 11 1>;    // GPIO 11, ACTIVE_LOW
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;    // GPIO 11, ACTIVE_LOW
 		};
 	};
 
@@ -61,17 +64,17 @@
 		// not present in the Freestation5 device.
 		wifi {
 			label = "freestation5:unknown:wifi";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		powerg {
 			label = "freestation5:unknown:powerg";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
 			label = "freestation5:unknown:usb";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/HLKRM04.dts
+++ b/target/linux/ramips/dts/HLKRM04.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "HLKRM04", "ralink,rt5350-soc";
+	compatible = "hilink,hlkrm04", "ralink,rt5350-soc";
 	model = "HILINK HLK-RM04";
 
 	memory@0 {
@@ -26,13 +27,13 @@
 			/* I2C_I2C_SD */
 			gpio-export,name = "hlk-rm04:gpio0";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 1 0>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
 		};
 		gpio2 {
 			/* I2C_I2C_SCLK */
 			gpio-export,name = "hlk-rm04:gpio1";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 2 0>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
@@ -43,12 +44,12 @@
 		poll-interval = <20>;
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 		wps {
 			label = "wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/HT-TM02.dts
+++ b/target/linux/ramips/dts/HT-TM02.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "HT-TM02", "ralink,rt5350-soc";
+	compatible = "hootoo,ht-tm02", "ralink,rt5350-soc";
 	model = "HooToo HT-TM02";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		wlan {
 			label = "ht-tm02:blue:wlan";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		lan {
 			label = "ht-tm02:green:lan";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,13 +31,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		modeswitch {
 			label = "modeswitch";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 			linux,input-type = <EV_SW>;
 		};

--- a/target/linux/ramips/dts/HW550-3G.dts
+++ b/target/linux/ramips/dts/HW550-3G.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "HW550-3G", "ralink,rt3052-soc";
+	compatible = "aztech,hw550-3g", "ralink,rt3052-soc";
 	model = "Aztech HW550-3G";
 
 	cfi@1f000000 {
@@ -45,22 +46,22 @@
 
 		usb {
 			label = "hw550-3g:green:usb";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		3g {
 			label = "hw550-3g:green:3g";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		status {
 			label = "hw550-3g:green:status";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "hw550-3g:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -72,19 +73,19 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		connect {
 			label = "connect";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_CONNECT>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/IP2202.dts
+++ b/target/linux/ramips/dts/IP2202.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "IP2202", "ralink,rt3052-soc";
+	compatible = "poray,ip2202", "ralink,rt3052-soc";
 	model = "Poray IP2202";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		run {
 			label = "ip2202:green:run";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		net {
 			label = "ip2202:amber:net";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,7 +63,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/JHR-N805R.dts
+++ b/target/linux/ramips/dts/JHR-N805R.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "JHR-N805R", "ralink,rt3050-soc";
+	compatible = "jcg,jhr-n805r", "ralink,rt3050-soc";
 	model = "JCG JHR-N805R";
 
 	gpio-leds {
@@ -13,7 +14,7 @@
 
 		system {
 			label = "jhr-n805r:blue:system";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -25,7 +26,7 @@
 
                 reset {
                         label = "reset";
-                        gpios = <&gpio0 10 1>;
+                        gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
                         linux,code = <KEY_RESTART>;
                 };
 	};

--- a/target/linux/ramips/dts/JHR-N825R.dts
+++ b/target/linux/ramips/dts/JHR-N825R.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "JHR-N825R", "ralink,rt3052-soc";
+	compatible = "jcg,jhr-n825r", "ralink,rt3052-soc";
 	model = "JCG JHR-N825R";
 
 	cfi@1f000000 {
@@ -44,7 +45,7 @@
 		compatible = "gpio-leds";
 		system {
 			label = "jhr-n825r:red:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -55,7 +56,7 @@
 		poll-interval = <20>;
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/JHR-N926R.dts
+++ b/target/linux/ramips/dts/JHR-N926R.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "JHR-N926R", "ralink,rt3052-soc";
+	compatible = "jcg,jhr-n926r", "ralink,rt3052-soc";
 	model = "JCG JHR-N926R";
 
 	cfi@1f000000 {
@@ -45,22 +46,22 @@
 
 		wlan1 {
 			label = "jhr-n926r:red:wlan";
-			gpios = <&gpio0 20 1>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan2 {
 			label = "jhr-n926r:yellow:wlan";
-			gpios = <&gpio0 19 1>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan3 {
 			label = "jhr-n926r:green:wlan";
-			gpios = <&gpio0 17 1>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 
 		system {
 			label = "jhr-n926r:blue:system";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -71,19 +72,19 @@
 		display_data {
 			gpio-export,name = "display_data";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		display_clock {
 			gpio-export,name = "display_clock";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 8 0>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		display_blank {
 			gpio-export,name = "display_blank";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 11 0>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
@@ -95,13 +96,13 @@
 
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wlan {
 			label = "wlan";
-			gpios = <&gpio0 1 1>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/M2M.dts
+++ b/target/linux/ramips/dts/M2M.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "M2M", "ralink,rt5350-soc";
+	compatible = "intenso,m2m", "ralink,rt5350-soc";
 	model = "Intenso Memory 2 Move";
 
 	chosen {
@@ -17,12 +18,12 @@
 
 		wifi {
 			label = "m2m:blue:wifi";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
 			label = "m2m:green:wan";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -34,13 +35,13 @@
 
 		power {
 			label = "power";
-			gpios = <&gpio0 1 1>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_POWER>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/M3.dts
+++ b/target/linux/ramips/dts/M3.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "M3", "ralink,rt5350-soc";
+	compatible = "poray,m3", "ralink,rt5350-soc";
 	model = "Poray M3";
 
 	gpio-leds {
@@ -13,7 +14,7 @@
 
 		status {
 			label = "m3:blue:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -25,13 +26,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 17 1>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 			linux,input-type = <EV_SW>;
 		};

--- a/target/linux/ramips/dts/M4-4M.dts
+++ b/target/linux/ramips/dts/M4-4M.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "M4", "ralink,rt5350-soc";
+	compatible = "poray,m4", "ralink,rt5350-soc";
 	model = "Poray M4 (4M)";
 
 	gpio-leds {
@@ -13,7 +14,7 @@
 
 		status {
 			label = "m4:blue:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -25,7 +26,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/M4-8M.dts
+++ b/target/linux/ramips/dts/M4-8M.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "M4", "ralink,rt5350-soc";
+	compatible = "poray,m4", "ralink,rt5350-soc";
 	model = "Poray M4 (8M)";
 
 	gpio-leds {
@@ -13,7 +14,7 @@
 
 		status {
 			label = "m4:blue:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -25,7 +26,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/MINIEMBPLUG.dts
+++ b/target/linux/ramips/dts/MINIEMBPLUG.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "MINIEMBPLUG", "ralink,rt5350-soc";
+	compatible = "omnima,miniembplug", "ralink,rt5350-soc";
 	model = "Omnima MiniEMBPlug";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		wlan {
 			label = "miniembplug:red:wlan";
-			gpios = <&gpio0 9 0>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		mobile {
 			label = "miniembplug:green:mobile";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,25 +31,25 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		mode-one {
 			label = "mode1";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		mode-two {
 			label = "mode2";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/MOFI3500-3GN.dts
+++ b/target/linux/ramips/dts/MOFI3500-3GN.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "MOFI3500-3GN", "ralink,rt3052-soc";
+	compatible = "mofinetwork,mofi3500-3gn", "ralink,rt3052-soc";
 	model = "MoFi Network MOFI3500-3GN";
 
 	cfi@1f000000 {
@@ -45,22 +46,22 @@
 
 		usb {
 			label = "mofi3500-3gn:green:usb";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		3g {
 			label = "mofi3500-3gn:green:3g";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		status {
 			label = "mofi3500-3gn:green:status";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "mofi3500-3gn:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -72,19 +73,19 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		connect {
 			label = "connect";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_CONNECT>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/MPRA1.dts
+++ b/target/linux/ramips/dts/MPRA1.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "MPRA1", "ralink,rt5350-soc";
+	compatible = "hame,mpra1", "ralink,rt5350-soc";
 	model = "HAME MPR-A1";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		system {
 			label = "mpr-a1:blue:system";
-			gpios = <&gpio0 20 1>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "mpr-a1:red:power";
-			gpios = <&gpio0 17 1>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,7 +31,7 @@
 
 		wps {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};
@@ -42,13 +43,13 @@
 		usb {
 			gpio-export,name = "usb";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 7 0>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		root_hub {
 			gpio-export,name = "root_hub";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 12 0>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/MPRA2.dts
+++ b/target/linux/ramips/dts/MPRA2.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "MPRA2", "ralink,rt5350-soc";
+	compatible = "hame,mpra2", "ralink,rt5350-soc";
 	model = "HAME MPR-A2";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		system {
 			label = "mpr-a2:blue:system";
-			gpios = <&gpio0 20 1>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "mpr-a2:red:power";
-			gpios = <&gpio0 17 1>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,7 +31,7 @@
 
 		wps {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};
@@ -42,13 +43,13 @@
 		usb {
 			gpio-export,name = "usb";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 7 0>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		root_hub {
 			gpio-export,name = "root_hub";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 12 0>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/MR-102N.dts
+++ b/target/linux/ramips/dts/MR-102N.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "MR-102N", "ralink,rt3052-soc";
+	compatible = "aximcom,MR-102N", "ralink,rt3052-soc";
 	model = "AXIMCom MR-102N";
 
 	cfi@1f000000 {
@@ -55,17 +56,17 @@
 
 		usb {
 			label = "mr-102n:green:usb";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		status {
 			label = "mr-102n:amber:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
 			label = "mr-102n:green:wlan";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -77,13 +78,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 18 1>;
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/MZK-DP150N.dts
+++ b/target/linux/ramips/dts/MZK-DP150N.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "MZK-DP150N", "ralink,rt5350-soc";
+	compatible = "planex,mzk-dp150n", "ralink,rt5350-soc";
 	model = "Planex MZK-DP150N";
 
 	gpio-leds {
@@ -13,7 +14,7 @@
 
 		power {
 			label = "mzk-dp150n:green:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -25,7 +26,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/MZK-W300NH2.dts
+++ b/target/linux/ramips/dts/MZK-W300NH2.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "MZK-W300NH2", "ralink,rt3052-soc";
+	compatible = "planex,mzk-w300nh2", "ralink,rt3052-soc";
 	model = "Planex MZK-W300NH2";
 
 	cfi@1f000000 {
@@ -51,17 +52,17 @@
 
 		power {
 			label = "mzk-w300nh2:green:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
 			label = "mzk-w300nh2:amber:wlan";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "mzk-w300nh2:amber:wps";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -73,19 +74,19 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		rt {
 			label = "rt";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/NBG-419N.dts
+++ b/target/linux/ramips/dts/NBG-419N.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "NBG-419N", "ralink,rt3052-soc";
+	compatible = "zyxel,nbg-419n", "ralink,rt3052-soc";
 	model = "ZyXEL NBG-419N";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		power {
 			label = "nbg-419n:green:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "nbg-419n:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,13 +63,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/NBG-419N2.dts
+++ b/target/linux/ramips/dts/NBG-419N2.dts
@@ -2,10 +2,11 @@
 
 #include "rt3352.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "NBG-419N2", "ralink,rt3352-soc";
+	compatible = "zyxel,nbg-419n2", "ralink,rt3352-soc";
 	model = "ZyXEL NBG-419N v2";
 
 	palmbus@10000000 {
@@ -49,17 +50,17 @@
 
 		power {
 			label = "nbg-419n2:green:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "nbg-419n2:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
 			label = "nbg-419n2:green:usb";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -70,18 +71,18 @@
 		poll-interval = <20>;
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 		rfkill {
 			label = "rfkill";
 			linux,input-type = <EV_SW>;
-			gpios = <&gpio0 12 0>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_RFKILL>;
 		};
 	};

--- a/target/linux/ramips/dts/NCS601W.dts
+++ b/target/linux/ramips/dts/NCS601W.dts
@@ -3,7 +3,7 @@
 #include "rt5350.dtsi"
 
 / {
-	compatible = "NCS601W", "ralink,rt5350-soc";
+	compatible = "wansview,ncs601w", "ralink,rt5350-soc";
 	model = "Wansview NCS601W";
 };
 

--- a/target/linux/ramips/dts/NIXCORE.dtsi
+++ b/target/linux/ramips/dts/NIXCORE.dtsi
@@ -1,7 +1,7 @@
 #include "rt5350.dtsi"
 
 / {
-	compatible = "Nixcore", "ralink,rt5350-soc";
+	compatible = "nixcore", "ralink,rt5350-soc";
 
 	chosen {
 		bootargs = "console=ttyS1,57600";
@@ -14,13 +14,13 @@
 		gpio0 {
 			gpio-export,name = "gpio0";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 0 0>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio1 {
 			gpio-export,name = "gpio1";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 0 0>;
+			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
 		};
 
 		/* GPIOs 1-6 are I2C,SPI */
@@ -32,35 +32,35 @@
 			/* JTAG_TDO */
 			gpio-export,name = "gpio17";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 17 0>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio18 {
 			/* JTAG_TDI */
 			gpio-export,name = "gpio18";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 18 0>;
+			gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio19 {
 			/* JTAG_TMS */
 			gpio-export,name = "gpio19";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 19 0>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio20 {
 			/* JTAG_TCLK */
 			gpio-export,name = "gpio20";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 20 0>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio21 {
 			/* JTAG_TRST_N */
 			gpio-export,name = "gpio21";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 21 0>;
+			gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
 		};
 
 		/* ETH LEDs */
@@ -68,25 +68,25 @@
 		gpio22 {
 			gpio-export,name = "gpio22";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 0 0>;
+			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio23 {
 			gpio-export,name = "gpio23";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 1 0>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio24 {
 			gpio-export,name = "gpio24";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 2 0>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio25 {
 			gpio-export,name = "gpio25";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 3 0>;
+			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
 		};
 
 		*/
@@ -94,14 +94,14 @@
 			/* ETH4_LED */
 			gpio-export,name = "gpio26";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 4 0>;
+			gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio27 {
 			/* spi_cs1 */
 			gpio-export,name = "gpio27";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 5 0>;
+			gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/NW718.dts
+++ b/target/linux/ramips/dts/NW718.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "NW718", "ralink,rt3050-soc";
+	compatible = "netcore,nw718", "ralink,rt3050-soc";
 	model = "Netcore NW718";
 
 	gpio-leds {
@@ -13,17 +14,17 @@
 
 		cpu {
 			label = "nw718:amber:cpu";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
 			label = "nw718:amber:usb";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "nw718:amber:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -35,13 +36,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/PSR-680W.dts
+++ b/target/linux/ramips/dts/PSR-680W.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "PSR-680W", "ralink,rt3052-soc";
+	compatible = "petatel,psr-680w", "ralink,rt3052-soc";
 	model = "Petatel PSR-680W Wireless 3G Router";
 
 	chosen {
@@ -49,7 +50,7 @@
 
 		wan {
 			label = "psr-680w:red:wan";
-			gpios = <&gpio0 19 1>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -61,7 +62,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/PWH2004.dts
+++ b/target/linux/ramips/dts/PWH2004.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "PWH2004", "ralink,rt3052-soc";
+	compatible = "prolink,pwh2004", "ralink,rt3052-soc";
 	model = "Prolink PWH2004";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		wifi {
 			label = "pwh2004:red:wifi";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "pwh2004:green:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,7 +63,7 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/PX-4885.dtsi
+++ b/target/linux/ramips/dts/PX-4885.dtsi
@@ -3,7 +3,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "PX-4885", "ralink,rt5350-soc";
+	compatible = "7Links,px-4885", "ralink,rt5350-soc";
 
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
@@ -13,7 +13,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};
@@ -23,12 +23,12 @@
 
 		orange {
 			label = "px-4885:orange:wifi";
-			gpios = <&gpio0 18 1>;
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
 		};
 
 		blue {
 			label = "px-4885:blue:storage";
-			gpios = <&gpio0 19 1>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/RT-G32-B1.dts
+++ b/target/linux/ramips/dts/RT-G32-B1.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "RT-G32-B1", "ralink,rt3050-soc";
+	compatible = "asus,rt-g32-b1", "ralink,rt3050-soc";
 	model = "Asus RT-G32 B1";
 
 	gpio-keys-polled {
@@ -16,13 +17,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/RT-N10-PLUS.dts
+++ b/target/linux/ramips/dts/RT-N10-PLUS.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "RT-N10-PLUS", "ralink,rt3050-soc";
+	compatible = "asus,rt-n10-plus", "ralink,rt3050-soc";
 	model = "Asus RT-N10+";
 
 	cfi@1f000000 {
@@ -45,7 +46,7 @@
 
 		wps {
 			label = "rt-n10-plus:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -57,13 +58,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/RT-N13U.dts
+++ b/target/linux/ramips/dts/RT-N13U.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "RT-N13U", "ralink,rt3052-soc";
+	compatible = "asus,rt-n13u", "ralink,rt3052-soc";
 	model = "Asus RT-N13U";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		power {
 			label = "rt-n13u:blue:power";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wifi {
 			label = "rt-n13u:blue:wifi";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,13 +63,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/RT5350F-OLINUXINO.dts
+++ b/target/linux/ramips/dts/RT5350F-OLINUXINO.dts
@@ -3,7 +3,7 @@
 #include "rt5350.dtsi"
 
 / {
-	compatible = "RT5350F-OLINUXINO", "ralink,rt5350-soc";
+	compatible = "olimex,rt5350f-olinuxino", "ralink,rt5350-soc";
 	model = "Olimex RT5350F-OLinuXino";
 };
 

--- a/target/linux/ramips/dts/RUT5XX.dts
+++ b/target/linux/ramips/dts/RUT5XX.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "RUT5XX", "ralink,rt3050-soc";
+	compatible = "teltonika,rut5XX", "ralink,rt3050-soc";
 	model = "Teltonika RUT5XX";
 
 	gpio-leds {
@@ -13,7 +14,7 @@
 
 		status {
 			label = "rut5xx:green:status";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -25,7 +26,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/SL-R7205.dts
+++ b/target/linux/ramips/dts/SL-R7205.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "SL-R7205", "ralink,rt3052-soc";
+	compatible = "skyline,sl-r7205", "ralink,rt3052-soc";
 	model = "Skyline SL-R7205 Wireless 3G Router";
 
 	cfi@1f000000 {
@@ -45,7 +46,7 @@
 
 		wifi {
 			label = "sl-r7205:green:wifi";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -57,13 +58,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/TEW-714TRU.dts
+++ b/target/linux/ramips/dts/TEW-714TRU.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "TEW-714TRU", "ralink,rt5350-soc";
+	compatible = "trendnet,tew-714tru", "ralink,rt5350-soc";
 	model = "TRENDnet TEW714TRU";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		usb {
 			label = "tew-714tru:red:usb";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wifi {
 			label = "tew-714tru:green:wifi";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,13 +31,13 @@
 
                 reset {
                         label = "reset";
-                        gpios = <&gpio0 10 1>;
+                        gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
                         linux,code = <KEY_RESTART>;
                 };
 
                 wps {
                         label = "wps";
-                        gpios = <&gpio0 0 1>;
+                        gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
                         linux,code = <KEY_WPS_BUTTON>;
                 };
 	};

--- a/target/linux/ramips/dts/UR-326N4G.dts
+++ b/target/linux/ramips/dts/UR-326N4G.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "UR-326N4G", "ralink,rt3052-soc";
+	compatible = "upvel,ur-326n4g", "ralink,rt3052-soc";
 	model = "UPVEL UR-326N4G";
 
 	cfi@1f000000 {
@@ -45,27 +46,27 @@
 
 		3g {
 			label = "ur-326n4g:green:3g";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		gateway {
 			label = "ur-326n4g:green:gateway";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		ap {
 			label = "ur-326n4g:green:ap";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "ur-326n4g:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		station {
 			label = "ur-326n4g:green:station";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -77,13 +78,13 @@
 
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/UR-336UN.dts
+++ b/target/linux/ramips/dts/UR-336UN.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "UR-336UN", "ralink,rt3052-soc";
+	compatible = "upvel,ur-336un", "ralink,rt3052-soc";
 	model = "UPVEL UR-336UN";
 
 	cfi@1f000000 {
@@ -22,27 +23,27 @@
 
 		3g {
 			label = "ur-336un:green:3g";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		gateway {
 			label = "ur-336un:green:gateway";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		ap {
 			label = "ur-336un:green:ap";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "ur-336un:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		station {
 			label = "ur-336un:green:station";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -54,13 +55,13 @@
 
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/V22RW-2X2.dts
+++ b/target/linux/ramips/dts/V22RW-2X2.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "V22RW-2X2", "ralink,rt3052-soc";
+	compatible = "ralink,v22rw-2x2", "ralink,rt3052-soc";
 	model = "Ralink AP-RT3052-V22RW-2X2";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		security {
 			label = "v22rw-2x2:green:security";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "v22rw-2x2:red:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,13 +63,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/VOCORE.dtsi
+++ b/target/linux/ramips/dts/VOCORE.dtsi
@@ -1,7 +1,10 @@
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
 / {
-	compatible = "VoCore", "ralink,rt5350-soc";
+	compatible = "vocore,vocore", "ralink,rt5350-soc";
 
 	gpio-export {
 		compatible = "gpio-export";
@@ -10,7 +13,7 @@
 		gpio0 {
 			gpio-export,name = "gpio0";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 0 0>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
 		};
 
 		/* UARTF */
@@ -18,42 +21,42 @@
 			/* UARTF_RTS_N */
 			gpio-export,name = "gpio7";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 7 0>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio8 {
 			/* UARTF_TXD */
 			gpio-export,name = "gpio8";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 8 0>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio9 {
 			/* UARTF_CTS_N */
 			gpio-export,name = "gpio9";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 9 0>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio12 {
 			/* UARTF_DCD_N */
 			gpio-export,name = "gpio12";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 12 0>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio13 {
 			/* UARTF_DSR_N */
 			gpio-export,name = "gpio13";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 13 0>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio14 {
 			/* UARTF_RIN */
 			gpio-export,name = "gpio14";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 14 0>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
 		};
 
 		/* JTAG */
@@ -61,35 +64,35 @@
 			/* JTAG_TDO */
 			gpio-export,name = "gpio17";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 17 0>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio18 {
 			/* JTAG_TDI */
 			gpio-export,name = "gpio18";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 18 0>;
+			gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio19 {
 			/* JTAG_TMS */
 			gpio-export,name = "gpio19";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 19 0>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio20 {
 			/* JTAG_TCLK */
 			gpio-export,name = "gpio20";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 20 0>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio21 {
 			/* JTAG_TRST_N */
 			gpio-export,name = "gpio21";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio0 21 0>;
+			gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
 		};
 
 		/* ETH LEDs */
@@ -97,35 +100,35 @@
 			/* ETH0_LED */
 			gpio-export,name = "gpio22";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 0 0>;
+			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio23 {
 			/* ETH1_LED */
 			gpio-export,name = "gpio23";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 1 0>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio24 {
 			/* ETH2_LED */
 			gpio-export,name = "gpio24";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 2 0>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio25 {
 			/* ETH3_LED */
 			gpio-export,name = "gpio25";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 3 0>;
+			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
 		};
 
 		gpio26 {
 			/* ETH4_LED */
 			gpio-export,name = "gpio26";
 			gpio-export,direction_may_change = <1>;
-			gpios = <&gpio1 4 0>;
+			gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
@@ -135,13 +138,13 @@
 		status {
 			/* UARTF_RXD */
 			label = "vocore:green:status";
-			gpios = <&gpio0 10 0>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
 		};
 
 		eth {
 			/* UARTF_DTR_N */
 			label = "vocore:orange:eth";
-			gpios = <&gpio0 11 0>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/W150M.dts
+++ b/target/linux/ramips/dts/W150M.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "W150M", "ralink,rt3050-soc";
+	compatible = "tenda,w150m", "ralink,rt3050-soc";
 	model = "Tenda W150M";
 
 	cfi@1f000000 {
@@ -45,32 +46,32 @@
 
 		3grouter {
 			label = "w150m:blue:3grouter";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		ap {
 			label = "w150m:blue:ap";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wisprouter {
 			label = "w150m:blue:wisprouter";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wirelessrouter {
 			label = "w150m:blue:wirelessrouter";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		3g {
 			label = "w150m:blue:3g";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wpsreset {
 			label = "w150m:blue:wpsreset";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -82,13 +83,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/W306R_V20.dts
+++ b/target/linux/ramips/dts/W306R_V20.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "W306R_V20", "ralink,rt3052-soc";
+	compatible = "tenda,w306r_v20", "ralink,rt3052-soc";
 	model = "Tenda W306R V2.0";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		sys {
 			label = "w306r-v20:green:sys";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "w306r-v20:green:wps";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,7 +63,7 @@
 
 		reset {
 			label = "RESET/WPS";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/W502U.dts
+++ b/target/linux/ramips/dts/W502U.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "W502U", "ralink,rt3052-soc";
+	compatible = "alfanetworks,w502u", "ralink,rt3052-soc";
 	model = "ALFA Networks W502U";
 
 	chosen {
@@ -49,12 +50,12 @@
 
 		usb {
 			label = "w502u:blue:usb";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "w502u:blue:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -66,13 +67,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/WCR150GN.dts
+++ b/target/linux/ramips/dts/WCR150GN.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "WCR150GN", "ralink,rt3050-soc";
+	compatible = "sparklan,wcr150gn", "ralink,rt3050-soc";
 	model = "Sparklan WCR-150GN";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		user {
 			label = "wcr-150gn:amber:user";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "wcr-150gn:amber:power";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,13 +63,13 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/WIZARD8800.dts
+++ b/target/linux/ramips/dts/WIZARD8800.dts
@@ -3,7 +3,7 @@
 #include "rt5350.dtsi"
 
 / {
-	compatible = "WIZARD8800", "ralink,rt5350-soc";
+	compatible = "easyacc,wizard8800", "ralink,rt5350-soc";
 	model = "EASYACC WI-STOR WIZARD 8800";
 };
 

--- a/target/linux/ramips/dts/WIZFI630A.dts
+++ b/target/linux/ramips/dts/WIZFI630A.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "wizfi630a", "ralink,rt5350-soc";
+	compatible = "wiznet,wizfi630a", "ralink,rt5350-soc";
 	model = "WIZnet WizFi630A";
 
 	chosen {
@@ -22,22 +23,22 @@
 
 		run {
 			label = "wizfi630a::run";
-			gpios = <&gpio0 1 1>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "wizfi630a::wps";
-			gpios = <&gpio0 20 1>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 		};
 
 		uart1 {
 			label = "wizfi630a::uart1";
-			gpios = <&gpio0 18 1>;
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
 		};
 
 		uart2 {
 			label = "wizfi630a::uart2";
-			gpios = <&gpio0 21 1>;
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -49,25 +50,25 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 17 1>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 		
 		scm1 {
 			label = "SCM1";
-			gpios = <&gpio0 19 1>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 
 		scm2 {
 			label = "SCM2";
-			gpios = <&gpio0 2 1>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_1>;
 		};
 	};

--- a/target/linux/ramips/dts/WL-330N.dts
+++ b/target/linux/ramips/dts/WL-330N.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "WL-330N", "ralink,rt3050-soc";
+	compatible = "asus,wl-330n", "ralink,rt3050-soc";
 	model = "Asus WL-330N";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		link {
 			label = "wl-330n:blue:link";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "wl-330n:blue:power";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,13 +31,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/WL-330N3G.dts
+++ b/target/linux/ramips/dts/WL-330N3G.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "WL-330N3G", "ralink,rt3050-soc";
+	compatible = "asus,wl-330n3g", "ralink,rt3050-soc";
 	model = "Asus WL-330N3G";
 
 	gpio-leds {
@@ -13,17 +14,17 @@
 
 		3g {
 			label = "wl-330n3g:blue:3g";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		3g2 {
 			label = "wl-330n3g:red:3g";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "wl-330n3g:blue:power";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -35,13 +36,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/WL-351.dts
+++ b/target/linux/ramips/dts/WL-351.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "WL-351", "ralink,rt3052-soc";
+	compatible = "sitecom,wl-351", "ralink,rt3052-soc";
 	model = "Sitecom WL-351 v1 002";
 
 	cfi@1f000000 {
@@ -45,17 +46,17 @@
 
 		power {
 			label = "wl-351:amber:power";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		unpopulated {
 			label = "wl-351:amber:unpopulated";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		unpopulated2 {
 			label = "wl-351:blue:unpopulated";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -67,21 +68,21 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
 
 	rtl8366rb {
 		compatible = "realtek,rtl8366rb";
-		gpio-sda = <&gpio0 1 0>;
-		gpio-sck = <&gpio0 2 0>;
+		gpio-sda = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/target/linux/ramips/dts/WNCE2001.dts
+++ b/target/linux/ramips/dts/WNCE2001.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "WNCE2001", "ralink,rt3052-soc";
+	compatible = "netgear,wnce2001", "ralink,rt3052-soc";
 	model = "Netgear WNCE2001";
 
 	chosen {
@@ -17,22 +18,22 @@
 
 		power-green {
 			label = "wnce2001:green:power";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		power-red {
 			label = "wnce2001:red:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan-green {
 			label = "wnce2001:green:wlan";
-			gpios = <&gpio0 12 0>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		};
 
 		wlan-red {
 			label = "wnce2001:red:wlan";
-			gpios = <&gpio0 13 0>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
@@ -44,25 +45,25 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		rt {
 			label = "rt";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 
 		ap {
 			label = "ap";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_1>;
 		};
 	};

--- a/target/linux/ramips/dts/WR512-3GN-4M.dts
+++ b/target/linux/ramips/dts/WR512-3GN-4M.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "WR512-3GN", "ralink,rt3052-soc";
+	compatible = "generic,wr512-3gn", "ralink,rt3052-soc";
 	model = "WR512-3GN (4M)";
 
 	cfi@1f000000 {
@@ -45,27 +46,27 @@
 
 		3g {
 			label = "wr512-3gn:green:3g";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		gateway {
 			label = "wr512-3gn:green:gateway";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		ap {
 			label = "wr512-3gn:green:ap";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "wr512-3gn:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		station {
 			label = "wr512-3gn:green:station";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -77,13 +78,13 @@
 
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/WR512-3GN-8M.dts
+++ b/target/linux/ramips/dts/WR512-3GN-8M.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "WR512-3GN", "ralink,rt3052-soc";
+	compatible = "generic,wr512-3gn", "ralink,rt3052-soc";
 	model = "WR512-3GN (8M)";
 
 	cfi@1f000000 {
@@ -45,27 +46,27 @@
 
 		3g {
 			label = "wr512-3gn:green:3g";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		gateway {
 			label = "wr512-3gn:green:gateway";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		ap {
 			label = "wr512-3gn:green:ap";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "wr512-3gn:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		station {
 			label = "wr512-3gn:green:station";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -77,13 +78,13 @@
 
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};

--- a/target/linux/ramips/dts/X5.dts
+++ b/target/linux/ramips/dts/X5.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "X5", "ralink,rt5350-soc";
+	compatible = "poray,x5", "ralink,rt5350-soc";
 	model = "Poray X5";
 
 	gpio-leds {
@@ -13,22 +14,22 @@
 
 		power {
 			label = "x5:green:power";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		20 {
 			label = "x5:green:20";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		50 {
 			label = "x5:green:50";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		80 {
 			label = "x5:green:80";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -40,19 +41,19 @@
 
 		bat {
 			label = "bat";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		mode {
 			label = "mode";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 			linux,input-type = <EV_SW>;
 		};

--- a/target/linux/ramips/dts/X8.dts
+++ b/target/linux/ramips/dts/X8.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "X8", "ralink,rt5350-soc";
+	compatible = "poray,x8", "ralink,rt5350-soc";
 	model = "Poray X8";
 
 	gpio-leds {
@@ -13,7 +14,7 @@
 
 		power {
 			label = "x8:green:power";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -25,7 +26,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/XDXRN502J.dts
+++ b/target/linux/ramips/dts/XDXRN502J.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "XDXRN502J", "ralink,rt3052-soc";
+	compatible = "generic,xdxrn502j", "ralink,rt3052-soc";
 	model = "XDX RN502J";
 
 	cfi@1f000000 {
@@ -45,12 +46,12 @@
 
 		wifi {
 			label = "xdxrn502j:green:wifi";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "xdxrn502j:green:power";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,7 +63,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};


### PR DESCRIPTION
       Use the GPIO dt-bindings macros and add compatible strings in the
       rt305x device tree source files.
    
       Signed-off-by: L. D. Pinney <ldpinney@gmail.com>


