### PR TITLE
ath10k: fix rx ring buffer memory leak and spectral scan on some boards

### DIFF
--- a/package/kernel/mac80211/patches/332-ath10k-fix-rx-ring-buffer-memory-leak.patch
+++ b/package/kernel/mac80211/patches/332-ath10k-fix-rx-ring-buffer-memory-leak.patch
@@ -1,0 +1,58 @@
+From f35a7f91f66af528b3ee1921de16bea31d347ab0 Mon Sep 17 00:00:00 2001
+From: Rakesh Pillai <pillair@qti.qualcomm.com>
+Date: Wed, 2 Aug 2017 16:03:37 +0530
+Subject: ath10k: fix memory leak in rx ring buffer allocation
+
+The rx ring buffers are added to a hash table if
+firmware support full rx reorder. If the full rx
+reorder support flag is not set before allocating
+the rx ring buffers, none of the buffers are added
+to the hash table.
+
+There is a race condition between rx ring refill and
+rx buffer replenish from napi poll. The interrupts are
+enabled in hif start, before the rx ring is refilled during init.
+We replenish buffers from napi poll due to the interrupts which
+get enabled after hif start. Hence before the entire rx ring is
+refilled during the init, the napi poll replenishes a few buffers
+in steps of 100 buffers per attempt. During this rx ring replenish
+from napi poll, the rx reorder flag has not been set due to which
+the replenished buffers are not added to the hash table
+
+Set the rx full reorder support flag before we allocate
+the rx ring buffer to avoid the memory leak.
+
+Signed-off-by: Rakesh Pillai <pillair@qti.qualcomm.com>
+Signed-off-by: Kalle Valo <kvalo@qca.qualcomm.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -1957,6 +1957,12 @@ int ath10k_core_start(struct ath10k *ar,
+ 		goto err_wmi_detach;
+ 	}
+ 
++	/* If firmware indicates Full Rx Reorder support it must be used in a
++	 * slightly different manner. Let HTT code know.
++	 */
++	ar->htt.rx_ring.in_ord_rx = !!(test_bit(WMI_SERVICE_RX_FULL_REORDER,
++						ar->wmi.svc_map));
++
+ 	status = ath10k_htt_rx_alloc(&ar->htt);
+ 	if (status) {
+ 		ath10k_err(ar, "failed to alloc htt rx: %d\n", status);
+@@ -2065,12 +2071,6 @@ int ath10k_core_start(struct ath10k *ar,
+ 		goto err_hif_stop;
+ 	}
+ 
+-	/* If firmware indicates Full Rx Reorder support it must be used in a
+-	 * slightly different manner. Let HTT code know.
+-	 */
+-	ar->htt.rx_ring.in_ord_rx = !!(test_bit(WMI_SERVICE_RX_FULL_REORDER,
+-						ar->wmi.svc_map));
+-
+ 	status = ath10k_htt_rx_ring_refill(ar);
+ 	if (status) {
+ 		ath10k_err(ar, "failed to refill htt rx ring: %d\n", status);

--- a/package/kernel/mac80211/patches/333-ath10k-fix-spectral-scan.patch
+++ b/package/kernel/mac80211/patches/333-ath10k-fix-spectral-scan.patch
@@ -1,0 +1,180 @@
+From a4aab099cc9e7c4c94b8a0973b2a483c69b541e3 Mon Sep 17 00:00:00 2001
+From: Mohammed Shafi Shajakhan <mohammed@qti.qualcomm.com>
+Date: Mon, 10 Apr 2017 21:08:17 +0530
+Subject: ath10k: fix spectral scan for QCA99X0 family of chipsets
+
+spectral_bin length (number of bins per fft sample) is usually
+a value where (2^n = value), n is an integer.  All of the QCA99X0
+family of chipsets seems to report a spectral_bin length of
+2^n + 'm' bytes, where m = 4, 12 based on the chipset. This 'm'
+bytes seems to carry some radar related info which is currently
+discarded only for 'bin_len = 68' bytes. Extend this discarding of
+irrelevant 'bin_len' for QCA9984, QCA9888, IPQ4019 as well by
+introducing a hardware parameter 'spectral_bin_discard'. Also
+for QCA988X based family of chipsets which doesn't seem to have this
+issue and also for some of the hardware which I have not tested
+like QCA6174/QCA9377 the existing behaviour is retained as it is.
+
+Signed-off-by: Mohammed Shafi Shajakhan <mohammed@qti.qualcomm.com>
+Signed-off-by: Kalle Valo <kvalo@qca.qualcomm.com>
+---
+ drivers/net/wireless/ath/ath10k/core.c     | 12 ++++++++++++
+ drivers/net/wireless/ath/ath10k/hw.h       |  3 +++
+ drivers/net/wireless/ath/ath10k/spectral.c | 26 +++++++++++++++++---------
+ 3 files changed, 32 insertions(+), 9 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -71,6 +71,7 @@ static const struct ath10k_hw_params ath
+ 		},
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
++		.spectral_bin_discard = 0,
+ 	},
+ 	{
+ 		.id = QCA9887_HW_1_0_VERSION,
+@@ -91,6 +92,7 @@ static const struct ath10k_hw_params ath
+ 		},
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
++		.spectral_bin_discard = 0,
+ 	},
+ 	{
+ 		.id = QCA6174_HW_2_1_VERSION,
+@@ -110,6 +112,7 @@ static const struct ath10k_hw_params ath
+ 		},
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
++		.spectral_bin_discard = 0,
+ 	},
+ 	{
+ 		.id = QCA6174_HW_2_1_VERSION,
+@@ -129,6 +132,7 @@ static const struct ath10k_hw_params ath
+ 		},
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
++		.spectral_bin_discard = 0,
+ 	},
+ 	{
+ 		.id = QCA6174_HW_3_0_VERSION,
+@@ -148,6 +152,7 @@ static const struct ath10k_hw_params ath
+ 		},
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
++		.spectral_bin_discard = 0,
+ 	},
+ 	{
+ 		.id = QCA6174_HW_3_2_VERSION,
+@@ -168,6 +173,7 @@ static const struct ath10k_hw_params ath
+ 		},
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
++		.spectral_bin_discard = 0,
+ 	},
+ 	{
+ 		.id = QCA99X0_HW_2_0_DEV_VERSION,
+@@ -193,6 +199,7 @@ static const struct ath10k_hw_params ath
+ 		.sw_decrypt_mcast_mgmt = true,
+ 		.hw_ops = &qca99x0_ops,
+ 		.decap_align_bytes = 1,
++		.spectral_bin_discard = 4,
+ 	},
+ 	{
+ 		.id = QCA9984_HW_1_0_DEV_VERSION,
+@@ -219,6 +226,7 @@ static const struct ath10k_hw_params ath
+ 		.sw_decrypt_mcast_mgmt = true,
+ 		.hw_ops = &qca99x0_ops,
+ 		.decap_align_bytes = 1,
++		.spectral_bin_discard = 12,
+ 	},
+ 	{
+ 		.id = QCA9888_HW_2_0_DEV_VERSION,
+@@ -244,6 +252,7 @@ static const struct ath10k_hw_params ath
+ 		.sw_decrypt_mcast_mgmt = true,
+ 		.hw_ops = &qca99x0_ops,
+ 		.decap_align_bytes = 1,
++		.spectral_bin_discard = 12,
+ 	},
+ 	{
+ 		.id = QCA9377_HW_1_0_DEV_VERSION,
+@@ -263,6 +272,7 @@ static const struct ath10k_hw_params ath
+ 		},
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
++		.spectral_bin_discard = 0,
+ 	},
+ 	{
+ 		.id = QCA9377_HW_1_1_DEV_VERSION,
+@@ -282,6 +292,7 @@ static const struct ath10k_hw_params ath
+ 		},
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
++		.spectral_bin_discard = 0,
+ 	},
+ 	{
+ 		.id = QCA4019_HW_1_0_DEV_VERSION,
+@@ -308,6 +319,7 @@ static const struct ath10k_hw_params ath
+ 		.sw_decrypt_mcast_mgmt = true,
+ 		.hw_ops = &qca99x0_ops,
+ 		.decap_align_bytes = 1,
++		.spectral_bin_discard = 4,
+ 	},
+ };
+ 
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -391,6 +391,9 @@ struct ath10k_hw_params {
+ 	 */
+ 	u32 max_probe_resp_desc_thres;
+ 
++	/* Number of bytes to be discarded for each FFT sample */
++	int spectral_bin_discard;
++
+ 	u32 tx_chain_mask;
+ 	u32 rx_chain_mask;
+ 	u32 max_spatial_stream;
+--- a/drivers/net/wireless/ath/ath10k/spectral.c
++++ b/drivers/net/wireless/ath/ath10k/spectral.c
+@@ -56,6 +56,21 @@ static uint8_t get_max_exp(s8 max_index,
+ 	return max_exp;
+ }
+ 
++static inline size_t ath10k_spectral_fix_bin_size(struct ath10k *ar,
++						  size_t bin_len)
++{
++	/* some chipsets reports bin size as 2^n bytes + 'm' bytes in
++	 * report mode 2. First 2^n bytes carries inband tones and last
++	 * 'm' bytes carries band edge detection data mainly used in
++	 * radar detection purpose. Strip last 'm' bytes to make bin size
++	 * as a valid one. 'm' can take possible values of 4, 12.
++	 */
++	if (!is_power_of_2(bin_len))
++		bin_len -= ar->hw_params.spectral_bin_discard;
++
++	return bin_len;
++}
++
+ int ath10k_spectral_process_fft(struct ath10k *ar,
+ 				struct wmi_phyerr_ev_arg *phyerr,
+ 				const struct phyerr_fft_report *fftr,
+@@ -70,18 +85,11 @@ int ath10k_spectral_process_fft(struct a
+ 
+ 	fft_sample = (struct fft_sample_ath10k *)&buf;
+ 
++	bin_len = ath10k_spectral_fix_bin_size(ar, bin_len);
++
+ 	if (bin_len < 64 || bin_len > SPECTRAL_ATH10K_MAX_NUM_BINS)
+ 		return -EINVAL;
+ 
+-	/* qca99x0 reports bin size as 68 bytes (64 bytes + 4 bytes) in
+-	 * report mode 2. First 64 bytes carries inband tones (-32 to +31)
+-	 * and last 4 byte carries band edge detection data (+32) mainly
+-	 * used in radar detection purpose. Strip last 4 byte to make bin
+-	 * size is valid one.
+-	 */
+-	if (bin_len == 68)
+-		bin_len -= 4;
+-
+ 	reg0 = __le32_to_cpu(fftr->reg0);
+ 	reg1 = __le32_to_cpu(fftr->reg1);
+ 

--- a/package/kernel/mac80211/patches/921-ath10k_init_devices_synchronously.patch
+++ b/package/kernel/mac80211/patches/921-ath10k_init_devices_synchronously.patch
@@ -14,7 +14,7 @@ Signed-off-by: Sven Eckelmann <sven@open-mesh.com>
 
 --- a/drivers/net/wireless/ath/ath10k/core.c
 +++ b/drivers/net/wireless/ath/ath10k/core.c
-@@ -2329,6 +2329,16 @@ int ath10k_core_register(struct ath10k *
+@@ -2341,6 +2341,16 @@ int ath10k_core_register(struct ath10k *
  	ar->chip_id = chip_id;
  	queue_work(ar->workqueue, &ar->register_work);
  

--- a/package/kernel/mac80211/patches/936-ath10k-fix-otp-failure-result.patch
+++ b/package/kernel/mac80211/patches/936-ath10k-fix-otp-failure-result.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/wireless/ath/ath10k/core.c
 +++ b/drivers/net/wireless/ath/ath10k/core.c
-@@ -691,7 +691,7 @@ static int ath10k_core_get_board_id_from
+@@ -703,7 +703,7 @@ static int ath10k_core_get_board_id_from
  	if (ret) {
  		ath10k_err(ar, "could not execute otp for board id check: %d\n",
  			   ret);


### PR DESCRIPTION
- ath10k: fix ring buffer memory leak
Backporting ath.git commit that moves rx ring buffer reorder flag earlier in the sequence thus avoiding race condition and preventing memory leak.

Fixes FS#801 - wifi crash caused by rx ring buffer corruption.

- ath10k: fix spectral scan
Backporting ath.git commit that fixes spectral scan for qca9984, qca9888, ipq4019 because of different spectral data length provided by the board.
