### PR TITLE
iperf3: update to 3.2

### DIFF
--- a/package/network/utils/iperf3/Makefile
+++ b/package/network/utils/iperf3/Makefile
@@ -21,21 +21,39 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
+PKG_FIXUP:=autoreconf
+
 include $(INCLUDE_DIR)/package.mk
 
 DISABLE_NLS:=
 
-define Package/iperf3
+define Package/iperf3/default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Internet Protocol bandwidth measuring tool
   URL:=https://github.com/esnet/iperf
+endef
+
+define Package/iperf3
+$(call Package/iperf3/default)
+  VARIANT:=nossl
+endef
+
+define Package/iperf3-ssl
+$(call Package/iperf3/default)
+  TITLE+= with iperf_auth support
+  VARIANT:=ssl
   DEPENDS:= +libopenssl
 endef
 
 TARGET_CFLAGS += -D_GNU_SOURCE
-CONFIGURE_ARGS += --disable-shared \
-                  --with-openssl="$(STAGING_DIR)/usr"
+CONFIGURE_ARGS += --disable-shared
+
+ifeq ($(BUILD_VARIANT),ssl)
+	CONFIGURE_ARGS += --with-openssl="$(STAGING_DIR)/usr"
+else
+	CONFIGURE_ARGS += --without-openssl
+endif
 
 MAKE_FLAGS += noinst_PROGRAMS=
 
@@ -45,9 +63,21 @@ define Package/iperf3/description
  characteristics.
 endef
 
+# autoreconf fails if the README file isn't present
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	touch $(PKG_BUILD_DIR)/README
+endef
+
 define Package/iperf3/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/iperf3 $(1)/usr/bin/
 endef
 
+define Package/iperf3-ssl/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/iperf3 $(1)/usr/bin/
+endef
+
 $(eval $(call BuildPackage,iperf3))
+$(eval $(call BuildPackage,iperf3-ssl))

--- a/package/network/utils/iperf3/Makefile
+++ b/package/network/utils/iperf3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
-PKG_VERSION:=3.1.7
+PKG_VERSION:=3.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.es.net/pub/iperf
-PKG_HASH:=a4ef73406fe92250602b8da2ae89ec53211f805df97a1d1d629db5a14043734f
+PKG_HASH:=f207b36f861485845dbdf09f909c62f3d2222a3cf3d2682095aede8213cd9c1d
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-3-Clause
@@ -23,15 +23,19 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
+DISABLE_NLS:=
+
 define Package/iperf3
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Internet Protocol bandwidth measuring tool
   URL:=https://github.com/esnet/iperf
+  DEPENDS:= +libopenssl
 endef
 
 TARGET_CFLAGS += -D_GNU_SOURCE
-CONFIGURE_ARGS += --disable-shared
+CONFIGURE_ARGS += --disable-shared \
+                  --with-openssl="$(STAGING_DIR)/usr"
 
 MAKE_FLAGS += noinst_PROGRAMS=
 

--- a/package/network/utils/iperf3/patches/010-fix-openssl-ac-macro.patch
+++ b/package/network/utils/iperf3/patches/010-fix-openssl-ac-macro.patch
@@ -1,0 +1,41 @@
+commit 3fd1a2ae907bff2d7593c0bb9944aa05eca7b58d
+Author: ralcini <roberto.alcini@gmail.com>
+Date:   Mon Aug 14 22:43:38 2017 +0200
+
+    fix for issue #624 - force build without openssl (#631)
+    
+    * fix: now --without-openssl configure flags works
+    enh: if openssl support is required and no valid installation is found, now it raise an error
+    
+    * enh: added warning if building without openssl (iperf_auth disabled)
+
+diff --git a/configure.ac b/configure.ac
+index 3c56cb3..79f3869 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -101,13 +101,18 @@ AC_CHECK_HEADERS([netinet/sctp.h],
+ #endif
+ ])
+ 
+-# Check for OPENSSL support
+-AX_CHECK_OPENSSL(
+-	AC_DEFINE([HAVE_SSL], [1], [OpenSSL Is Available])
+-)
+-LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
+-LIBS="$OPENSSL_LIBS $LIBS"
+-CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
++if test "x$with_openssl" = "xno"; then
++    AC_MSG_WARN( [Building without OpenSSL; disabling iperf_auth functionality.] )
++else
++    # Check for OPENSSL support
++    AX_CHECK_OPENSSL(
++        [ AC_DEFINE([HAVE_SSL], [1], [OpenSSL Is Available]) ],
++	[ AC_MSG_FAILURE([--with-openssl was given, but test for openssl failed]) ]
++    )
++    LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
++    LIBS="$OPENSSL_LIBS $LIBS"
++    CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
++fi
+ 
+ # Check for TCP_CONGESTION sockopt (believed to be Linux and FreeBSD only)
+ AC_CACHE_CHECK([TCP_CONGESTION socket option],

--- a/package/network/utils/iperf3/patches/100-iperf_auth-rsa-header.patch
+++ b/package/network/utils/iperf3/patches/100-iperf_auth-rsa-header.patch
@@ -1,0 +1,17 @@
+commit 31d5b6b580a356c5149dbc4f53118b7f83c60822
+Author: Philip Prindeville <philipp@redfish-solutions.com>
+Date:   Sun Jul 30 18:54:46 2017 -0600
+Subject: Add required RSA header for OpenSSL
+    
+Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
+
+--- a/src/iperf_auth.c	2017-06-26 11:42:56.000000000 -0600
++++ b/src/iperf_auth.c	2017-07-30 17:42:43.070447875 -0600
+@@ -40,6 +40,7 @@
+ #include <openssl/pem.h>
+ #include <openssl/sha.h>
+ #include <openssl/buffer.h>
++#include <openssl/rsa.h>
+ 
+ void sha256(const char *string, char outputBuffer[65])
+ {


### PR DESCRIPTION
Needed to add patch containing missing header for `src/iperf_auth.c` to compile.

Also, authentication brings in new dependency on OpenSSL.