### PR TITLE
package/base-file: suppress uci not found output in login.sh

### DIFF
--- a/package/base-files/files/usr/libexec/login.sh
+++ b/package/base-files/files/usr/libexec/login.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-[ "$(uci get system.@system[0].ttylogin)" == 1 ] || exec /bin/ash --login
+[ "$(uci -q get system.@system[0].ttylogin)" == 1 ] || exec /bin/ash --login
 
 exec /bin/login


### PR DESCRIPTION
If `ttylogin` is not set in `/etc/config/system`, the we get on the tty the output `uci: Entry not found`.
This PR will fix this issue.