### PR TITLE
ramips: adding support for D-link dwr-921

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -159,6 +159,9 @@ vr500)
 dir-860l-b1)
 	ucidef_set_led_netdev "wan" "wan" "$board:green:net" "eth0.2"
 	;;
+dwr-921-c1)
+	ucidef_set_led_netdev "lan" "lan" "$board:green:lan" "eth0.1"
+	;;
 ex2700|\
 wn3000rpv3)
 	ucidef_set_led_default "power_r" "POWER (red)" "$board:red:power" "0"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -78,6 +78,7 @@ ramips_setup_interfaces()
 	dir-320-b1|\
 	dir-610-a1|\
 	dir-615-h1|\
+	dwr-921-c1|\
 	firewrt|\
 	hlk-rm04|\
 	mac1200rv2|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -178,6 +178,9 @@ ramips_board_detect() {
 	*"DWR-512 B")
 		name="dwr-512-b"
 		;;
+	*"DWR-921 C1")
+		name="dwr-921-c1"
+		;;
 	*"E1700")
 		name="e1700"
 		;;

--- a/target/linux/ramips/dts/DWR-921.dts
+++ b/target/linux/ramips/dts/DWR-921.dts
@@ -1,0 +1,132 @@
+/dts-v1/;
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "d-link,dwr-921", "ralink,mt7620n-soc";
+	model = "D-Link DWR-921 C1";
+
+        gpio-keys-polled {
+                compatible = "gpio-keys-polled";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                poll-interval = <20>;
+
+                wps {
+                        label = "wps";
+                        gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+                        linux,code = <KEY_WPS_BUTTON>;
+                };
+                reset {
+                        label = "reset";
+                        gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+                        linux,code = <KEY_RESTART>;
+                };
+
+        };
+
+        gpio-leds {
+                compatible = "gpio-leds";
+
+                sms {
+                        label = "dwr-921-c1:green:sms";
+                        gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+                };
+                lan {
+                        label = "dwr-921-c1:green:lan";
+                        gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
+                };
+                sstrengthg {
+                        label = "dwr-921-c1:green:sigstrength";
+                        gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+                };
+                sstrengthr {
+                        label = "dwr-921-c1:red:sigstrength";
+                        gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+                };
+                4g {
+                        label = "dwr-921-c1:green:4g";
+                        gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+                };
+                3g {
+                        label = "dwr-921-c1:green:3g";
+                        gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+                };
+
+        };
+
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		uboot: partition@0 {
+			label = "uboot";
+			reg = <0x0 0x40000>;
+			read-only;
+		};
+		
+		uboot_env: partition@40000 {
+			label = "uboot-env";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		firmware: partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfa0000>;
+		};
+
+		config: partition@ff0000 {
+			label = "config";
+			reg = <0xff0000 0x10000>;
+			read-only;
+		};
+
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&config 0xe2ac>;
+	mediatek,portmap = "llllw";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&config 0xe08e>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "i2c", "wdt", "ephy", "spi refclk", "rgmii1", "rgmii2", "nd_sd";
+			ralink,function = "gpio";
+		};
+
+	};
+};

--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -248,6 +248,14 @@
 				ralink,function = "uartlite";
 			};
 		};
+
+                wled_pins: wled {
+                        wled {
+                                ralink,group = "wled";
+                                ralink,function = "wled";
+                        };
+                };
+
 	};
 
 	rstctrl: rstctrl {

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -473,3 +473,10 @@ define Device/d240
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76 kmod-sdhci-mt7620
 endef
 TARGET_DEVICES += d240
+
+define Device/dwr-921
+  DTS := DWR-921
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := D-Link DWR-921
+endef
+TARGET_DEVICES += dwr-921


### PR DESCRIPTION
Two commit here.
The first to update the mt7620n.dtsi describing the wled function,
The second to support the dlink dwr-921.

known bug on dwr-921: the wan port is currently not working.
see more detail in the mailing list
http://lists.infradead.org/pipermail/lede-dev/2017-August/008456.html