### PR TITLE
dnsmasq: add support for multiple tags for each host.

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -322,12 +322,17 @@ dhcp_host_add() {
 			hex_to_hostid hostid "$hostid"
 	fi
 
+	tags=""
+	if [ -n "$tag" ]; then
+		for t in $tag; do append tags "$t" ",set:"; done
+	fi
+
 	config_get_bool broadcast "$cfg" broadcast 0
 	config_get leasetime "$cfg" leasetime
 
 	[ "$broadcast" = "0" ] && broadcast= || broadcast=",set:needs-broadcast"
 
-	hosttag="${networkid:+,set:${networkid}}${tag:+,set:${tag}}$broadcast"
+	hosttag="${networkid:+,set:${networkid}}${tags:+,set:${tags}}$broadcast"
 	nametime="${name:+,$name}${leasetime:+,$leasetime}"
 
 	if [ $DNSMASQ_DHCP_VER -eq 6 ]; then


### PR DESCRIPTION
Currently, dnsmasq support assigning multiple tags to a host record
(--dhcp-host), but we only support only 1 tag for a host. The commit
makes the following config to be valid:

  config host
      option name 'computer'
      option mac '00:11:22:33:44:55'
      option ip '192.168.1.100'
      list tag 'vendor_class'
      list tag 'vendor_id'

  config tag 'vendor_class'
      list dhcp_option 'option:vendor-class,00:...<omitted>'

  config tag 'vendor_id'
      option force '1'
      list dhcp_option 'option:vendor-id-encap,00:...<omitted>'
