### PR TITLE
tools: patch various gnu tools for macOS 10.13

### DIFF
--- a/tools/bison/patches/001-fix-macos-vasnprintf.patch
+++ b/tools/bison/patches/001-fix-macos-vasnprintf.patch
@@ -1,0 +1,25 @@
+--- a/lib/vasnprintf.c
++++ b/lib/vasnprintf.c
+@@ -4858,7 +4858,11 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if ! (((__GLIBC__ > 2                                                 \
++          || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3))                  \
++         && !defined __UCLIBC__)                                        \
++        || (defined __APPLE__ && defined __MACH__)                      \
++        || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
+@@ -4872,6 +4876,9 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+                    in format strings in writable memory may crash the program
+                    (if compiled with _FORTIFY_SOURCE=2), so we should avoid it
+                    in this situation.  */
++                /* macOS 10.13 High Sierra behaves like glibc with
++                   _FORTIFY_SOURCE=2, and older macOS releases
++                   presumably do not need %n.  */
+                 /* On native Windows systems (such as mingw), we can avoid using
+                    %n because:
+                      - Although the gl_SNPRINTF_TRUNCATION_C99 test fails,

--- a/tools/coreutils/patches/001-fix-macos-vasnprintf.patch
+++ b/tools/coreutils/patches/001-fix-macos-vasnprintf.patch
@@ -1,0 +1,25 @@
+--- a/lib/vasnprintf.c
++++ b/lib/vasnprintf.c
+@@ -4858,7 +4858,11 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if ! (((__GLIBC__ > 2                                                 \
++          || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3))                  \
++         && !defined __UCLIBC__)                                        \
++        || (defined __APPLE__ && defined __MACH__)                      \
++        || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
+@@ -4872,6 +4876,9 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+                    in format strings in writable memory may crash the program
+                    (if compiled with _FORTIFY_SOURCE=2), so we should avoid it
+                    in this situation.  */
++                /* macOS 10.13 High Sierra behaves like glibc with
++                   _FORTIFY_SOURCE=2, and older macOS releases
++                   presumably do not need %n.  */
+                 /* On native Windows systems (such as mingw), we can avoid using
+                    %n because:
+                      - Although the gl_SNPRINTF_TRUNCATION_C99 test fails,

--- a/tools/m4/patches/001-fix-macos-vasnprintf.patch
+++ b/tools/m4/patches/001-fix-macos-vasnprintf.patch
@@ -1,0 +1,25 @@
+--- a/lib/vasnprintf.c
++++ b/lib/vasnprintf.c
+@@ -4858,7 +4858,11 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if ! (((__GLIBC__ > 2                                                 \
++          || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3))                  \
++         && !defined __UCLIBC__)                                        \
++        || (defined __APPLE__ && defined __MACH__)                      \
++        || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
+@@ -4872,6 +4876,9 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+                    in format strings in writable memory may crash the program
+                    (if compiled with _FORTIFY_SOURCE=2), so we should avoid it
+                    in this situation.  */
++                /* macOS 10.13 High Sierra behaves like glibc with
++                   _FORTIFY_SOURCE=2, and older macOS releases
++                   presumably do not need %n.  */
+                 /* On native Windows systems (such as mingw), we can avoid using
+                    %n because:
+                      - Although the gl_SNPRINTF_TRUNCATION_C99 test fails,

--- a/tools/patch/patches/001-fix-macos-vasnprintf.patch
+++ b/tools/patch/patches/001-fix-macos-vasnprintf.patch
@@ -1,0 +1,25 @@
+--- a/lib/vasnprintf.c
++++ b/lib/vasnprintf.c
+@@ -4858,7 +4858,11 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if ! (((__GLIBC__ > 2                                                 \
++          || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3))                  \
++         && !defined __UCLIBC__)                                        \
++        || (defined __APPLE__ && defined __MACH__)                      \
++        || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
+@@ -4872,6 +4876,9 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+                    in format strings in writable memory may crash the program
+                    (if compiled with _FORTIFY_SOURCE=2), so we should avoid it
+                    in this situation.  */
++                /* macOS 10.13 High Sierra behaves like glibc with
++                   _FORTIFY_SOURCE=2, and older macOS releases
++                   presumably do not need %n.  */
+                 /* On native Windows systems (such as mingw), we can avoid using
+                    %n because:
+                      - Although the gl_SNPRINTF_TRUNCATION_C99 test fails,

--- a/tools/tar/patches/001-fix-macos-vasnprintf.patch
+++ b/tools/tar/patches/001-fix-macos-vasnprintf.patch
@@ -1,0 +1,25 @@
+--- a/gnu/vasnprintf.c
++++ b/gnu/vasnprintf.c
+@@ -4858,7 +4858,11 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if ! (((__GLIBC__ > 2                                                 \
++          || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3))                  \
++         && !defined __UCLIBC__)                                        \
++        || (defined __APPLE__ && defined __MACH__)                      \
++        || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
+@@ -4872,6 +4876,9 @@ VASNPRINTF (DCHAR_T *resultbuf, size_t *
+                    in format strings in writable memory may crash the program
+                    (if compiled with _FORTIFY_SOURCE=2), so we should avoid it
+                    in this situation.  */
++                /* macOS 10.13 High Sierra behaves like glibc with
++                   _FORTIFY_SOURCE=2, and older macOS releases
++                   presumably do not need %n.  */
+                 /* On native Windows systems (such as mingw), we can avoid using
+                    %n because:
+                      - Although the gl_SNPRINTF_TRUNCATION_C99 test fails,


### PR DESCRIPTION
These host tools compile but crash at runtime when calling gnulib's vasnprintf on
macOS 10.13 (High Sierra). Backport upstream gnulib patch until new
releases of affected tools.

https://lists.gnu.org/archive/html/bug-gnulib/2017-07/msg00056.html
https://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=c41f233c4c38e84023a16339782ee306f03e7f59