### PR TITLE
ramips: mt76x8: update device tree source files

### DIFF
--- a/target/linux/ramips/dts/DUZUN-DM06.dts
+++ b/target/linux/ramips/dts/DUZUN-DM06.dts
@@ -2,6 +2,7 @@
 
 #include "mt7628an.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
@@ -21,13 +22,13 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio1 14 1>;
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
 		wps {
 			label = "wps";
-			gpios = <&gpio1 6 1>;
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/HC5661A.dts
+++ b/target/linux/ramips/dts/HC5661A.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "HC5661A", "mediatek,mt7628an-soc";
+	compatible = "hiwifi,hc5661a", "mediatek,mt7628an-soc";
 	model = "HiWiFi HC5661A";
 
 	chosen {

--- a/target/linux/ramips/dts/LINKIT7688.dts
+++ b/target/linux/ramips/dts/LINKIT7688.dts
@@ -2,6 +2,7 @@
 
 #include "mt7628an.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
@@ -32,7 +33,7 @@
 
 		wifi {
 			label = "mediatek:orange:wifi";
-			gpios = <&wgpio 0 0>;
+			gpios = <&wgpio 0 GPIO_ACTIVE_HIGH>;
 			default-state = "on";
 		};
 	};
@@ -45,7 +46,7 @@
 
 		wps {
 			label = "reset";
-			gpios = <&gpio1 6 1>;
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/MAC1200RV2.dts
+++ b/target/linux/ramips/dts/MAC1200RV2.dts
@@ -2,6 +2,9 @@
 
 #include "mt7628an.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
 / {
 	compatible = "mercury,mac1200rv2", "mediatek,mt7628an-soc";
 	model = "Mercury MAC1200R v2";
@@ -19,7 +22,7 @@
 		compatible = "gpio-leds";
 		status {
 			label = "mac1200rv2:green:status";
-			gpios = <&gpio0 11 1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/MIWIFI-NANO.dts
+++ b/target/linux/ramips/dts/MIWIFI-NANO.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "xiaomi,MiWifi Nano", "mediatek,mt7628an-soc";
+	compatible = "xiaomi,miwifi nano", "mediatek,mt7628an-soc";
 	model = "MiWiFi Nano";
 
 	chosen {

--- a/target/linux/ramips/dts/PBR-D1.dts
+++ b/target/linux/ramips/dts/PBR-D1.dts
@@ -2,6 +2,7 @@
 
 #include "mt7628an.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
@@ -26,13 +27,13 @@
 
 		usb {
 			label = "pbr-d1:orange:usb";
-			gpios = <&gpio0 0 1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
 		power {
 			label = "pbr-d1:orange:power";
-			gpios = <&gpio0 14 1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 	};
@@ -45,7 +46,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio1 38 1>;
+			gpios = <&gpio1 38 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/VOCORE2.dts
+++ b/target/linux/ramips/dts/VOCORE2.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "vocore,VoCore2", "mediatek,mt7628an-soc";
+	compatible = "vocore,vocore2", "mediatek,mt7628an-soc";
 	model = "VoCore2";
 
 	chosen {
@@ -22,7 +22,7 @@
 		compatible = "gpio-leds";
 
 		status {
-			label = "vocore2:fuchsia:status";
+			label = "vocore2:pink:status";
 			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 		};
 	};

--- a/target/linux/ramips/dts/WIDORA-NEO.dts
+++ b/target/linux/ramips/dts/WIDORA-NEO.dts
@@ -2,6 +2,7 @@
 
 #include "mt7628an.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
@@ -22,7 +23,7 @@
 
 		wifi {
 			label = "widora:orange:wifi";
-			gpios = <&wgpio 0 0>;
+			gpios = <&wgpio 0 GPIO_ACTIVE_HIGH>;
 			default-state = "on";
 		};
 	};
@@ -35,7 +36,7 @@
 
 		wps {
 			label = "reset";
-			gpios = <&gpio1 6 1>;
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/WRTNODE2.dtsi
+++ b/target/linux/ramips/dts/WRTNODE2.dtsi
@@ -1,5 +1,6 @@
 #include "mt7628an.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
 / {
@@ -15,7 +16,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio0 5 1>;
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};

--- a/target/linux/ramips/dts/WRTNODE2P.dts
+++ b/target/linux/ramips/dts/WRTNODE2P.dts
@@ -11,7 +11,7 @@
 
 		indicator {
 			label = "wrtnode:blue:indicator";
-			gpios = <&gpio1 9 1>;
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 		};
 	}; 
 };


### PR DESCRIPTION
   Use the GPIO dt-bindings macros and add compatible strings in the
   mt76x8 device tree source files.

   Signed-off-by: L. D. Pinney <ldpinney@gmail.com>
