### PR TITLE
ramips: add Xiaomi Mi Router 3G support

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -242,6 +242,10 @@ miniembplug)
 	set_wifi_led "$board:red:wlan"
 	set_usb_led "$board:green:mobile"
 	;;
+mir3g)
+	ucidef_set_led_netdev "eth" "Ethernet" "$board:red:wan" "eth0"
+	set_usb_led "$board:blue:usb"
+	;;
 miwifi-mini)
 	ucidef_set_led_default "power" "power" "$board:red:status" "1"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -122,6 +122,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
+	mir3g)
+		ucidef_add_switch "switch0" \
+			"1:wan" "2:lan:2" "3:lan:1" "6@eth0"
+		;;
 	psg1218b)
 		ucidef_add_switch "switch0" \
 			"0:lan:3" "1:lan:2" "2:lan:1" "3:wan" "6@eth0"
@@ -420,6 +424,9 @@ ramips_setup_macs()
 	mac1200rv2)
 		lan_mac=$(mtd_get_mac_binary factory_info 13)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
+	mir3g)
+		lan_mac=$(mtd_get_mac_binary Factory e006)
 		;;
 	miwifi-mini)
 		wan_mac=$(cat /sys/class/net/eth0/address)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -177,6 +177,9 @@ get_status_led() {
 	m4-8M)
 		status_led="m4:blue:status"
 		;;
+	mir3g)
+		status_led="$board:yellow:status"
+		;;
 	miwifi-mini|\
 	zte-q7)
 		status_led="$board:red:status"

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -286,6 +286,9 @@ ramips_board_detect() {
 	*"Mercury MAC1200R v2")
 		name="mac1200rv2"
 		;;
+	*"Mi Router 3G")
+		name="mir3g"
+		;;
 	*"MicroWRT")
 		name="microwrt"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -251,6 +251,7 @@ platform_check_image() {
 		return 0
 		;;
 	hc5962|\
+	mir3g|\
 	r6220)
 		# these boards use metadata images
 		return 0
@@ -297,6 +298,7 @@ platform_do_upgrade() {
 
 	case "$board" in
 	hc5962|\
+	mir3g|\
 	r6220|\
 	ubnt-erx|\
 	ubnt-erx-sfp)

--- a/target/linux/ramips/dts/MIR3G.dts
+++ b/target/linux/ramips/dts/MIR3G.dts
@@ -1,0 +1,163 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "xiaomi,mir3g", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router 3G";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wan {
+			label = "mir3g:red:wan";
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "mir3g:blue:usb";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		status {
+			label = "mir3g:yellow:status";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partition@0 {
+		label = "Bootloader";
+		reg = <0x0 0x80000>;
+		read-only;
+	};
+
+	partition@80000 {
+		label = "Config";
+		reg = <0x80000 0x40000>;
+		read-only;
+	};
+
+	partition@c0000 {
+		label = "Bdata";
+		reg = <0xc0000 0x40000>;
+		read-only;
+	};
+
+	factory: partition@100000 {
+		label = "Factory";
+		reg = <0x100000 0x40000>;
+		read-only;
+	};
+
+	partition@140000 {
+		label = "crash";
+		reg = <0x140000 0x40000>;
+		read-only;
+	};
+
+	partition@180000 {
+		label = "crash_syslog";
+		reg = <0x180000 0x40000>;
+		read-only;
+	};
+
+	partition@1c0000 {
+		label = "reserved0";
+		reg = <0x1c0000 0x40000>;
+		read-only;
+	};
+
+	/* 
+	 * kernel0 partition should be erased, so 
+	 * u-boot in failsafe routine switches 
+	 * to next one looking for kernel image.
+	 * To remind about this fact rename kernel0
+	 * into kernel_erase.
+	 */
+	partition@200000 {
+		label = "kernel_erase";
+		reg = <0x200000 0x400000>;
+	};
+
+	partition@600000 {
+		label = "kernel";
+		reg = <0x600000 0x400000>;
+	};
+
+	/* ubi partition is the result of squashing
+	 * next consequent stock partitions:
+	 * - rootfs0 (rootfs partition for stock kernel0), 
+	 * - rootfs1 (rootfs partition for stock failsafe kernel1), 
+	 * - overlay (used as ubi overlay in stock fw)
+	 * resulting 117,5MiB space for packages.
+	 */
+	partition@a00000 {
+		label = "ubi";
+		reg = <0xa00000 0x7580000>;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		wifi@14c3,7603 {
+			compatible = "pci14c3,7603";
+			reg = <0x0000 0 0 0 0>;
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+			ieee80211-freq-limit = <2400000 2500000>;
+		};
+	};	
+
+	pcie1 {
+		wifi@14c3,7662 {
+			compatible = "pci14c3,7662";
+			reg = <0x0000 0 0 0 0>;
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+	mediatek,portmap = "lwlll";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "jtag", "uart3", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -105,6 +105,26 @@ define Device/k2p
 endef
 TARGET_DEVICES += k2p
 
+define Device/mir3g
+  DTS := MIR3G
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  IMAGE_SIZE := 32768k
+  UBINIZE_OPTS := -E 5
+  IMAGES := sysupgrade.tar kernel1.bin rootfs0.bin
+  IMAGE/kernel1.bin := append-kernel
+  IMAGE/rootfs0.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
+  DEVICE_TITLE := Xiaomi Mi Router 3G
+  SUPPORTED_DEVICES += R3G
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-mini \
+	kmod-softdog
+endef
+TARGET_DEVICES += mir3g
+
 define Device/mt7621
   DTS := MT7621
   BLOCKSIZE := 64k


### PR DESCRIPTION
This commit adds support for Xiaomi Mi WiFi Router 3G.

Short specification:
 - MT7621AT + MT7603EN + 7612EN
 - 256MB DDR3 RAM
 - 128MB NAND flash
 - 1+2 x 1000M Ethernet
 - 1x USB 3.0 port
 - reset button
 - yellow, blue, red leds

Installation through telnet/ssh:
- copy lede-ramips-mt7621-mir3g-squashfs-kernel1.bin and lede-ramips-mt7621-mir3g-squashfs-rootfs0.bin to usb disk or wget it from LEDE download site to /tmp
- switch to /extdisks/sda1/ (if copied to USB drive) or to /tmp if wgetted from LEDE download site
- run: mtd write lede-ramips-mt7621-mir3g-squashfs-kernel1.bin kernel1
- run: mtd write lede-ramips-mt7621-mir3g-squashfs-rootfs0.bin rootfs0
- run: mtd erase kernel0
- run: reboot

Originally stock firmware has following partitions:
 - ...
 - kernel0 (primary kernel image)
 - kernel1 (secondary kernel image, used by u-boot in failsafe routine)
 - rootfs0 (primary rootfs)
 - rootfs1 (secondary rootfs in case primary fails)
 - overlay (used as ubi overlay)

This commit squashes rootfs0, rootfs1 and overlay partitions into 1, so it can be used by LEDE fully for package installation, resulting in 117,5MiB.

This device lacks hw watchdog, so adding softdog instead (stock does the same).