### PR TITLE
rules.mk: add missing CPP configuration argument

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -260,6 +260,7 @@ endif
 BUILD_KEY=$(TOPDIR)/key-build
 
 TARGET_CC:=$(TARGET_CROSS)gcc
+TARGET_CPP:=$(TARGET_CROSS)cpp
 TARGET_CXX:=$(TARGET_CROSS)g++
 KPATCH:=$(SCRIPT_DIR)/patch-kernel.sh
 SED:=$(STAGING_DIR_HOST)/bin/sed -i -e
@@ -300,6 +301,7 @@ TARGET_CONFIGURE_OPTS = \
   NM="$(TARGET_NM)" \
   CC="$(TARGET_CC)" \
   GCC="$(TARGET_CC)" \
+  CPP="$(TARGET_CPP)" \
   CXX="$(TARGET_CXX)" \
   RANLIB="$(TARGET_RANLIB)" \
   STRIP=$(TARGET_CROSS)strip \


### PR DESCRIPTION
Some build system (such as waf [https://waf.io](url)) requires CPP variable during configuration phase, for the compatibility, I think this should be pre-set in rules.mk.

Signed-off-by: BangLang Huang <banglang.huang@foxmail.com>