### PR TITLE
modules: definition should include explict params

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -133,11 +133,13 @@ define ModuleAutoLoad
 	probe_module() { \
 		local mods="$$$$$$$$1"; \
 		local boot="$$$$$$$$2"; \
-		local mod; \
 		shift 2; \
+		local mod; \
 		for mod in $$$$$$$$mods; do \
+			local params="$$$$$$$$1"; \
+			shift; \
 			mkdir -p $(2)/etc/modules.d; \
-			echo "$$$$$$$$mod" >> $(2)/etc/modules.d/$(1); \
+			echo "$$$$$$$$mod $$$$$$$$params" >> $(2)/etc/modules.d/$(1); \
 		done; \
 		if [ -e $(2)/etc/modules.d/$(1) ]; then \
 			if [ "$$$$$$$$boot" = "1" -a ! -e $(2)/etc/modules-boot.d/$(1) ]; then \
@@ -151,11 +153,13 @@ define ModuleAutoLoad
 		local priority="$$$$$$$$1"; \
 		local mods="$$$$$$$$2"; \
 		local boot="$$$$$$$$3"; \
-		local mod; \
 		shift 3; \
+		local mod; \
 		for mod in $$$$$$$$mods; do \
+			local params="$$$$$$$$1"; \
+			shift; \
 			mkdir -p $(2)/etc/modules.d; \
-			echo "$$$$$$$$mod" >> $(2)/etc/modules.d/$$$$$$$$priority-$(1); \
+			echo "$$$$$$$$mod $$$$$$$$params" >> $(2)/etc/modules.d/$$$$$$$$priority-$(1); \
 		done; \
 		if [ -e $(2)/etc/modules.d/$$$$$$$$priority-$(1) ]; then \
 			if [ "$$$$$$$$boot" = "1" -a ! -e $(2)/etc/modules-boot.d/$$$$$$$$priority-$(1) ]; then \
@@ -266,11 +270,11 @@ endef
 version_filter=$(if $(findstring @,$(1)),$(shell $(SCRIPT_DIR)/package-metadata.pl version_filter $(KERNEL_PATCHVER) $(1)),$(1))
 
 define AutoLoad
-  add_module "$(1)" "$(call version_filter,$(2))" "$(3)";
+  add_module "$(1)" "$(call version_filter,$(2))" "$(3)" $$(foreach mod,$$(FILES),"$$(MODPARAMS.$$(basename $$(notdir $$(mod))))");
 endef
 
 define AutoProbe
-  probe_module "$(call version_filter,$(1))" "$(2)";
+  probe_module "$(call version_filter,$(1))" "$(2)" $$(foreach mod,$$(FILES),"$$(MODPARAMS.$$(basename $$(notdir $$(mod))))");
 endef
 
 version_field=$(if $(word $(1),$(2)),$(word $(1),$(2)),0)

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -494,6 +494,9 @@ define KernelPackage/e1000e
   DEPENDS:=@PCIE_SUPPORT +kmod-ptp
   KCONFIG:=CONFIG_E1000E
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/e1000e/e1000e.ko
+  MODPARAMS.e1000e:= \
+	IntMode=1 \
+	InterruptThrottleRate='4,4,4,4,4,4,4,4'
   AUTOLOAD:=$(call AutoProbe,e1000e)
 endef
 

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -651,7 +651,7 @@ define KernelPackage/arptables
   SUBMENU:=$(NF_MENU)
   TITLE:=ARP firewalling modules
   DEPENDS:=+kmod-ipt-core
-  FILES:=$(LINUX_DIR)/net/ipv4/netfilter/arp*.ko
+  FILES:=$(wildcard $(LINUX_DIR)/net/ipv4/netfilter/arp*.ko)
   KCONFIG:=CONFIG_IP_NF_ARPTABLES \
     CONFIG_IP_NF_ARPFILTER \
     CONFIG_IP_NF_ARP_MANGLE


### PR DESCRIPTION
Some modules build out-of-the-box with defaults which are useful for end-systems, desktops, etc. but suboptimal for network devices (routers) or small footprint embedded systems.

Allow the module packager to specify saner parameters.

Fixes FS#935.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>