### PR TITLE
Implement get_port_stats() for several switch drivers

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/adm6996.c
+++ b/target/linux/generic/files/drivers/net/phy/adm6996.c
@@ -112,6 +112,9 @@ static const struct adm6996_mib_desc adm6996_mibs[] = {
 	MIB_DESC(ADM_CL30, "Error"),
 };
 
+#define ADM6996_MIB_RXB_ID	1
+#define ADM6996_MIB_TXB_ID	3
+
 static inline u16
 r16(struct adm6996_priv *priv, enum admreg reg)
 {
@@ -888,6 +891,34 @@ adm6996_sw_get_port_mib(struct switch_dev *dev,
 	return 0;
 }
 
+static int
+adm6996_get_port_stats(struct switch_dev *dev, int port,
+			struct switch_port_stats *stats)
+{
+	struct adm6996_priv *priv = to_adm(dev);
+	int id;
+	u32 reg = 0;
+
+	if (port >= ADM_NUM_PORTS)
+		return -EINVAL;
+
+	mutex_lock(&priv->mib_lock);
+
+	id = ADM6996_MIB_TXB_ID;
+	reg = r16(priv, adm6996_mibs[id].offset + ADM_OFFSET_PORT(port));
+	reg += r16(priv, adm6996_mibs[id].offset + ADM_OFFSET_PORT(port) + 1) << 16;
+	stats->tx_bytes = reg;
+
+	id = ADM6996_MIB_RXB_ID;
+	reg = r16(priv, adm6996_mibs[id].offset + ADM_OFFSET_PORT(port));
+	reg += r16(priv, adm6996_mibs[id].offset + ADM_OFFSET_PORT(port) + 1) << 16;
+	stats->rx_bytes = reg;
+
+	mutex_unlock(&priv->mib_lock);
+
+	return 0;
+}
+
 static struct switch_attr adm6996_globals[] = {
 	{
 	 .type = SWITCH_TYPE_INT,
@@ -956,6 +987,7 @@ static struct switch_dev_ops adm6996_ops = {
 	.apply_config = adm6996_hw_apply,
 	.reset_switch = adm6996_reset_switch,
 	.get_port_link = adm6996_get_port_link,
+	.get_port_stats = adm6996_get_port_stats,
 };
 
 static int adm6996_switch_init(struct adm6996_priv *priv, const char *alias, struct net_device *netdev)

--- a/target/linux/generic/files/drivers/net/phy/ar8216.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8216.c
@@ -49,6 +49,12 @@ extern const struct ar8xxx_chip ar8337_chip;
 		.name = (_n),	\
 	}
 
+#define AR8216_MIB_RXB_ID	14	/* RxGoodByte */
+#define AR8216_MIB_TXB_ID	29	/* TxByte */
+
+#define AR8236_MIB_RXB_ID	15	/* RxGoodByte */
+#define AR8236_MIB_TXB_ID	31	/* TxByte */
+
 static const struct ar8xxx_mib_desc ar8216_mibs[] = {
 	MIB_DESC(1, AR8216_STATS_RXBROAD, "RxBroad"),
 	MIB_DESC(1, AR8216_STATS_RXPAUSE, "RxPause"),
@@ -1581,6 +1587,56 @@ ar8xxx_sw_set_flush_port_arl_table(struct switch_dev *dev,
 	return ret;
 }
 
+int
+ar8xxx_sw_get_port_stats(struct switch_dev *dev, int port,
+			struct switch_port_stats *stats)
+{
+	struct ar8xxx_priv *priv = swdev_to_ar8xxx(dev);
+	u64 *mib_stats;
+	int ret;
+	int mib_txb_id, mib_rxb_id;
+
+	if (!ar8xxx_has_mib_counters(priv))
+		return -EOPNOTSUPP;
+
+	if (port >= dev->ports)
+		return -EINVAL;
+
+	switch (priv->chip_ver) {
+		case AR8XXX_VER_AR8216:
+			mib_txb_id = AR8216_MIB_TXB_ID;
+			mib_rxb_id = AR8216_MIB_RXB_ID;
+			break;
+		case AR8XXX_VER_AR8236:
+		case AR8XXX_VER_AR8316:
+		case AR8XXX_VER_AR8327:
+		case AR8XXX_VER_AR8337:
+			mib_txb_id = AR8236_MIB_TXB_ID;
+			mib_rxb_id = AR8236_MIB_RXB_ID;
+			break;
+		default:
+			return -EOPNOTSUPP;
+	}
+
+	mutex_lock(&priv->mib_lock);
+	ret = ar8xxx_mib_capture(priv);
+	if (ret)
+		goto unlock;
+
+	ar8xxx_mib_fetch_port_stat(priv, port, false);
+
+	mib_stats = &priv->mib_stats[port * priv->chip->num_mibs];
+
+	stats->tx_bytes = mib_stats[mib_txb_id];
+	stats->rx_bytes = mib_stats[mib_rxb_id];
+
+	ret = 0;
+
+unlock:
+	mutex_unlock(&priv->mib_lock);
+	return ret;
+}
+
 static const struct switch_attr ar8xxx_sw_attr_globals[] = {
 	{
 		.type = SWITCH_TYPE_INT,
@@ -1696,6 +1752,7 @@ static const struct switch_dev_ops ar8xxx_sw_ops = {
 	.apply_config = ar8xxx_sw_hw_apply,
 	.reset_switch = ar8xxx_sw_reset_switch,
 	.get_port_link = ar8xxx_sw_get_port_link,
+	.get_port_stats = ar8xxx_sw_get_port_stats,
 };
 
 static const struct ar8xxx_chip ar8216_chip = {

--- a/target/linux/generic/files/drivers/net/phy/ar8216.h
+++ b/target/linux/generic/files/drivers/net/phy/ar8216.h
@@ -566,6 +566,9 @@ ar8xxx_sw_set_flush_port_arl_table(struct switch_dev *dev,
 				   const struct switch_attr *attr,
 				   struct switch_val *val);
 int
+ar8xxx_sw_get_port_stats(struct switch_dev *dev, int port,
+			struct switch_port_stats *stats);
+int
 ar8216_wait_bit(struct ar8xxx_priv *priv, int reg, u32 mask, u32 val);
 
 static inline struct ar8xxx_priv *

--- a/target/linux/generic/files/drivers/net/phy/ar8327.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8327.c
@@ -1411,6 +1411,7 @@ static const struct switch_dev_ops ar8327_sw_ops = {
 	.apply_config = ar8327_sw_hw_apply,
 	.reset_switch = ar8xxx_sw_reset_switch,
 	.get_port_link = ar8xxx_sw_get_port_link,
+	.get_port_stats = ar8xxx_sw_get_port_stats,
 };
 
 const struct ar8xxx_chip ar8327_chip = {

--- a/target/linux/generic/files/drivers/net/phy/rtl8366_smi.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366_smi.c
@@ -1030,6 +1030,33 @@ int rtl8366_sw_get_port_mib(struct switch_dev *dev,
 }
 EXPORT_SYMBOL_GPL(rtl8366_sw_get_port_mib);
 
+int rtl8366_sw_get_port_stats(struct switch_dev *dev, int port,
+				struct switch_port_stats *stats,
+				int txb_id, int rxb_id)
+{
+	struct rtl8366_smi *smi = sw_to_rtl8366_smi(dev);
+	unsigned long long counter = 0;
+	int ret;
+
+	if (port >= smi->num_ports)
+		return -EINVAL;
+
+	ret = smi->ops->get_mib_counter(smi, txb_id, port, &counter);
+	if (ret)
+		return ret;
+
+	stats->tx_bytes = counter;
+
+	ret = smi->ops->get_mib_counter(smi, rxb_id, port, &counter);
+	if (ret)
+		return ret;
+
+	stats->rx_bytes = counter;
+
+	return 0;
+}
+EXPORT_SYMBOL_GPL(rtl8366_sw_get_port_stats);
+
 int rtl8366_sw_get_vlan_info(struct switch_dev *dev,
 			     const struct switch_attr *attr,
 			     struct switch_val *val)

--- a/target/linux/generic/files/drivers/net/phy/rtl8366_smi.h
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366_smi.h
@@ -146,6 +146,9 @@ int rtl8366_sw_get_vlan_enable(struct switch_dev *dev,
 int rtl8366_sw_set_vlan_enable(struct switch_dev *dev,
 			       const struct switch_attr *attr,
 			       struct switch_val *val);
+int rtl8366_sw_get_port_stats(struct switch_dev *dev, int port,
+				struct switch_port_stats *stats,
+				int txb_id, int rxb_id);
 
 struct rtl8366_smi* rtl8366_smi_probe(struct platform_device *pdev);
 

--- a/target/linux/generic/files/drivers/net/phy/rtl8366rb.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366rb.c
@@ -205,6 +205,9 @@
 #define RTL8366RB_QOS_DEFAULT_PREIFG	1
 
 
+#define RTL8366RB_MIB_RXB_ID		0	/* IfInOctets */
+#define RTL8366RB_MIB_TXB_ID		20	/* IfOutOctets */
+
 static struct rtl8366_mib_counter rtl8366rb_mib_counters[] = {
 	{ 0,  0, 4, "IfInOctets"				},
 	{ 0,  4, 4, "EtherStatsOctets"				},
@@ -1146,6 +1149,13 @@ static int rtl8366rb_sw_reset_port_mibs(struct switch_dev *dev,
 				RTL8366RB_MIB_CTRL_PORT_RESET(val->port_vlan));
 }
 
+static int rtl8366rb_sw_get_port_stats(struct switch_dev *dev, int port,
+					struct switch_port_stats *stats)
+{
+	return (rtl8366_sw_get_port_stats(dev, port, stats,
+				RTL8366RB_MIB_TXB_ID, RTL8366RB_MIB_RXB_ID));
+}
+
 static struct switch_attr rtl8366rb_globals[] = {
 	{
 		.type = SWITCH_TYPE_INT,
@@ -1317,6 +1327,7 @@ static const struct switch_dev_ops rtl8366_ops = {
 	.set_port_pvid = rtl8366_sw_set_port_pvid,
 	.reset_switch = rtl8366_sw_reset_switch,
 	.get_port_link = rtl8366rb_sw_get_port_link,
+	.get_port_stats = rtl8366rb_sw_get_port_stats,
 };
 
 static int rtl8366rb_switch_init(struct rtl8366_smi *smi)

--- a/target/linux/generic/files/drivers/net/phy/rtl8366s.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366s.c
@@ -181,6 +181,9 @@
 #define RTL8366S_VLAN_FID_SHIFT		12
 #define RTL8366S_VLAN_FID_MASK		0x7
 
+#define RTL8366S_MIB_RXB_ID		0	/* IfInOctets */
+#define RTL8366S_MIB_TXB_ID		20	/* IfOutOctets */
+
 static struct rtl8366_mib_counter rtl8366s_mib_counters[] = {
 	{ 0,  0, 4, "IfInOctets"				},
 	{ 0,  4, 4, "EtherStatsOctets"				},
@@ -982,6 +985,13 @@ static int rtl8366s_sw_reset_port_mibs(struct switch_dev *dev,
 				0, (1 << (val->port_vlan + 3)));
 }
 
+static int rtl8366s_sw_get_port_stats(struct switch_dev *dev, int port,
+                                        struct switch_port_stats *stats)
+{
+	return (rtl8366_sw_get_port_stats(dev, port, stats,
+				RTL8366S_MIB_TXB_ID, RTL8366S_MIB_RXB_ID));
+}
+
 static struct switch_attr rtl8366s_globals[] = {
 	{
 		.type = SWITCH_TYPE_INT,
@@ -1105,6 +1115,7 @@ static const struct switch_dev_ops rtl8366_ops = {
 	.set_port_pvid = rtl8366_sw_set_port_pvid,
 	.reset_switch = rtl8366_sw_reset_switch,
 	.get_port_link = rtl8366s_sw_get_port_link,
+	.get_port_stats = rtl8366s_sw_get_port_stats,
 };
 
 static int rtl8366s_switch_init(struct rtl8366_smi *smi)

--- a/target/linux/generic/files/drivers/net/phy/rtl8367.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367.c
@@ -253,6 +253,9 @@ struct rtl8367_initval {
 	u16 val;
 };
 
+#define RTL8367_MIB_RXB_ID		0	/* IfInOctets */
+#define RTL8367_MIB_TXB_ID		20	/* IfOutOctets */
+
 static struct rtl8366_mib_counter rtl8367_mib_counters[] = {
 	{ 0,  0, 4, "IfInOctets"				},
 	{ 0,  4, 2, "Dot3StatsFCSErrors"			},
@@ -1535,6 +1538,13 @@ static int rtl8367_sw_reset_port_mibs(struct switch_dev *dev,
 				RTL8367_MIB_CTRL_PORT_RESET_MASK(port % 8));
 }
 
+static int rtl8367_sw_get_port_stats(struct switch_dev *dev, int port,
+                                        struct switch_port_stats *stats)
+{
+	return (rtl8366_sw_get_port_stats(dev, port, stats,
+				RTL8367_MIB_TXB_ID, RTL8367_MIB_RXB_ID));
+}
+
 static struct switch_attr rtl8367_globals[] = {
 	{
 		.type = SWITCH_TYPE_INT,
@@ -1622,6 +1632,7 @@ static const struct switch_dev_ops rtl8367_sw_ops = {
 	.set_port_pvid = rtl8366_sw_set_port_pvid,
 	.reset_switch = rtl8366_sw_reset_switch,
 	.get_port_link = rtl8367_sw_get_port_link,
+	.get_port_stats = rtl8367_sw_get_port_stats,
 };
 
 static int rtl8367_switch_init(struct rtl8366_smi *smi)

--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -235,6 +235,9 @@ struct rtl8367b_initval {
 	u16 val;
 };
 
+#define RTL8367B_MIB_RXB_ID		0	/* IfInOctets */
+#define RTL8367B_MIB_TXB_ID		28	/* IfOutOctets */
+
 static struct rtl8366_mib_counter
 rtl8367b_mib_counters[RTL8367B_NUM_MIB_COUNTERS] = {
 	{0,   0, 4, "ifInOctets"			},
@@ -1302,6 +1305,13 @@ static int rtl8367b_sw_reset_port_mibs(struct switch_dev *dev,
 				RTL8367B_MIB_CTRL0_PORT_RESET_MASK(port % 8));
 }
 
+static int rtl8367b_sw_get_port_stats(struct switch_dev *dev, int port,
+                                        struct switch_port_stats *stats)
+{
+	return (rtl8366_sw_get_port_stats(dev, port, stats,
+				RTL8367B_MIB_TXB_ID, RTL8367B_MIB_RXB_ID));
+}
+
 static struct switch_attr rtl8367b_globals[] = {
 	{
 		.type = SWITCH_TYPE_INT,
@@ -1382,6 +1392,7 @@ static const struct switch_dev_ops rtl8367b_sw_ops = {
 	.set_port_pvid = rtl8366_sw_set_port_pvid,
 	.reset_switch = rtl8366_sw_reset_switch,
 	.get_port_link = rtl8367b_sw_get_port_link,
+	.get_port_stats = rtl8367b_sw_get_port_stats,
 };
 
 static int rtl8367b_switch_init(struct rtl8366_smi *smi)

--- a/target/linux/generic/files/drivers/net/phy/swconfig_leds.c
+++ b/target/linux/generic/files/drivers/net/phy/swconfig_leds.c
@@ -36,7 +36,7 @@ struct switch_led_trigger {
 	struct delayed_work sw_led_work;
 	u32 port_mask;
 	u32 port_link;
-	unsigned long port_traffic[SWCONFIG_LED_NUM_PORTS];
+	unsigned long long port_traffic[SWCONFIG_LED_NUM_PORTS];
 	u8 link_speed[SWCONFIG_LED_NUM_PORTS];
 };
 

--- a/target/linux/generic/files/include/linux/switch.h
+++ b/target/linux/generic/files/include/linux/switch.h
@@ -59,8 +59,8 @@ struct switch_port_link {
 };
 
 struct switch_port_stats {
-	unsigned long tx_bytes;
-	unsigned long rx_bytes;
+	unsigned long long tx_bytes;
+	unsigned long long rx_bytes;
 };
 
 /**

--- a/target/linux/ramips/files-4.9/drivers/net/ethernet/mtk/mt7530.c
+++ b/target/linux/ramips/files-4.9/drivers/net/ethernet/mtk/mt7530.c
@@ -44,6 +44,12 @@
 #define MT7530_MAX_VID		4095
 #define MT7530_MIN_VID		0
 
+#define MT7530_PORT_MIB_TXB_ID	2	/* TxGOC */
+#define MT7530_PORT_MIB_RXB_ID	6	/* RxGOC */
+
+#define MT7621_PORT_MIB_TXB_ID	18	/* TxByte */
+#define MT7621_PORT_MIB_RXB_ID	37	/* RxByte */
+
 /* registers */
 #define REG_ESW_VLAN_VTCR		0x90
 #define REG_ESW_VLAN_VAWD1		0x94
@@ -744,6 +750,34 @@ static int mt7530_sw_get_port_mib(struct switch_dev *dev,
 	return 0;
 }
 
+static int mt7530_get_port_stats(struct switch_dev *dev, int port,
+					struct switch_port_stats *stats)
+{
+	struct mt7530_priv *priv = container_of(dev, struct mt7530_priv, swdev);
+
+	if (port < 0 || port >= MT7530_NUM_PORTS)
+		return -EINVAL;
+
+	stats->tx_bytes = get_mib_counter_port_7620(priv, MT7530_PORT_MIB_TXB_ID, port);
+	stats->rx_bytes = get_mib_counter_port_7620(priv, MT7530_PORT_MIB_RXB_ID, port);
+
+	return 0;
+}
+
+static int mt7621_get_port_stats(struct switch_dev *dev, int port,
+					struct switch_port_stats *stats)
+{
+	struct mt7530_priv *priv = container_of(dev, struct mt7530_priv, swdev);
+
+	if (port < 0 || port >= MT7530_NUM_PORTS)
+		return -EINVAL;
+
+	stats->tx_bytes = get_mib_counter(priv, MT7621_PORT_MIB_TXB_ID, port);
+	stats->rx_bytes = get_mib_counter(priv, MT7621_PORT_MIB_RXB_ID, port);
+
+	return 0;
+}
+
 static const struct switch_attr mt7530_global[] = {
 	{
 		.type = SWITCH_TYPE_INT,
@@ -811,6 +845,7 @@ static const struct switch_dev_ops mt7621_ops = {
 	.get_port_pvid = mt7530_get_port_pvid,
 	.set_port_pvid = mt7530_set_port_pvid,
 	.get_port_link = mt7530_get_port_link,
+	.get_port_stats = mt7621_get_port_stats,
 	.apply_config = mt7530_apply_config,
 	.reset_switch = mt7530_reset_switch,
 };
@@ -833,6 +868,7 @@ static const struct switch_dev_ops mt7530_ops = {
 	.get_port_pvid = mt7530_get_port_pvid,
 	.set_port_pvid = mt7530_set_port_pvid,
 	.get_port_link = mt7530_get_port_link,
+	.get_port_stats = mt7530_get_port_stats,
 	.apply_config = mt7530_apply_config,
 	.reset_switch = mt7530_reset_switch,
 };


### PR DESCRIPTION
This patch series implements get_port_stats() for several switch devices.

This enables the swconfig_leds trigger to correctly blink selected LED when port(s) traffic occurs.

This change has been successfully tested on mt7620, but **needs testing** for all other devices.