### PR TITLE
samba36-net: new package

### DIFF
--- a/package/network/services/samba36/Makefile
+++ b/package/network/services/samba36/Makefile
@@ -46,12 +46,19 @@ define Package/samba36-client
   DEPENDS:=+libreadline +libncurses
 endef
 
+define Package/samba36-net
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Samba 3.6 SMB/CIFS net commands
+  URL:=https://www.samba.org/
+  DEPENDS:=+libreadline +libncurses
+endef
+
 define Package/samba36-server/config
 	config PACKAGE_SAMBA_MAX_DEBUG_LEVEL
 		int "Maximum level of compiled-in debug messages"
 		depends on PACKAGE_samba36-server || PACKAGE_samba36-client
 		default -1
-
 endef
 
 define Package/samba36-server/description
@@ -156,6 +163,12 @@ define Package/samba36-client/install
 	$(INSTALL_BIN) $(PKG_BUILD_BIN)/nmblookup $(1)/usr/sbin
 endef
 
+define Package/samba36-net/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_BIN)/net $(1)/usr/sbin
+endef
+
 $(eval $(call BuildPackage,samba36-client))
 $(eval $(call BuildPackage,samba36-server))
+$(eval $(call BuildPackage,samba36-net))
 


### PR DESCRIPTION
Samba could also be usefull for sending commands to windows pc (like shoutdown command). This new package add the bin to include this kind of command to the samba package.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>