### PR TITLE
ramips: mt7620: update device tree source files

### DIFF
--- a/target/linux/ramips/dts/AI-BR100.dts
+++ b/target/linux/ramips/dts/AI-BR100.dts
@@ -2,10 +2,11 @@
 
 #include "mt7620a.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "AI-BR100", "ralink,mt7620a-soc";
+	compatible = "aigale,ai-br100", "ralink,mt7620a-soc";
 	model = "Aigale Ai-BR100";
 
 	gpio-leds {
@@ -13,12 +14,12 @@
 
 		wan {
 			label = "ai-br100:blue:wan";
-			gpios = <&gpio2 4 1>;
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
 			label = "ai-br100:blue:wlan";
-			gpios = <&gpio3 0 1>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -30,7 +31,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 12 1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/ArcherC20i.dts
+++ b/target/linux/ramips/dts/ArcherC20i.dts
@@ -2,10 +2,11 @@
 
 #include "mt7620a.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ralink,mt7620a-soc";
+	compatible = "tplink,c20i", ralink,mt7620a-soc";
 	model = "TP-Link Archer C20i";
 
 	chosen {
@@ -16,23 +17,23 @@
 		compatible = "gpio-leds";
 		lan {
 			label = "c20i:blue:lan";
-			gpios = <&gpio0 1 1>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		};
 		usb {
 			label = "c20i:blue:usb";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 		wps {
 			label = "c20i:blue:wps";
-			gpios = <&gpio1 15 1>;
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 		wan {
 			label = "c20i:blue:wan";
-			gpios = <&gpio2 0 1>;
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 		};
 		wlan {
 			label = "c20i:blue:wlan";
-			gpios = <&gpio3 0 1>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -42,12 +43,12 @@
 		#size-cells = <0>;
 		rfkill {
 			label = "rfkill";
-			gpios = <&gpio0 2 1>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
 		};
 		reset_wps {
 			label = "reset_wps";
-			gpios = <&gpio0 13 1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/ArcherC50.dts
+++ b/target/linux/ramips/dts/ArcherC50.dts
@@ -1,11 +1,12 @@
 /dts-v1/;
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/gpio/gpio.h>
 
 #include "mt7620a.dtsi"
 
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
 / {
-	compatible = "ralink,mt7620a-soc";
+	compatible = "tplink,c50", "ralink,mt7620a-soc";
 	model = "TP-Link Archer C50";
 
 	chosen {

--- a/target/linux/ramips/dts/ArcherMR200.dts
+++ b/target/linux/ramips/dts/ArcherMR200.dts
@@ -1,11 +1,12 @@
 /dts-v1/;
 
 #include "mt7620a.dtsi"
+
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	compatible = "ralink,mt7620a-soc";
+	compatible = "tplink,mr200", "ralink,mt7620a-soc";
 	model = "TP-Link Archer MR200";
 
 	chosen {

--- a/target/linux/ramips/dts/CF-WR800N.dts
+++ b/target/linux/ramips/dts/CF-WR800N.dts
@@ -2,10 +2,11 @@
 
 #include "mt7620n.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "cf-wr800n", "ralink,mt7620n-soc";
+	compatible = "comfast,cf-wr800n", "ralink,mt7620n-soc";
 	model = "Comfast CF-WR800N";
 
 	chosen {
@@ -17,17 +18,17 @@
 
 		ethernet {
 			label = "cf-wr800n:white:ethernet";
-			gpios = <&gpio2 4 1>;
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 		};
 
 		wifi {
 			label = "cf-wr800n:white:wifi";
-			gpios = <&gpio3 0 1>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "cf-wr800n:white:wps";
-			gpios = <&gpio1 15 1>;
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -39,7 +40,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 2 1>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/CS-QR10.dts
+++ b/target/linux/ramips/dts/CS-QR10.dts
@@ -2,10 +2,11 @@
 
 #include "mt7620a.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ralink,mt7620a-soc";
+	compatible = "planex,cs-qr10", "ralink,mt7620a-soc";
 	model = "Planex CS-QR10";
 
 	gpio-leds {
@@ -13,7 +14,7 @@
 
 		power {
 			label = "cs-qr10:red:power";
-			gpios = <&gpio1 4 1>;
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -25,13 +26,13 @@
 
 		s1 {
 			label = "reset";
-			gpios = <&gpio1 1 1>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		s2 {
 			label = "wps";
-			gpios = <&gpio1 3 1>;
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};


### PR DESCRIPTION
   Use the GPIO dt-bindings macros and add compatible strings in the
   mt7620 device tree source files.

   Signed-off-by: L. D. Pinney <ldpinney@gmail.com>
