### PR TITLE
uboot-mvebu: fix build on macOS

### DIFF
--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -16,7 +16,9 @@ PKG_HASH:=f54baf3f9325bf444c7905f3a5b6f83680edb1e6e1a4d5f8a5ad80abe885113f
 include $(INCLUDE_DIR)/u-boot.mk
 include $(INCLUDE_DIR)/package.mk
 
-UBOOT_MAKE_FLAGS:=
+UBOOT_MAKE_FLAGS:= \
+	PKG_CONFIG_PATH="$(STAGING_DIR_HOST)/lib/pkgconfig:$(PKG_CONFIG_PATH)" \
+	PKG_CONFIG_LIBDIR="$(STAGING_DIR_HOST)/lib/pkgconfig:$(PKG_CONFIG_LIBDIR)"
 
 define U-Boot/Default
   BUILD_TARGET:=mvebu

--- a/package/boot/uboot-mvebu/patches/0901-use-host-pkg-config-libssl.patch
+++ b/package/boot/uboot-mvebu/patches/0901-use-host-pkg-config-libssl.patch
@@ -1,0 +1,11 @@
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -152,7 +152,7 @@ endif
+ # MXSImage needs LibSSL
+ ifneq ($(CONFIG_MX23)$(CONFIG_MX28)$(CONFIG_ARMADA_38X)$(CONFIG_ARMADA_39X)$(CONFIG_FIT_SIGNATURE),)
+ HOSTLOADLIBES_mkimage += \
+-	$(shell pkg-config --libs libssl libcrypto 2> /dev/null || echo "-lssl -lcrypto")
++	$(shell pkg-config.real --libs libssl libcrypto 2> /dev/null || echo "-lssl -lcrypto")
+ 
+ # OS X deprecate openssl in favour of CommonCrypto, supress deprecation
+ # warnings on those systems


### PR DESCRIPTION
macOS no longer provides OpenSSL/libssl which is required to build u-boot for mvebu. LibreSSL is built to work around this elsewhere and u-boot uses pkg-config to include libssl, however a workaround is required to use the correct host staging directories for pkg-config.