### PR TITLE
ramips: cleanup EX2700 and WN3000RPv3 LEDs

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -163,7 +163,6 @@ dir-860l-b1)
 	;;
 ex2700|\
 wn3000rpv3)
-	ucidef_set_led_default "power_r" "POWER (red)" "$board:red:power" "0"
 	set_wifi_led "$board:green:router"
 	;;
 ex3700)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -22,6 +22,7 @@ get_status_led() {
 	dch-m225|\
 	dir-860l-b1|\
 	e1700|\
+	ex2700|\
 	ex3700|\
 	fonera20n|\
 	kn|\
@@ -42,7 +43,8 @@ get_status_led() {
 	wndr3700v5|\
 	x5|\
 	x8|\
-	xdxrn502j)
+	xdxrn502j|\
+	wn3000rpv3)
 		status_led="$board:green:power"
 		;;
 	3g-6200nl)
@@ -52,13 +54,11 @@ get_status_led() {
 	cs-qr10|\
 	d105|\
 	dcs-930l-b1|\
-	ex2700|\
 	hlk-rm04|\
 	jhr-n825r|\
 	mpr-a1|\
 	mpr-a2|\
-	mzk-ex750np|\
-	wn3000rpv3)
+	mzk-ex750np)
 		status_led="$board:red:power"
 		;;
 	ai-br100|\


### PR DESCRIPTION
This patch cleans up the WN3000RPv3 and EX2700 setup, bringing it in line
with other similar devices:

The power led is a bicolor one. The bootloader brings the red side on at
powerup.

Instead of blinking the red side in diag.sh and need to forcefully turn it off
in 01_leds, this patch simplifies the setup by setting the default state of the
red side to off in the DTS and blinking the green side as with other devices.