### PR TITLE
ramips: rt305x-legacy: update device tree source files

### DIFF
--- a/target/linux/ramips/dts/ALL0239-3G.dts
+++ b/target/linux/ramips/dts/ALL0239-3G.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ALL0239-3G", "ralink,rt3052-soc";
+	compatible = "allnet,all0239-3g", "ralink,rt3052-soc";
 	model = "Allnet ALL0239-3G";
 
 
@@ -46,22 +47,22 @@
 
 		usb {
 			label = "all0239-3g:green:usb";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		3g {
 			label = "all0239-3g:green:3g";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		status {
 			label = "all0239-3g:green:status";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "all0239-3g:green:wps";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -73,19 +74,19 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		connect {
 			label = "connect";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_CONNECT>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/DCS-930.dts
+++ b/target/linux/ramips/dts/DCS-930.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DCS-930", "ralink,rt3050-soc";
+	compatible = "dlink,dcs-930", "ralink,rt3050-soc";
 	model = "D-Link DCS-930";
 
 	cfi@1f000000 {
@@ -55,17 +56,17 @@
 
 		wifi {
 			label = "dcs-930:red:alert";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
 			label = "dcs-930:green:status";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dcs-930:blue:wps";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -77,13 +78,13 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_1>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/DCS-930L-B1.dts
+++ b/target/linux/ramips/dts/DCS-930L-B1.dts
@@ -2,10 +2,11 @@
 
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DCS-930L-B1", "ralink,rt5350-soc";
+	compatible = "dlink,dcs-930L-B1", "ralink,rt5350-soc";
 	model = "D-Link DCS-930L B1";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		power {
 			label = "dcs-930l-b1:red:power";
-			gpios = <&gpio0 17 1>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dcs-930l-b1:blue:wps";
-			gpios = <&gpio0 19 1>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,13 +31,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 20 1>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/WHR-G300N.dts
+++ b/target/linux/ramips/dts/WHR-G300N.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "WHR-G300N", "ralink,rt3052-soc";
+	compatible = "buffalo,whr-g300n", "ralink,rt3052-soc";
 	model = "Buffalo WHR-G300N";
 
 	cfi@1f000000 {
@@ -22,17 +23,17 @@
 
 		diag {
 			label = "whr-g300n:red:diag";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		router {
 			label = "whr-g300n:green:router";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		security {
 			label = "whr-g300n:amber:security";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -44,25 +45,25 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		aoss {
 			label = "aoss";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		router-off {
 			label = "router-off";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_2>;
 		};
 
 		router-on {
 			label = "router-on";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_3>;
 		};
 	};

--- a/target/linux/ramips/dts/WL-341V3.dts
+++ b/target/linux/ramips/dts/WL-341V3.dts
@@ -2,10 +2,11 @@
 
 #include "rt3050.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "WL-341V3", "ralink,rt3052-soc";
+	compatible = "sitecom,wl-341v3", "ralink,rt3052-soc";
 	model = "Sitecom WL-341 v3";
 
 	cfi@1f000000 {
@@ -45,37 +46,37 @@
 
 		first {
 			label = "wl-341v3:amber:first";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		first2 {
 			label = "wl-341v3:blue:first";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		third {
 			label = "wl-341v3:amber:third";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		third2 {
 			label = "wl-341v3:blue:third";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		fourth {
 			label = "wl-341v3:blue:fourth";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 		};
 
 		fifth {
 			label = "wl-341v3:amber:fifth";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		fifth2 {
 			label = "wl-341v3:blue:fifth";
-			gpios = <&gpio0 8 1>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -87,13 +88,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 5 1>;
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};


### PR DESCRIPTION
   Use the GPIO dt-bindings macros and add compatible strings in the
   rt305x-legacy device tree source files.

   Signed-off-by: L. D. Pinney <ldpinney@gmail.com>
