### PR TITLE
ar71xx: add metadata to wpj344 and wpj558

### DIFF
--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -852,6 +852,9 @@ define Device/wpj344
   $(Device/wpj-16m)
   DEVICE_TITLE := Compex WPJ344 (16MB flash)
   BOARDNAME := WPJ344
+  SUPPORTED_DEVICES := wpj344
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
 
 define Device/wpj531
@@ -864,6 +867,9 @@ define Device/wpj558
   $(Device/wpj-16m)
   DEVICE_TITLE := Compex WPJ558 (16MB flash)
   BOARDNAME := WPJ558
+  SUPPORTED_DEVICES := wpj558
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
 
 define Device/wpj563


### PR DESCRIPTION
This commit add metadata to wpj344 and wpj558 to prevent
load a firmware of wpj344 in a wpj558 and vice versa.
This until now was possible and break the units and had to
be recovered from the uboot.

Signed-off-by: Enrique Giraldo <enrique.giraldo@galgus.net>
