### PR TITLE
ramips: Add support for EX3800, fix factory image name for EX3700

### DIFF
--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -187,7 +187,7 @@ ramips_board_detect() {
 	*"EX2700")
 		name="ex2700";
 		;;
-	*"EX3700")
+	*"EX3700/EX3800")
 		name="ex3700"
 		;;
 	*"F5D8235 v1")

--- a/target/linux/ramips/dts/EX3700.dts
+++ b/target/linux/ramips/dts/EX3700.dts
@@ -9,7 +9,7 @@
 
 / {
 	compatible = "ralink,mt7620a-soc";
-	model = "Netgear EX3700";
+	model = "Netgear EX3700/EX3800";
 
 	chosen {
 		bootargs = "console=ttyS0,57600";

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -145,8 +145,8 @@ define Device/ex3700
   DTS := EX3700
   BLOCKSIZE := 4k
   IMAGE_SIZE := 7744k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | netgear-chk
+  IMAGES += factory.chk
+  IMAGE/factory.chk := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | netgear-chk
   DEVICE_PACKAGES := -kmod-mt76 kmod-mt76x2
   DEVICE_TITLE := Netgear EX3700
 endef

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -140,7 +140,7 @@ define Device/ex2700
 endef
 TARGET_DEVICES += ex2700
 
-define Device/ex3700
+define Device/ex3700-ex3800
   NETGEAR_BOARD_ID := U12H319T00_NETGEAR
   DTS := EX3700
   BLOCKSIZE := 4k
@@ -148,9 +148,10 @@ define Device/ex3700
   IMAGES += factory.chk
   IMAGE/factory.chk := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | netgear-chk
   DEVICE_PACKAGES := -kmod-mt76 kmod-mt76x2
-  DEVICE_TITLE := Netgear EX3700
+  DEVICE_TITLE := Netgear EX3700/EX3800
+  SUPPORTED_DEVICES := ex3700
 endef
-TARGET_DEVICES += ex3700
+TARGET_DEVICES += ex3700-ex3800
 
 define Device/gl-mt300a
   DTS := GL-MT300A

--- a/tools/firmware-utils/src/mkchkimg.c
+++ b/tools/firmware-utils/src/mkchkimg.c
@@ -31,6 +31,20 @@
 
 #define MAX_BOARD_ID_LEN (64)
 
+/*
+ * Note on the reserved field of the chk_header:
+ * OFW naming scheme is typically: DEVICENAME-VA.B.C.D_E.F.G.chk, with A-G
+ * between 0 and 255. For instance: EX3700_EX3800-V1.0.0.58_1.0.38.chk
+ * The reserved field works like this:
+ * reserved[0]: region code. 1 for WW (WorldWide) and 2 for NA (North America)
+ * reserved[1]: A
+ * reserved[2]: B
+ * reserved[3]: C
+ * reserved[4]: D
+ * reserved[5]: E
+ * reserved[6]: F
+ * reserved[7]: G
+ */
 struct chk_header {
 	uint32_t magic;
 	uint32_t header_len;
@@ -248,10 +262,10 @@ main (int argc, char * argv[])
 	hdr->reserved[1] = 1;		/* Major */
 	hdr->reserved[2] = 1;		/* Minor */
 	hdr->reserved[3] = 99;		/* Build */
-	hdr->reserved[4] = 0;		/* Unknown t1 ? was 1 */
-	hdr->reserved[5] = 0;		/* Unknonw t2 ? was 0 */
-	hdr->reserved[6] = 0;		/* Unknonw t3 ? was 1 */
-	hdr->reserved[7] = 0;		/* Unused ? */
+	hdr->reserved[4] = 0;
+	hdr->reserved[5] = 0;
+	hdr->reserved[6] = 0;
+	hdr->reserved[7] = 0;
 	message ("       Board Id: %s", board_id);
 	message ("         Region: %s", region == 1 ? "World Wide (WW)" 
 			: (region == 2 ? "North America (NA)" : "Unknown"));


### PR DESCRIPTION
This patch series:

- Fixes the image name for the EX3700 target so that the factory image can be flashed from stock firmware web interface
- Adds support for the EX3800, which is a 3700 with an output mains socket
- Adds some documentation to mkchkimage