### PR TITLE
lede-17.01: ramips: mt7620 do not pad sysupgrade Archer images

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -38,7 +38,7 @@ define Device/ArcherC20i
   KERNEL := $(KERNEL_DTB)
   KERNEL_INITRAMFS := $(KERNEL_DTB) | tplink-header ArcherC20i -c
   IMAGE/factory.bin := append-kernel | tplink-header ArcherC20i -j
-  IMAGE/sysupgrade.bin := append-kernel | tplink-header ArcherC20i -j | append-metadata
+  IMAGE/sysupgrade.bin := append-kernel | tplink-header ArcherC20i -j -s | append-metadata
   IMAGES += factory.bin
   DEVICE_TITLE := TP-Link ArcherC20i
 endef
@@ -50,7 +50,7 @@ define Device/ArcherC50
   KERNEL := $(KERNEL_DTB)
   KERNEL_INITRAMFS := $(KERNEL_DTB) | tplink-header ArcherC50 -c
   IMAGE/factory.bin := append-kernel | tplink-header ArcherC50 -j
-  IMAGE/sysupgrade.bin := append-kernel | tplink-header ArcherC50 -j | append-metadata
+  IMAGE/sysupgrade.bin := append-kernel | tplink-header ArcherC50 -j -s | append-metadata
   IMAGES += factory.bin
   DEVICE_TITLE := TP-Link ArcherC50
 endef
@@ -61,7 +61,7 @@ define Device/ArcherMR200
   SUPPORTED_DEVICES := mr200
   KERNEL := $(KERNEL_DTB)
   KERNEL_INITRAMFS := $(KERNEL_DTB) | tplink-header ArcherMR200 -c
-  IMAGE/sysupgrade.bin := append-kernel | tplink-header ArcherMR200 -j | append-metadata
+  IMAGE/sysupgrade.bin := append-kernel | tplink-header ArcherMR200 -j -s | append-metadata
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-net kmod-usb-net-rndis kmod-usb-serial kmod-usb-serial-option adb
   DEVICE_TITLE := TP-Link ArcherMR200
 endef


### PR DESCRIPTION
The current makefile unnecessarily pads sysupgrade image for Archer devices.

This has two implications:
1. higher risk of OOM when uploading the binary image to the device
2. much slower upgrade due to time wasted erasing and writing padding

This is already fixed in master, albeit in a completely different way (the
whole target have been reworked)