### PR TITLE
ramips: fix cd-poll sd card remove randomly

### DIFF
--- a/target/linux/ramips/patches-4.9/0046-mmc-MIPS-ralink-add-sdhci-for-mt7620a-SoC.patch
+++ b/target/linux/ramips/patches-4.9/0046-mmc-MIPS-ralink-add-sdhci-for-mt7620a-SoC.patch
@@ -2345,6 +2345,8 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	else
 +	        inserted = (status & MSDC_PS_CDSTS) ? 1 : 0;
 +    }
++    if (host->mmc->caps & MMC_CAP_NEEDS_POLL)
++        inserted = 1;
 +
 +#if 0
 +    change = host->card_inserted ^ inserted;
@@ -4092,6 +4094,8 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		present = (sdr_read32(MSDC_PS) & MSDC_PS_CDSTS) ? 0 : 1; 
 +        else
 +		present = (sdr_read32(MSDC_PS) & MSDC_PS_CDSTS) ? 1 : 0; 
++   if (host->mmc->caps & MMC_CAP_NEEDS_POLL)
++       present = 1;
 +        host->card_inserted = present;  
 +#endif        
 +        spin_unlock_irqrestore(&host->lock, flags);


### PR DESCRIPTION
Fix when add 'mediatek,cd-poll' to dts cause the sd card be removed randomly.
Special for the device without card-detect pin.