### PR TITLE
ramips: add support for Youku-L2 router

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -440,7 +440,8 @@ zbt-wr8305rt)
 zte-q7)
 	set_wifi_led "$board:blue:status"
 	;;
-youku-yk1)
+youku-yk1|\
+yk-l2)
 	ucidef_set_led_default "power" "power" "$board:blue:power" "1"
 	set_wifi_led "$board:blue:air"
 	set_usb_led "$board:blue:usb"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -111,6 +111,7 @@ ramips_setup_interfaces()
 	wt1520-8M|\
 	y1|\
 	youku-yk1|\
+        yk-l2|\
 	zbt-ape522ii|\
 	zbt-we1326|\
 	zbt-we826-16M|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -715,6 +715,9 @@ ramips_board_detect() {
 	*"YK1")
 		name="youku-yk1"
 		;;
+	*"YOUKU-L2")
+		name="yk-l2"
+		;;
 	*)
 		name="generic"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -117,6 +117,7 @@ platform_check_image() {
 	pbr-m1|\
 	psg1208|\
 	psg1218a|\
+	yk-l2|\
 	psg1218b|\
 	psr-680w|\
 	px-4885-4M|\

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -321,6 +321,16 @@ define Device/zbt-we1326
 endef
 TARGET_DEVICES += zbt-we1326
 
+define Device/yk-l2
+  DTS := YOUKU-L2
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := YOUKU-L2
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-mt76x2 kmod-sdhci-mt7620 \
+	kmod-usb3 kmod-usb-ledtrig-usbport wpad
+endef
+TARGET_DEVICES += yk-l2
+
 define Device/zbt-wg2626
   DTS := ZBT-WG2626
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
ramips: Add Youku-L2 router support

This a MT7621 based board, 256 MB RAM, 16 MB SPI flash,
with onboard MT7603EN 2.4G wifi and MT7612EN 5G wifi,
 3 ethernet ports and 1 USB3.0 host port