### PR TITLE
base-file: add pkgcheck script

### DIFF
--- a/package/base-files/files/bin/pkgcheck.sh
+++ b/package/base-files/files/bin/pkgcheck.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+OPKG_INFO_DIR=/usr/lib/opkg/info/
+OPKG_ROM_INFO_DIR=/rom/usr/lib/opkg/info/
+
+[ ! -d "${OPKG_ROM_INFO_DIR}" ] && {
+	echo "No ROM filesystem found!"
+	exit 1
+}
+
+package_diff="$(diff -q "${OPKG_INFO_DIR}" "${OPKG_ROM_INFO_DIR}")"
+
+echo "$package_diff" | \
+	sed -e "s|Only in ${OPKG_INFO_DIR}: \(.*\)\..*|Added/Modified: \1|" | \
+	sed -e "s|Files ${OPKG_INFO_DIR}\(.*\)\..* and ${OPKG_ROM_INFO_DIR}.* differ|Added/Modified: \1|" | \
+	sed -e "s|Only in ${OPKG_ROM_INFO_DIR}: \(.*\)\..*|Deleted:        \1|" | \
+	sort | uniq


### PR DESCRIPTION
This script shows in a easy way all packages installed into the overlay
by diff the two opkg dir "usr/lib/opkg/info" and "/rom/usr/lib/opkg/info".

Usefull if you change/reflash your sytem to get the name of the
package which need to get re/installed on a blank box.

Signed-off-by: Florian Eckert <fe@dev.tdt.de>