### PR TITLE
comgt-ncm: add support for specifying modem manufacturer

### DIFF
--- a/package/network/utils/comgt/Makefile
+++ b/package/network/utils/comgt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=comgt
 PKG_VERSION:=0.32
-PKG_RELEASE:=29
+PKG_RELEASE:=30
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=@SF/comgt


### PR DESCRIPTION
Add `manufacturer` option for manual modem manufacturer selection.

On Huawei E3372 manufacturer string cannot be reliably determined using
`AT+CGMI` due to:
 1. modem mixing periodic (unsolicited) status messages with reply to
    AT commands,
 2. the lack of prefix in `AT+CGMI` response which makes distinguishing
    the reply from random status messages impossible.

What's worse when auto-detection returns invalid (random) manufacturer
name, interface is in FAILED state and it's impossible to bring it up
even manually without touching uci configuration.

A real-life example of `AT+CGMI` output from Huawei E3372 below. In this
case, autodetection returns `a` as a manufacturer:

```
A
^RSSI:20

^HCSQ:"LTE",49,39,121,20
T+CGMI
huawei

OK
```
