### PR TITLE
packages: add ifrename util from the wireless-tools

### DIFF
--- a/package/network/utils/wireless-tools/Makefile
+++ b/package/network/utils/wireless-tools/Makefile
@@ -52,6 +52,19 @@ define Package/libiw/description
  "Linux Wireless Extensions".
 endef
 
+define Package/ifrename
+$(call Package/wireless-tools/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Tool to rename network interfaces
+  DEPENDS:= +libiw
+endef
+
+define Package/ifrename/description
+ This package installs the tool ifrename from wireless-tools,
+ which makes it possible to rename network interfaces.
+endef
+
 define Build/Compile
 	rm -rf $(PKG_INSTALL_DIR)
 	mkdir -p $(PKG_INSTALL_DIR)
@@ -60,12 +73,13 @@ define Build/Compile
 		CFLAGS="$(TARGET_CFLAGS) -I." \
 		BUILD_WE_ESSENTIAL=y \
 		LIBS="-lm -Wl,--gc-sections" \
-		libiw.so.$(PKG_VERSION) iwmulticall
+		libiw.so.$(PKG_VERSION) iwmulticall ifrename
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		PREFIX="$(PKG_INSTALL_DIR)" \
 		INSTALL_DIR="$(PKG_INSTALL_DIR)/usr/sbin" \
 		INSTALL_LIB="$(PKG_INSTALL_DIR)/usr/lib" \
 		install-iwmulticall
+	install -m 755 $(PKG_BUILD_DIR)/ifrename $(PKG_INSTALL_DIR)/usr/sbin
 endef
 
 define Build/InstallDev
@@ -88,5 +102,11 @@ define Package/libiw/install
 	$(CP) $(PKG_BUILD_DIR)/libiw.so.* $(1)/usr/lib/
 endef
 
+define Package/ifrename/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ifrename $(1)/usr/sbin/
+endef
+
 $(eval $(call BuildPackage,wireless-tools))
 $(eval $(call BuildPackage,libiw))
+$(eval $(call BuildPackage,ifrename))

--- a/package/network/utils/wireless-tools/patches/005-dont-load-mapping-file-if-new_name-is-used.patch
+++ b/package/network/utils/wireless-tools/patches/005-dont-load-mapping-file-if-new_name-is-used.patch
@@ -1,0 +1,39 @@
+Don't load mapping file if using options '-n' + '-i' [ifrename]
+
+Backport from version 30-pre9
+
+--- a/ifrename.c
++++ b/ifrename.c
+@@ -2666,10 +2666,6 @@ main(int	argc,
+ 	}
+     }
+ 
+-  /* Read the specified/default config file, or stdin. */
+-  if(mapping_readfile(conf_file) < 0)
+-    return(-1);
+-
+   /* Create a channel to the NET kernel. */
+   if((skfd = iw_sockets_open()) < 0)
+     {
+@@ -2688,6 +2684,10 @@ main(int	argc,
+ 	}
+       else
+ 	{
++	  /* Read the specified/default config file, or stdin. */
++	  if(mapping_readfile(conf_file) < 0)
++	    return(-1);
++
+ 	  /* Rename only this interface based on mappings
+ 	   * Mostly used for HotPlug processing (from /etc/hotplug/net.agent)
+ 	   * or udev processing (from a udev IMPORT rule).
+@@ -2700,6 +2700,10 @@ main(int	argc,
+     }
+   else
+     {
++      /* Read the specified/default config file, or stdin. */
++      if(mapping_readfile(conf_file) < 0)
++	return(-1);
++
+       /* Load all the necesary modules */
+       if(use_probe)
+ 	{


### PR DESCRIPTION
This tool makes it possible to simply rename netdevices.

example: ifrename -i ptm0 -n dsl0

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
