### PR TITLE
ramips: add support for the VoCore2 Lite

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -361,6 +361,9 @@ vocore-16M)
 vocore2)
 	set_wifi_led "$board:fuchsia:status"
 	;;
+vocore2lite)
+	set_wifi_led "$board:green:status"
+	;;
 w502u)
 	set_usb_led "$board:blue:usb"
 	set_wifi_led "rt2800pci-phy0::radio"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -302,7 +302,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
 		;;
-	vocore2)
+	vocore2|\
+	vocore2lite)
 		ucidef_add_switch "switch0" \
 			"0:lan" "2:lan" "6t@eth0"
 		;;

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -240,6 +240,9 @@ get_status_led() {
 	vocore2)
 		status_led="$board:fuchsia:status"
 		;;
+	vocore2lite)
+		status_led="$board:green:status"
+		;;
 	w306r-v20|\
 	witi|\
 	zbt-wr8305rt)

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -523,6 +523,9 @@ ramips_board_detect() {
 	*"VoCore2")
 		name="vocore2"
 		;;
+	*"VoCore2-Lite")
+		name="vocore2lite"
+		;;
 	*"VR500")
 		name="vr500"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -149,6 +149,7 @@ platform_check_image() {
 	vocore-8M|\
 	vocore-16M|\
 	vocore2|\
+	vocore2lite|\
 	vr500|\
 	w150m|\
 	w2914nsv2|\

--- a/target/linux/ramips/dts/VOCORE2.dtsi
+++ b/target/linux/ramips/dts/VOCORE2.dtsi
@@ -1,0 +1,49 @@
+#include "mt7628an.dtsi"
+
+/ {
+	compatible = "vocore,vocore2", "mediatek,mt7628an-soc";
+
+	chosen {
+		bootargs = "console=ttyS2,115200";
+	};
+};
+
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wled_an", "perst", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	ralink,mtd-eeprom = <&factory 0x4>;
+};
+
+&esw {
+	mediatek,portmap = <0x7>;
+	mediatek,portdisable = <0x3a>;
+};
+
+&i2s {
+	status = "okay";
+};
+
+&gdma {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};

--- a/target/linux/ramips/dts/VOCORE2LITE.dts
+++ b/target/linux/ramips/dts/VOCORE2LITE.dts
@@ -5,14 +5,14 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	compatible = "vocore,vocore2", "mediatek,mt7628an-soc";
-	model = "VoCore2";
+	compatible = "vocore,vocore2lite", "vocore,vocore2", "mediatek,mt7628an-soc";
+	model = "VoCore2-Lite";
 
 	gpio-leds {
 		compatible = "gpio-leds";
 
 		status {
-			label = "vocore2:fuchsia:status";
+			label = "vocore2lite:green:status";
 			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
@@ -49,7 +49,7 @@
 
 		partition@50000 {
 			label = "firmware";
-			reg = <0x50000 0xfb0000>;
+			reg = <0x50000 0x7b0000>;
 		};
 	};
 };

--- a/target/linux/ramips/image/mt7688.mk
+++ b/target/linux/ramips/image/mt7688.mk
@@ -19,6 +19,15 @@ define Device/pbr-d1
 endef
 TARGET_DEVICES += pbr-d1
 
+define Device/vocore2lite
+  DTS := VOCORE2LITE
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  DEVICE_TITLE := VoCore VoCore2-Lite
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
+    kmod-sdhci kmod-sdhci-mt7620
+endef
+TARGET_DEVICES += vocore2lite
+
 define Device/wrtnode2r
   DTS := WRTNODE2R
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
ramips: add support for the VoCore2 Lite

The VoCore2 Lite uses the same PCB as the Vocore2.
This patch adds support for the VoCore2 Lite.
It also moves the common VoCore2 parts into dtsi and
removes memory node in the device tree source file.
Memory is detected automatically.

http://vocore.io/    http://vonger.net/    http://vonger.cn/
    
    Specifications:
    - SoC: MediaTek MT7688AN
    - RAM: 64MB DDR2 EtronTech EM68B16CWQH-25H
    - Flash: 8MB NOR SPI Flash GigaDevice GD25Q64CWIG
    - Wireless: Built into MT7688AN with onboard IPEX connector
    
    Firmware installation:
    - VoCore2-Lite ships with firmware forked from OpenWrt.
    - Installation from the bootloader is recommended.
    - If using luci/sysupgrade use the -n option (do not keep settings)
      original firmware uses a modified proprietary MediaTek wireless driver.
    - The wireless is disabled by default in LEDE.
    - If reverting to factory firmware using the bootloader is recommended.
    
    Signed-off-by: L. D. Pinney <ldpinney@gmail.com>
    Tested by: Noble Pepper <noblepepper@gmail.com>