### PR TITLE
package/firewall: add start/stop/reload hotplug events

### DIFF
--- a/package/network/config/firewall/patches/0001-rename-fw3-hotplug.patch
+++ b/package/network/config/firewall/patches/0001-rename-fw3-hotplug.patch
@@ -1,0 +1,33 @@
+--- a/utils.c
++++ b/utils.c
+@@ -711,7 +711,7 @@ fw3_free_list(struct list_head *head)
+ }
+ 
+ bool
+-fw3_hotplug(bool add, void *zone, void *device)
++fw3_hotplug_zone(bool add, void *zone, void *device)
+ {
+ 	struct fw3_zone *z = zone;
+ 	struct fw3_device *d = device;
+--- a/utils.h
++++ b/utils.h
+@@ -106,7 +106,7 @@ void fw3_free_object(void *obj, const vo
+ 
+ void fw3_free_list(struct list_head *head);
+ 
+-bool fw3_hotplug(bool add, void *zone, void *device);
++bool fw3_hotplug_zone(bool add, void *zone, void *device);
+ 
+ int fw3_netmask2bitlen(int family, void *mask);
+ 
+--- a/zones.c
++++ b/zones.c
+@@ -703,7 +703,7 @@ fw3_hotplug_zones(struct fw3_state *stat
+ 		if (add != fw3_hasbit(z->flags[0], FW3_FLAG_HOTPLUG))
+ 		{
+ 			list_for_each_entry(d, &z->devices, list)
+-				fw3_hotplug(add, z, d);
++				fw3_hotplug_zone(add, z, d);
+ 
+ 			if (add)
+ 				fw3_setbit(z->flags[0], FW3_FLAG_HOTPLUG);

--- a/package/network/config/firewall/patches/0002-add-hotplug-events.patch
+++ b/package/network/config/firewall/patches/0002-add-hotplug-events.patch
@@ -1,0 +1,87 @@
+--- a/main.c
++++ b/main.c
+@@ -181,7 +181,10 @@ stop(bool complete)
+ 	}
+ 
+ 	if (!print_family && run_state)
++	{
++		fw3_hotplug("stop");
+ 		fw3_hotplug_zones(run_state, false);
++	}
+ 
+ 	for (family = FW3_FAMILY_V4; family <= FW3_FAMILY_V6; family++)
+ 	{
+@@ -304,6 +307,7 @@ start(void)
+ 		{
+ 			fw3_run_includes(cfg_state, false);
+ 			fw3_hotplug_zones(cfg_state, true);
++			fw3_hotplug("start");
+ 			fw3_write_statefile(cfg_state);
+ 		}
+ 	}
+@@ -324,6 +328,7 @@ reload(void)
+ 		return start();
+ 
+ 	fw3_hotplug_zones(run_state, false);
++	fw3_hotplug("reload");
+ 
+ 	for (family = FW3_FAMILY_V4; family <= FW3_FAMILY_V6; family++)
+ 	{
+--- a/utils.c
++++ b/utils.c
+@@ -749,6 +749,35 @@ fw3_hotplug_zone(bool add, void *zone, v
+ 	return false;
+ }
+ 
++bool
++fw3_hotplug(const char *event)
++{
++	switch (fork())
++	{
++	case -1:
++		warn("Unable to fork(): %s\n", strerror(errno));
++		return false;
++
++	case 0:
++		break;
++
++	default:
++		return true;
++	}
++
++	close(0);
++	close(1);
++	close(2);
++	if (chdir("/")) {};
++
++	clearenv();
++	setenv("ACTION", event, 1);
++	execl(FW3_HOTPLUG, FW3_HOTPLUG, "firewall", NULL);
++
++	/* unreached */
++	return false;
++}
++
+ int
+ fw3_netmask2bitlen(int family, void *mask)
+ {
+--- a/utils.h
++++ b/utils.h
+@@ -38,7 +38,7 @@
+ 
+ #define FW3_STATEFILE	"/var/run/fw3.state"
+ #define FW3_LOCKFILE	"/var/run/fw3.lock"
+-#define FW3_HOTPLUG     "/sbin/hotplug-call"
++#define FW3_HOTPLUG	"/sbin/hotplug-call"
+ 
+ extern bool fw3_pr_debug;
+ 
+@@ -108,6 +108,8 @@ void fw3_free_list(struct list_head *hea
+ 
+ bool fw3_hotplug_zone(bool add, void *zone, void *device);
+ 
++bool fw3_hotplug(const char *event);
++
+ int fw3_netmask2bitlen(int family, void *mask);
+ 
+ bool fw3_bitlen2netmask(int family, int bits, void *mask);


### PR DESCRIPTION
I have added the following hotplug events into fw3
- start
- stop
- reload

This is a replacement for PR #1270 
