### PR TITLE
RFC: Firewall hook for /sbin/hotplug-call firewall

### DIFF
--- a/package/network/config/firewall/files/firewall.init
+++ b/package/network/config/firewall/files/firewall.init
@@ -29,7 +29,7 @@ validate_firewall_rule()
 }
 
 service_triggers() {
-	procd_add_reload_trigger firewall	
+	procd_add_reload_trigger firewall
 
 	procd_open_validate
 	validate_firewall_redirect

--- a/package/network/config/firewall/files/firewall.init
+++ b/package/network/config/firewall/files/firewall.init
@@ -38,19 +38,27 @@ service_triggers() {
 }
 
 restart() {
+	ACTION="pre-restart" /sbin/hotplug-call firewall
 	fw3 restart
+	ACTION="post-restart" /sbin/hotplug-call firewall
 }
 
 start_service() {
+	ACTION="pre-start" /sbin/hotplug-call firewall
 	fw3 ${QUIET} start
+	ACTION="post-start" /sbin/hotplug-call firewall
 }
 
 stop_service() {
+	ACTION="pre-stop" /sbin/hotplug-call firewall
 	fw3 flush
+	ACTION="post-stop" /sbin/hotplug-call firewall
 }
 
 reload_service() {
+	ACTION="pre-reload" /sbin/hotplug-call firewall
 	fw3 reload
+	ACTION="post-reload" /sbin/hotplug-call firewall
 }
 
 boot() {


### PR DESCRIPTION
The use case is:
If the firewall changed then some package could hook into the firewall to do some ACTION per `/etc/hotplug.d/firewall`.

My use case is:
I need this for mwan3, because if the firewall is restarted then the firewall configuration for mwan3 get flushed as well. Because mwan3 is not a service mwan3 gets no notification that something happens. 
To fix this if the firewall gets restarted a callback script under `/etc/hotplug.d/firewall` with the `ACTION=post-restart `could restart mwan3 to set the firewall rules again.

I am not sure if a similar PR was already made? I did not find any PR or mails on the mailing list.
