### PR TITLE
lantiq: Fix DM200 support - missing rootfs

### DIFF
--- a/target/linux/lantiq/dts/DM200.dts
+++ b/target/linux/lantiq/dts/DM200.dts
@@ -8,7 +8,7 @@
 	model = "DM200 - Netgear DM200";
 
 	chosen {
-		bootargs = "console=ttyLTQ0,115200";
+		bootargs = "root=/dev/mtdblock4 ro rootfstype=squashfs,jffs2 console=ttyLTQ0,115200";
 	};
 
 	aliases {


### PR DESCRIPTION
Fix screw up in original support commit 50e36597, possibly from
a bad rebase.

Signed-off-by: Edward O'Callaghan <funfunctor@folklore1984.net>
