### PR TITLE
lantiq: Bump kernel from 4.4stable to 4.9stable

### DIFF
--- a/target/linux/lantiq/Makefile
+++ b/target/linux/lantiq/Makefile
@@ -12,7 +12,7 @@ FEATURES:=squashfs
 SUBTARGETS:=xrx200 xway xway_legacy falcon ase
 MAINTAINER:=John Crispin <john@phrozen.org>
 
-KERNEL_PATCHVER:=4.4
+KERNEL_PATCHVER:=4.9
 
 define Target/Description
 	Build firmware images for Lantiq SoC


### PR DESCRIPTION
Tested on a Netgear DM200.

Signed-off-by: Edward O'Callaghan <funfunctor@folklore1984.net>