### PR TITLE
Update ARV7519RW22.dts

### DIFF
--- a/target/linux/lantiq/dts/ARV7519RW22.dts
+++ b/target/linux/lantiq/dts/ARV7519RW22.dts
@@ -91,7 +91,8 @@
 		};
 
 		pcie@d900000 {
-			status = "disabled";
+			status = "okay";
+			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 		};
 	};
 


### PR DESCRIPTION
Enable PCIe bus and therefore access to the wifi chipset for this platform




