### PR TITLE
ramips: rt3883: update device tree source files

### DIFF
--- a/target/linux/ramips/dts/BR-6475ND.dts
+++ b/target/linux/ramips/dts/BR-6475ND.dts
@@ -2,10 +2,11 @@
 
 #include "rt3883.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "BR-6475ND", "ralink,rt3883-soc";
+	compatible = "edimax,br-6475nd", "ralink,rt3883-soc";
 	model = "Edimax BR-6475nD";
 
 	gpio-keys-polled {
@@ -16,13 +17,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		rfkill {
 			label = "rfkill";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 			linux,input-type = <EV_SW>;
 			linux,code = <KEY_RFKILL>;
 		};
@@ -33,17 +34,17 @@
 
 		power {
 			label = "br-6475nd:green:power";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
 			label = "br-6475nd:amber:wlan";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan_5ghz {
 			label = "br-6475nd:amber:wlan_5ghz";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -86,8 +87,8 @@
 
 	rtl8367 {
 		compatible = "realtek,rtl8367";
-		gpio-sda = <&gpio0 5 0>;
-		gpio-sck = <&gpio0 4 0>;
+		gpio-sda = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio0 4 GPIO_ACTIVE_HIGH>;
 		realtek,extif0 = <1 0 1 1 1 1 1 1 2>;
 	};
 
@@ -102,7 +103,7 @@
 		usb {
 			gpio-export,name="usb";
 			gpio-export,output=<0>;
-			gpios = <&gpio0 19 0>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
 		};
 	};
 	*/

--- a/target/linux/ramips/dts/CY-SWR1100.dts
+++ b/target/linux/ramips/dts/CY-SWR1100.dts
@@ -2,10 +2,11 @@
 
 #include "rt3883.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "CY-SWR1100", "ralink,rt3883-soc";
+	compatible = "samsung,cy-swr1100", "ralink,rt3883-soc";
 	model = "Samsung CY-SWR1100";
 
 	nor-flash@1c000000 {
@@ -65,13 +66,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 6 1>;
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 3 1>;
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
@@ -81,12 +82,12 @@
 
 		wps {
 			label = "cy-swr1100:blue:wps";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
 			label = "cy-swr1100:blue:usb";
-			gpios = <&gpio1 1 1>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/DIR-645.dts
+++ b/target/linux/ramips/dts/DIR-645.dts
@@ -2,10 +2,11 @@
 
 #include "rt3883.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "DIR-645", "ralink,rt3883-soc";
+	compatible = "dlink,dir-645", "ralink,rt3883-soc";
 	model = "D-Link DIR-645";
 
 	rtl8367b {
@@ -23,13 +24,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 9 0>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio0 14 0>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
@@ -39,12 +40,12 @@
 
 		inet {
 			label = "dir-645:green:inet";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "dir-645:green:wps";
-			gpios = <&gpio1 2 0>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
@@ -55,7 +56,7 @@
 		usb {
 			gpio-export,name = "usb";
 			gpio-export,output = <1>;
-			gpios = <&gpio1 6 0>;
+			gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/HPM.dts
+++ b/target/linux/ramips/dts/HPM.dts
@@ -2,10 +2,11 @@
 
 #include "rt3883.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "HPM", "ralink,rt3883-soc";
+	compatible = "omnima,hpm", "ralink,rt3883-soc";
 	model = "Omnima HPM";
 
 	chosen {
@@ -30,32 +31,32 @@
 
 		power {
 			label = "hpm:orange:power";
-			gpios = <&gpio0 7 1>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		status {
 			label = "hpm:green:status";
-			gpios = <&gpio0 21 1>;
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		};
 
 		eth {
 			label = "hpm:green:eth";
-			gpios = <&gpio0 20 1>;
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 		};
 
 		eth2 {
 			label = "hpm:red:eth";
-			gpios = <&gpio0 18 1>;
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
 		};
 
 		wifi {
 			label = "hpm:green:wifi";
-			gpios = <&gpio0 17 1>;
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 
 		wifi2 {
 			label = "hpm:red:wifi";
-			gpios = <&gpio0 19 1>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -67,13 +68,13 @@
 		usb0 {
 			gpio-export,name = "usb0";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 2 0>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 		};
 
 		usb1 {
 			gpio-export,name = "usb1";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 1 0>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/RT-N56U.dts
+++ b/target/linux/ramips/dts/RT-N56U.dts
@@ -2,10 +2,11 @@
 
 #include "rt3883.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "RT-N56U", "ralink,rt3883-soc";
+	compatible = "asus,rt-N56u", "ralink,rt3883-soc";
 	model = "Asus RT-N56U";
 
 	nor-flash@1c000000 {
@@ -54,13 +55,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio1 2 1>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
@@ -70,22 +71,22 @@
 
 		power {
 			label = "rt-n56u:blue:power";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 		};
 
 		lan {
 			label = "rt-n56u:blue:lan";
-			gpios = <&gpio0 19 1>;
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
 			label = "rt-n56u:blue:wan";
-			gpios = <&gpio1 3 1>;
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
 			label = "rt-n56u:blue:usb";
-			gpios = <&gpio1 0 1>;
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/TEW-691GR.dts
+++ b/target/linux/ramips/dts/TEW-691GR.dts
@@ -2,10 +2,11 @@
 
 #include "rt3883.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "TEW-691GR", "ralink,rt3883-soc";
+	compatible = "trendnet,tew-691gr", "ralink,rt3883-soc";
 	model = "TRENDnet TEW-691GR";
 
 	nor-flash@1c000000 {
@@ -47,19 +48,19 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio1 2 1>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		rfkill {
 			label = "rfkill";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
 		};
 	};
@@ -69,7 +70,7 @@
 
 		wps {
 			label = "tew-691gr:green:wps";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/TEW-692GR.dts
+++ b/target/linux/ramips/dts/TEW-692GR.dts
@@ -2,10 +2,11 @@
 
 #include "rt3883.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "TEW-692GR", "ralink,rt3883-soc";
+	compatible = "trendnet,tew-692gr", "ralink,rt3883-soc";
 	model = "TRENDnet TEW-692GR";
 
 	nor-flash@1c000000 {
@@ -47,13 +48,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio1 2 1>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
@@ -63,12 +64,12 @@
 
 		wps {
 			label = "tew-692gr:orange:wps";
-			gpios = <&gpio0 9 1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wps2 {
 			label = "tew-692gr:green:wps";
-			gpios = <&gpio1 4 1>;
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/WLR-6000.dts
+++ b/target/linux/ramips/dts/WLR-6000.dts
@@ -6,6 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
+	compatible = "sitenet,wlr-6000", "ralink,rt3883-soc";
 	model = "Sitecom WLR-6000";
 
 	gpio-keys-polled {


### PR DESCRIPTION
   Use the GPIO dt-bindings macros and add compatible strings in the
   rt3883 device tree source files.

   Signed-off-by: L. D. Pinney <ldpinney@gmail.com>
