### PR TITLE
ramips: set ethernet mac address for VoCore2 devices

### DIFF
--- a/target/linux/ramips/dts/VOCORE2.dtsi
+++ b/target/linux/ramips/dts/VOCORE2.dtsi
@@ -23,6 +23,10 @@
 	ralink,mtd-eeprom = <&factory 0x4>;
 };
 
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
 &esw {
 	mediatek,portmap = <0x7>;
 	mediatek,portdisable = <0x3a>;


### PR DESCRIPTION
Set the Ethernet MAC address as found on mtd2 on the VoCore2 devices.

Signed-off-by: L. D. Pinney <ldpinney@gmail.com>