### PR TITLE
wwan: fix extra bracket in some modem definitions

### DIFF
--- a/package/network/utils/wwan/files/data/0421-03a7
+++ b/package/network/utils/wwan/files/data/0421-03a7
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia C5-00 Mobile phone",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0421-060d
+++ b/package/network/utils/wwan/files/data/0421-060d
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia CS-10",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0421-060e
+++ b/package/network/utils/wwan/files/data/0421-060e
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia CS-10",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0421-0612
+++ b/package/network/utils/wwan/files/data/0421-0612
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia CS-15/CS-18",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0421-0619
+++ b/package/network/utils/wwan/files/data/0421-0619
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia CS-12",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0421-061e
+++ b/package/network/utils/wwan/files/data/0421-061e
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia CS-11",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0421-0623
+++ b/package/network/utils/wwan/files/data/0421-0623
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia CS-17",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0421-0629
+++ b/package/network/utils/wwan/files/data/0421-0629
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia CS-18",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0421-062d
+++ b/package/network/utils/wwan/files/data/0421-062d
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia CS-19",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0421-062f
+++ b/package/network/utils/wwan/files/data/0421-062f
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia CS-19",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0421-0638
+++ b/package/network/utils/wwan/files/data/0421-0638
@@ -1,6 +1,6 @@
 {
 	"desc": "Nokia 21M-02",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/05c6-0016
+++ b/package/network/utils/wwan/files/data/05c6-0016
@@ -1,6 +1,6 @@
 {
 	"desc": "iBall 3.5G Connect",
 	"control": 2,
-	"data": 2
-}	"generic": 1
+	"data": 2,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/05c6-0023
+++ b/package/network/utils/wwan/files/data/05c6-0023
@@ -2,4 +2,4 @@
 	"desc": "Leoxsys LN-72V",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/05c6-00a0
+++ b/package/network/utils/wwan/files/data/05c6-00a0
@@ -1,6 +1,6 @@
 {
 	"desc": "Axesstel MV241",
 	"control": 2,
-	"data": 0
-}	"generic": 1
+	"data": 0,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/05c6-6000
+++ b/package/network/utils/wwan/files/data/05c6-6000
@@ -2,4 +2,4 @@
 	"desc": "Siemens SG75",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/05c6-9000
+++ b/package/network/utils/wwan/files/data/05c6-9000
@@ -2,4 +2,4 @@
 	"desc": "Generic Qualcomm",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/07d1-3e01
+++ b/package/network/utils/wwan/files/data/07d1-3e01
@@ -2,4 +2,4 @@
 	"desc": "D-Link DWM-152",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/07d1-3e02
+++ b/package/network/utils/wwan/files/data/07d1-3e02
@@ -2,4 +2,4 @@
 	"desc": "D-Link DWM-156",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/07d1-7e11
+++ b/package/network/utils/wwan/files/data/07d1-7e11
@@ -1,6 +1,6 @@
 {
 	"desc": "D-Link DWM-156",
 	"control": 1,
-	"data": 2
-}	"generic": 1
+	"data": 2,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/0af0-6901
+++ b/package/network/utils/wwan/files/data/0af0-6901
@@ -2,4 +2,4 @@
 	"desc": "Option GI0201",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/0af0-7201
+++ b/package/network/utils/wwan/files/data/0af0-7201
@@ -2,4 +2,4 @@
 	"desc": "Option GTM380",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/0af0-9200
+++ b/package/network/utils/wwan/files/data/0af0-9200
@@ -2,4 +2,4 @@
 	"desc": "Option GTM671WFS",
 	"control": 2,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/0b3c-c003
+++ b/package/network/utils/wwan/files/data/0b3c-c003
@@ -2,4 +2,4 @@
 	"desc": "Olivetti Olicard 145",
 	"control": 0,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/0bdb-1900
+++ b/package/network/utils/wwan/files/data/0bdb-1900
@@ -1,6 +1,6 @@
 {
 	"desc": "Ericsson F3507g",
 	"control": 4,
-	"data": 1
-}	"acm": 1
+	"data": 1,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0bdb-1902
+++ b/package/network/utils/wwan/files/data/0bdb-1902
@@ -1,6 +1,6 @@
 {
 	"desc": "Ericsson F3507g",
 	"control": 4,
-	"data": 1
-}	"acm": 1
+	"data": 1,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0bdb-190a
+++ b/package/network/utils/wwan/files/data/0bdb-190a
@@ -1,6 +1,6 @@
 {
 	"desc": "Ericsson F3307",
 	"control": 4,
-	"data": 1
-}	"acm": 1
+	"data": 1,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0bdb-190d
+++ b/package/network/utils/wwan/files/data/0bdb-190d
@@ -1,6 +1,6 @@
 {
 	"desc": "Ericsson F5521gw",
 	"control": 4,
-	"data": 1
-}	"acm": 1
+	"data": 1,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0bdb-1910
+++ b/package/network/utils/wwan/files/data/0bdb-1910
@@ -1,6 +1,6 @@
 {
 	"desc": "Ericsson F5521gw",
 	"control": 4,
-	"data": 1
-}	"acm": 1
+	"data": 1,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/0c88-17da
+++ b/package/network/utils/wwan/files/data/0c88-17da
@@ -2,4 +2,4 @@
 	"desc": "Kyocera KPC650",
 	"control": 0,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/0c88-180a
+++ b/package/network/utils/wwan/files/data/0c88-180a
@@ -2,4 +2,4 @@
 	"desc": "Kyocera KPC680",
 	"control": 0,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/0f3d-68aa
+++ b/package/network/utils/wwan/files/data/0f3d-68aa
@@ -2,4 +2,4 @@
 	"desc": "Sierra Wireless AC313U/320U/330U Direct IP",
 	"control": 3,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/1004-6124
+++ b/package/network/utils/wwan/files/data/1004-6124
@@ -1,6 +1,6 @@
 {
 	"desc": "LG L-05A",
 	"control": 0,
-	"data": 2
-}	"acm": 1
+	"data": 2,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/1004-6141
+++ b/package/network/utils/wwan/files/data/1004-6141
@@ -1,6 +1,6 @@
 {
 	"desc": "LG LUU-2100TI",
 	"control": 0,
-	"data": 2
-}	"acm": 1
+	"data": 2,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/1004-6157
+++ b/package/network/utils/wwan/files/data/1004-6157
@@ -1,6 +1,6 @@
 {
 	"desc": "LG LUU-2110TI",
 	"control": 0,
-	"data": 2
-}	"acm": 1
+	"data": 2,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/1004-618f
+++ b/package/network/utils/wwan/files/data/1004-618f
@@ -2,4 +2,4 @@
 	"desc": "LG L-02C",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/106c-3711
+++ b/package/network/utils/wwan/files/data/106c-3711
@@ -1,6 +1,6 @@
 {
 	"desc": "PANTECH UM-150",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/106c-3714
+++ b/package/network/utils/wwan/files/data/106c-3714
@@ -1,6 +1,6 @@
 {
 	"desc": "PANTECH UM-175",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/106c-3715
+++ b/package/network/utils/wwan/files/data/106c-3715
@@ -1,6 +1,6 @@
 {
 	"desc": "PANTECH UM-175AL",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/106c-3716
+++ b/package/network/utils/wwan/files/data/106c-3716
@@ -1,6 +1,6 @@
 {
 	"desc": "PANTECH UM-190",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/106c-3717
+++ b/package/network/utils/wwan/files/data/106c-3717
@@ -1,6 +1,6 @@
 {
 	"desc": "PANTECH UM-185C/UM185E",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/1199-0017
+++ b/package/network/utils/wwan/files/data/1199-0017
@@ -2,4 +2,4 @@
 	"desc": "Sierra EM5625",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0018
+++ b/package/network/utils/wwan/files/data/1199-0018
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC5720",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0019
+++ b/package/network/utils/wwan/files/data/1199-0019
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC595U",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0020
+++ b/package/network/utils/wwan/files/data/1199-0020
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC5725",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0021
+++ b/package/network/utils/wwan/files/data/1199-0021
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC597E",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0022
+++ b/package/network/utils/wwan/files/data/1199-0022
@@ -2,4 +2,4 @@
 	"desc": "Sierra EM5725",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0023
+++ b/package/network/utils/wwan/files/data/1199-0023
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC597",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0024
+++ b/package/network/utils/wwan/files/data/1199-0024
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC5727 CDMA",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0025
+++ b/package/network/utils/wwan/files/data/1199-0025
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC598",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0026
+++ b/package/network/utils/wwan/files/data/1199-0026
@@ -2,4 +2,4 @@
 	"desc": "Sierra T11",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0027
+++ b/package/network/utils/wwan/files/data/1199-0027
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC402",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0028
+++ b/package/network/utils/wwan/files/data/1199-0028
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC5728",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0112
+++ b/package/network/utils/wwan/files/data/1199-0112
@@ -2,4 +2,4 @@
 	"desc": "Sierra CDMA 1xEVDO PC Card, AC580",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0120
+++ b/package/network/utils/wwan/files/data/1199-0120
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC595U",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0218
+++ b/package/network/utils/wwan/files/data/1199-0218
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC5720",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0220
+++ b/package/network/utils/wwan/files/data/1199-0220
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC5725",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0224
+++ b/package/network/utils/wwan/files/data/1199-0224
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC5727",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-0301
+++ b/package/network/utils/wwan/files/data/1199-0301
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC250U",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6802
+++ b/package/network/utils/wwan/files/data/1199-6802
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8755",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6803
+++ b/package/network/utils/wwan/files/data/1199-6803
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8765",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6804
+++ b/package/network/utils/wwan/files/data/1199-6804
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8755",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6805
+++ b/package/network/utils/wwan/files/data/1199-6805
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8765",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6808
+++ b/package/network/utils/wwan/files/data/1199-6808
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8755",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6809
+++ b/package/network/utils/wwan/files/data/1199-6809
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8755",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6813
+++ b/package/network/utils/wwan/files/data/1199-6813
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8775",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6815
+++ b/package/network/utils/wwan/files/data/1199-6815
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8775",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6816
+++ b/package/network/utils/wwan/files/data/1199-6816
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8775",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6820
+++ b/package/network/utils/wwan/files/data/1199-6820
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC875",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6821
+++ b/package/network/utils/wwan/files/data/1199-6821
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC875U",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6822
+++ b/package/network/utils/wwan/files/data/1199-6822
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC875E",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6833
+++ b/package/network/utils/wwan/files/data/1199-6833
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8781",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6834
+++ b/package/network/utils/wwan/files/data/1199-6834
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8780",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6835
+++ b/package/network/utils/wwan/files/data/1199-6835
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8781",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6838
+++ b/package/network/utils/wwan/files/data/1199-6838
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8780",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6839
+++ b/package/network/utils/wwan/files/data/1199-6839
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8781",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-683a
+++ b/package/network/utils/wwan/files/data/1199-683a
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8785",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-683b
+++ b/package/network/utils/wwan/files/data/1199-683b
@@ -2,4 +2,4 @@
 	"desc": "Sierra MC8785 Composite",
 	"control": 3,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6850
+++ b/package/network/utils/wwan/files/data/1199-6850
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC880",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6851
+++ b/package/network/utils/wwan/files/data/1199-6851
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC 881",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6852
+++ b/package/network/utils/wwan/files/data/1199-6852
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC880E",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6853
+++ b/package/network/utils/wwan/files/data/1199-6853
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC881E",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6855
+++ b/package/network/utils/wwan/files/data/1199-6855
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC880U",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6856
+++ b/package/network/utils/wwan/files/data/1199-6856
@@ -2,4 +2,4 @@
 	"desc": "Sierra ATT USB Connect 881",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6859
+++ b/package/network/utils/wwan/files/data/1199-6859
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC885E",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-685a
+++ b/package/network/utils/wwan/files/data/1199-685a
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC885E",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6880
+++ b/package/network/utils/wwan/files/data/1199-6880
@@ -2,4 +2,4 @@
 	"desc": "Sierra C885",
 	"control": 3,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6890
+++ b/package/network/utils/wwan/files/data/1199-6890
@@ -2,4 +2,4 @@
 	"desc": "Sierra C888",
 	"control": 3,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6891
+++ b/package/network/utils/wwan/files/data/1199-6891
@@ -2,4 +2,4 @@
 	"desc": "Sierra C22 and C33",
 	"control": 3,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6892
+++ b/package/network/utils/wwan/files/data/1199-6892
@@ -2,4 +2,4 @@
 	"desc": "Sierra Compass HSPA",
 	"control": 3,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-6893
+++ b/package/network/utils/wwan/files/data/1199-6893
@@ -2,4 +2,4 @@
 	"desc": "Sierra C889",
 	"control": 3,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/1199-68aa
+++ b/package/network/utils/wwan/files/data/1199-68aa
@@ -2,4 +2,4 @@
 	"desc": "Sierra AC320U/AC330U Direct IP",
 	"control": 3,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1035
+++ b/package/network/utils/wwan/files/data/12d1-1035
@@ -2,4 +2,4 @@
 	"desc": "HUAWEI U8110",
 	"control": 0,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1406
+++ b/package/network/utils/wwan/files/data/12d1-1406
@@ -2,4 +2,4 @@
 	"desc": "HUAWEI/Option newer modems",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-140b
+++ b/package/network/utils/wwan/files/data/12d1-140b
@@ -2,4 +2,4 @@
 	"desc": "HUAWEI/Option EC1260 Wireless Data Modem HSD USB Card",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1412
+++ b/package/network/utils/wwan/files/data/12d1-1412
@@ -2,4 +2,4 @@
 	"desc": "HUAWEI/Option EC168",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-141b
+++ b/package/network/utils/wwan/files/data/12d1-141b
@@ -2,4 +2,4 @@
 	"desc": "HUAWEI/Option newer modems",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1433
+++ b/package/network/utils/wwan/files/data/12d1-1433
@@ -2,4 +2,4 @@
 	"desc": "HUAWEI/Option E1756C",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1436
+++ b/package/network/utils/wwan/files/data/12d1-1436
@@ -2,4 +2,4 @@
 	"desc": "HUAWEI/Option E1800",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1444
+++ b/package/network/utils/wwan/files/data/12d1-1444
@@ -2,4 +2,4 @@
 	"desc": "HUAWEI/Option E352-R1",
 	"control": 0,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-144e
+++ b/package/network/utils/wwan/files/data/12d1-144e
@@ -2,4 +2,4 @@
 	"desc": "Huawei K3806",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1464
+++ b/package/network/utils/wwan/files/data/12d1-1464
@@ -2,4 +2,4 @@
 	"desc": "Huawei K4505",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1465
+++ b/package/network/utils/wwan/files/data/12d1-1465
@@ -2,4 +2,4 @@
 	"desc": "Huawei K3765",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1491
+++ b/package/network/utils/wwan/files/data/12d1-1491
@@ -2,4 +2,4 @@
 	"desc": "Huawei R201",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-14a5
+++ b/package/network/utils/wwan/files/data/12d1-14a5
@@ -2,4 +2,4 @@
 	"desc": "Huawei E173",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-14a8
+++ b/package/network/utils/wwan/files/data/12d1-14a8
@@ -2,4 +2,4 @@
 	"desc": "Huawei E173",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-14ae
+++ b/package/network/utils/wwan/files/data/12d1-14ae
@@ -2,4 +2,4 @@
 	"desc": "Huawei K3806",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-14cb
+++ b/package/network/utils/wwan/files/data/12d1-14cb
@@ -2,4 +2,4 @@
 	"desc": "Huawei K4510",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-14cf
+++ b/package/network/utils/wwan/files/data/12d1-14cf
@@ -2,4 +2,4 @@
 	"desc": "Huawei K3772",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1506
+++ b/package/network/utils/wwan/files/data/12d1-1506
@@ -2,4 +2,4 @@
 	"desc": "Huawei E367/E398",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-151d
+++ b/package/network/utils/wwan/files/data/12d1-151d
@@ -2,4 +2,4 @@
 	"desc": "Huawei E3131",
 	"control": 3,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-156c
+++ b/package/network/utils/wwan/files/data/12d1-156c
@@ -2,4 +2,4 @@
 	"desc": "Huawei E3276",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1c05
+++ b/package/network/utils/wwan/files/data/12d1-1c05
@@ -2,4 +2,4 @@
 	"desc": "Huawei E173s",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1c07
+++ b/package/network/utils/wwan/files/data/12d1-1c07
@@ -2,4 +2,4 @@
 	"desc": "Huawei E188",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1c08
+++ b/package/network/utils/wwan/files/data/12d1-1c08
@@ -2,4 +2,4 @@
 	"desc": "Huawei E173s",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1c10
+++ b/package/network/utils/wwan/files/data/12d1-1c10
@@ -2,4 +2,4 @@
 	"desc": "Huawei E173",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1c12
+++ b/package/network/utils/wwan/files/data/12d1-1c12
@@ -2,4 +2,4 @@
 	"desc": "Huawei E173",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/12d1-1c23
+++ b/package/network/utils/wwan/files/data/12d1-1c23
@@ -2,4 +2,4 @@
 	"desc": "Huawei E173",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-1400
+++ b/package/network/utils/wwan/files/data/1410-1400
@@ -2,4 +2,4 @@
 	"desc": "Novatel U730",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-1410
+++ b/package/network/utils/wwan/files/data/1410-1410
@@ -2,4 +2,4 @@
 	"desc": "Novatel U740",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-1420
+++ b/package/network/utils/wwan/files/data/1410-1420
@@ -2,4 +2,4 @@
 	"desc": "Novatel U870",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-1430
+++ b/package/network/utils/wwan/files/data/1410-1430
@@ -2,4 +2,4 @@
 	"desc": "Novatel XU870",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-1450
+++ b/package/network/utils/wwan/files/data/1410-1450
@@ -2,4 +2,4 @@
 	"desc": "Novatel X950D",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-2100
+++ b/package/network/utils/wwan/files/data/1410-2100
@@ -2,4 +2,4 @@
 	"desc": "Novatel EV620",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-2110
+++ b/package/network/utils/wwan/files/data/1410-2110
@@ -2,4 +2,4 @@
 	"desc": "Novatel ES720",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-2120
+++ b/package/network/utils/wwan/files/data/1410-2120
@@ -2,4 +2,4 @@
 	"desc": "Novatel E725",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-2130
+++ b/package/network/utils/wwan/files/data/1410-2130
@@ -2,4 +2,4 @@
 	"desc": "Novatel ES620",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-2400
+++ b/package/network/utils/wwan/files/data/1410-2400
@@ -2,4 +2,4 @@
 	"desc": "Novatel EU730",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-2410
+++ b/package/network/utils/wwan/files/data/1410-2410
@@ -2,4 +2,4 @@
 	"desc": "Novatel EU740",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-2420
+++ b/package/network/utils/wwan/files/data/1410-2420
@@ -2,4 +2,4 @@
 	"desc": "Novatel EU870D",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-4100
+++ b/package/network/utils/wwan/files/data/1410-4100
@@ -2,4 +2,4 @@
 	"desc": "Novatel MC727/U727",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-4400
+++ b/package/network/utils/wwan/files/data/1410-4400
@@ -2,4 +2,4 @@
 	"desc": "Novatel Ovation MC930D/MC950D",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-6000
+++ b/package/network/utils/wwan/files/data/1410-6000
@@ -2,4 +2,4 @@
 	"desc": "Novatel USB760",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-6001
+++ b/package/network/utils/wwan/files/data/1410-6001
@@ -2,4 +2,4 @@
 	"desc": "Novatel USB760",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-6002
+++ b/package/network/utils/wwan/files/data/1410-6002
@@ -2,4 +2,4 @@
 	"desc": "Novatel USB760 3G",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-6010
+++ b/package/network/utils/wwan/files/data/1410-6010
@@ -2,4 +2,4 @@
 	"desc": "Novatel MC780",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-7001
+++ b/package/network/utils/wwan/files/data/1410-7001
@@ -2,4 +2,4 @@
 	"desc": "Novatel MiFi 2372",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-7003
+++ b/package/network/utils/wwan/files/data/1410-7003
@@ -2,4 +2,4 @@
 	"desc": "Novatel MiFi 2372",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-7030
+++ b/package/network/utils/wwan/files/data/1410-7030
@@ -2,4 +2,4 @@
 	"desc": "Novatel USB998",
 	"control": 0,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-7031
+++ b/package/network/utils/wwan/files/data/1410-7031
@@ -1,6 +1,6 @@
 {
 	"desc": "Novatel USB679",
 	"control": 0,
-	"data": 0
-}	"generic": 1
+	"data": 0,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/1410-7041
+++ b/package/network/utils/wwan/files/data/1410-7041
@@ -2,4 +2,4 @@
 	"desc": "Novatel MF3470",
 	"control": 0,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1410-7042
+++ b/package/network/utils/wwan/files/data/1410-7042
@@ -2,4 +2,4 @@
 	"desc": "Novatel Ovation MC545/MC547",
 	"control": 0,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1529-3100
+++ b/package/network/utils/wwan/files/data/1529-3100
@@ -1,6 +1,6 @@
 {
 	"desc": "UBIQUAM U-100/105/200/300/520",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d5-6202
+++ b/package/network/utils/wwan/files/data/16d5-6202
@@ -2,4 +2,4 @@
 	"desc": "AnyData ADU-620UW",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/16d5-6501
+++ b/package/network/utils/wwan/files/data/16d5-6501
@@ -2,4 +2,4 @@
 	"desc": "AnyData ADU-300A",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/16d5-6502
+++ b/package/network/utils/wwan/files/data/16d5-6502
@@ -2,4 +2,4 @@
 	"desc": "AnyData ADU-500A",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/16d5-6603
+++ b/package/network/utils/wwan/files/data/16d5-6603
@@ -1,6 +1,6 @@
 {
 	"desc": "AnyData ADU-890WH",
 	"control": 0,
-	"data": 0
-}	"generic": 1
+	"data": 0,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/16d5-900d
+++ b/package/network/utils/wwan/files/data/16d5-900d
@@ -1,6 +1,6 @@
 {
 	"desc": "AnyData ADU-890WH",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d8-5141
+++ b/package/network/utils/wwan/files/data/16d8-5141
@@ -1,6 +1,6 @@
 {
 	"desc": "Cmotech CNU-510",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d8-5533
+++ b/package/network/utils/wwan/files/data/16d8-5533
@@ -1,6 +1,6 @@
 {
 	"desc": "Cmotech CNU-550",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d8-5543
+++ b/package/network/utils/wwan/files/data/16d8-5543
@@ -1,6 +1,6 @@
 {
 	"desc": "Cmotech CNU-550",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d8-5553
+++ b/package/network/utils/wwan/files/data/16d8-5553
@@ -1,6 +1,6 @@
 {
 	"desc": "Cmotech CDU-550",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d8-6002
+++ b/package/network/utils/wwan/files/data/16d8-6002
@@ -2,4 +2,4 @@
 	"desc": "Franklin U300",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/16d8-6006
+++ b/package/network/utils/wwan/files/data/16d8-6006
@@ -2,4 +2,4 @@
 	"desc": "Cmotech CGU-628",
 	"control": 0,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/16d8-6522
+++ b/package/network/utils/wwan/files/data/16d8-6522
@@ -1,6 +1,6 @@
 {
 	"desc": "Cmotech CDU-650",
 	"control": 2,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d8-6523
+++ b/package/network/utils/wwan/files/data/16d8-6523
@@ -1,6 +1,6 @@
 {
 	"desc": "Cmotech CCU-650U",
 	"control": 2,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d8-6532
+++ b/package/network/utils/wwan/files/data/16d8-6532
@@ -1,6 +1,6 @@
 {
 	"desc": "Cmotech CCU-650",
 	"control": 2,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d8-6533
+++ b/package/network/utils/wwan/files/data/16d8-6533
@@ -1,6 +1,6 @@
 {
 	"desc": "Cmotech CNM-650",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d8-6543
+++ b/package/network/utils/wwan/files/data/16d8-6543
@@ -1,6 +1,6 @@
 {
 	"desc": "Cmotech CNU-650",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/16d8-680a
+++ b/package/network/utils/wwan/files/data/16d8-680a
@@ -1,6 +1,6 @@
 {
 	"desc": "Cmotech CDU-680",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-0001
+++ b/package/network/utils/wwan/files/data/19d2-0001
@@ -2,4 +2,4 @@
 	"desc": "ONDA MT505UP/ZTE",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0015
+++ b/package/network/utils/wwan/files/data/19d2-0015
@@ -2,4 +2,4 @@
 	"desc": "ONDA MT505UP/ZTE",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0016
+++ b/package/network/utils/wwan/files/data/19d2-0016
@@ -2,4 +2,4 @@
 	"desc": "ONDA MF110/ZTE",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0018
+++ b/package/network/utils/wwan/files/data/19d2-0018
@@ -2,4 +2,4 @@
 	"desc": "ONDA MSA110UP/ZTE",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0022
+++ b/package/network/utils/wwan/files/data/19d2-0022
@@ -2,4 +2,4 @@
 	"desc": "ZTE K2525",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0024
+++ b/package/network/utils/wwan/files/data/19d2-0024
@@ -2,4 +2,4 @@
 	"desc": "ONDA MT503HSA",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0033
+++ b/package/network/utils/wwan/files/data/19d2-0033
@@ -2,4 +2,4 @@
 	"desc": "ZTE MF636",
 	"control": 1,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0037
+++ b/package/network/utils/wwan/files/data/19d2-0037
@@ -2,4 +2,4 @@
 	"desc": "ONDA MT505UP/ZTE",
 	"control": 2,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0039
+++ b/package/network/utils/wwan/files/data/19d2-0039
@@ -2,4 +2,4 @@
 	"desc": "ZTE MF100",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0057
+++ b/package/network/utils/wwan/files/data/19d2-0057
@@ -2,4 +2,4 @@
 	"desc": "AIKO 83D",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0064
+++ b/package/network/utils/wwan/files/data/19d2-0064
@@ -2,4 +2,4 @@
 	"desc": "ZTE MF627",
 	"control": 0,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0066
+++ b/package/network/utils/wwan/files/data/19d2-0066
@@ -2,4 +2,4 @@
 	"desc": "ZTE MF626",
 	"control": 1,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0073
+++ b/package/network/utils/wwan/files/data/19d2-0073
@@ -2,4 +2,4 @@
 	"desc": "ZTE A580",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0079
+++ b/package/network/utils/wwan/files/data/19d2-0079
@@ -2,4 +2,4 @@
 	"desc": "ZTE A353",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0082
+++ b/package/network/utils/wwan/files/data/19d2-0082
@@ -2,4 +2,4 @@
 	"desc": "ZTE MF668/MF190",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0086
+++ b/package/network/utils/wwan/files/data/19d2-0086
@@ -2,4 +2,4 @@
 	"desc": "ZTE MF645",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0091
+++ b/package/network/utils/wwan/files/data/19d2-0091
@@ -2,4 +2,4 @@
 	"desc": "ZTE MF636",
 	"control": 1,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0094
+++ b/package/network/utils/wwan/files/data/19d2-0094
@@ -2,4 +2,4 @@
 	"desc": "ZTE AC581",
 	"control": 3,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0108
+++ b/package/network/utils/wwan/files/data/19d2-0108
@@ -2,4 +2,4 @@
 	"desc": "ONDA MT505UP/ZTE",
 	"control": 1,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0116
+++ b/package/network/utils/wwan/files/data/19d2-0116
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF651",
 	"control": 1,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-0117
+++ b/package/network/utils/wwan/files/data/19d2-0117
@@ -2,4 +2,4 @@
 	"desc": "ZTE MF112",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0128
+++ b/package/network/utils/wwan/files/data/19d2-0128
@@ -2,4 +2,4 @@
 	"desc": "ZTE MF651",
 	"control": 1,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0142
+++ b/package/network/utils/wwan/files/data/19d2-0142
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF665C",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-0143
+++ b/package/network/utils/wwan/files/data/19d2-0143
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF190B",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-0152
+++ b/package/network/utils/wwan/files/data/19d2-0152
@@ -2,4 +2,4 @@
 	"desc": "ZTE AC583",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-0170
+++ b/package/network/utils/wwan/files/data/19d2-0170
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE A371",
 	"control": 0,
-	"data": 1
-}	"generic": 1
+	"data": 1,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1003
+++ b/package/network/utils/wwan/files/data/19d2-1003
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE K3805-Z",
 	"control": 1,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1015
+++ b/package/network/utils/wwan/files/data/19d2-1015
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE K3806-Z",
 	"control": 1,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1172
+++ b/package/network/utils/wwan/files/data/19d2-1172
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE K4510-Z",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1173
+++ b/package/network/utils/wwan/files/data/19d2-1173
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE K4510-Z",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1177
+++ b/package/network/utils/wwan/files/data/19d2-1177
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE K3770-Z",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1181
+++ b/package/network/utils/wwan/files/data/19d2-1181
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE K3772-Z",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1203
+++ b/package/network/utils/wwan/files/data/19d2-1203
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF691",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1208
+++ b/package/network/utils/wwan/files/data/19d2-1208
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF192",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1211
+++ b/package/network/utils/wwan/files/data/19d2-1211
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF195",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1212
+++ b/package/network/utils/wwan/files/data/19d2-1212
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF195",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1217
+++ b/package/network/utils/wwan/files/data/19d2-1217
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF192",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1218
+++ b/package/network/utils/wwan/files/data/19d2-1218
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF192",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1220
+++ b/package/network/utils/wwan/files/data/19d2-1220
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF192",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1222
+++ b/package/network/utils/wwan/files/data/19d2-1222
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF192",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1512
+++ b/package/network/utils/wwan/files/data/19d2-1512
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MFxxx",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1515
+++ b/package/network/utils/wwan/files/data/19d2-1515
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF192",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1518
+++ b/package/network/utils/wwan/files/data/19d2-1518
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF192",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1519
+++ b/package/network/utils/wwan/files/data/19d2-1519
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF192",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1522
+++ b/package/network/utils/wwan/files/data/19d2-1522
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF652",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1525
+++ b/package/network/utils/wwan/files/data/19d2-1525
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF591",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1527
+++ b/package/network/utils/wwan/files/data/19d2-1527
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF196",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1537
+++ b/package/network/utils/wwan/files/data/19d2-1537
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF190J",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1538
+++ b/package/network/utils/wwan/files/data/19d2-1538
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF190J",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-1544
+++ b/package/network/utils/wwan/files/data/19d2-1544
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE MF190J",
 	"control": 0,
-	"data": 0
-}	"acm": 1
+	"data": 0,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-2003
+++ b/package/network/utils/wwan/files/data/19d2-2003
@@ -2,4 +2,4 @@
 	"desc": "ZTE MF180",
 	"control": 1,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-ffdd
+++ b/package/network/utils/wwan/files/data/19d2-ffdd
@@ -2,4 +2,4 @@
 	"desc": "ZTE AC682",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-ffe4
+++ b/package/network/utils/wwan/files/data/19d2-ffe4
@@ -1,6 +1,6 @@
 {
 	"desc": "ZTE AC3781",
 	"control": 1,
-	"data": 0
-}	"generic": 1
+	"data": 0,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/19d2-ffe9
+++ b/package/network/utils/wwan/files/data/19d2-ffe9
@@ -2,4 +2,4 @@
 	"desc": "ZTE AC2738",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-fff1
+++ b/package/network/utils/wwan/files/data/19d2-fff1
@@ -2,4 +2,4 @@
 	"desc": "ZTE generic",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-fffb
+++ b/package/network/utils/wwan/files/data/19d2-fffb
@@ -2,4 +2,4 @@
 	"desc": "ZTE MG880",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-fffc
+++ b/package/network/utils/wwan/files/data/19d2-fffc
@@ -2,4 +2,4 @@
 	"desc": "ZTE MG880",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-fffd
+++ b/package/network/utils/wwan/files/data/19d2-fffd
@@ -2,4 +2,4 @@
 	"desc": "ZTE MG880",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-fffe
+++ b/package/network/utils/wwan/files/data/19d2-fffe
@@ -2,4 +2,4 @@
 	"desc": "ZTE AC8700",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/19d2-ffff
+++ b/package/network/utils/wwan/files/data/19d2-ffff
@@ -2,4 +2,4 @@
 	"desc": "ZTE AC8710",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1a8d-1002
+++ b/package/network/utils/wwan/files/data/1a8d-1002
@@ -2,4 +2,4 @@
 	"desc": "Bandrich C-100/C-120",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1a8d-1003
+++ b/package/network/utils/wwan/files/data/1a8d-1003
@@ -2,4 +2,4 @@
 	"desc": "Bandrich C-100/C-120",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1a8d-1007
+++ b/package/network/utils/wwan/files/data/1a8d-1007
@@ -2,4 +2,4 @@
 	"desc": "Bandrich C-270",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1a8d-1009
+++ b/package/network/utils/wwan/files/data/1a8d-1009
@@ -2,4 +2,4 @@
 	"desc": "Bandrich C-170/C-180",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1a8d-100c
+++ b/package/network/utils/wwan/files/data/1a8d-100c
@@ -2,4 +2,4 @@
 	"desc": "Bandrich C-320",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1a8d-100d
+++ b/package/network/utils/wwan/files/data/1a8d-100d
@@ -2,4 +2,4 @@
 	"desc": "Bandrich C-508",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1a8d-2006
+++ b/package/network/utils/wwan/files/data/1a8d-2006
@@ -1,6 +1,6 @@
 {
 	"desc": "Bandrich C-33x",
 	"control": 0,
-	"data": 1
-}	"acm": 1
+	"data": 1,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/1bbb-0000
+++ b/package/network/utils/wwan/files/data/1bbb-0000
@@ -2,4 +2,4 @@
 	"desc": "Alcatel X060S/X070S/X080S/X200",
 	"control": 2,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1bbb-0012
+++ b/package/network/utils/wwan/files/data/1bbb-0012
@@ -1,6 +1,6 @@
 {
 	"desc": "Alcatel X085C",
 	"control": 2,
-	"data": 2
-}	"generic": 1
+	"data": 2,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/1bbb-0017
+++ b/package/network/utils/wwan/files/data/1bbb-0017
@@ -2,4 +2,4 @@
 	"desc": "Alcatel X220L",
 	"control": 4,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1bbb-0052
+++ b/package/network/utils/wwan/files/data/1bbb-0052
@@ -2,4 +2,4 @@
 	"desc": "Alcatel X220L",
 	"control": 4,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1bbb-00b7
+++ b/package/network/utils/wwan/files/data/1bbb-00b7
@@ -2,4 +2,4 @@
 	"desc": "Alcatel X600",
 	"control": 0,
 	"data": 4
-}}
+}

--- a/package/network/utils/wwan/files/data/1bbb-00ca
+++ b/package/network/utils/wwan/files/data/1bbb-00ca
@@ -1,6 +1,6 @@
 {
 	"desc": "Alcatel X080C",
 	"control": 0,
-	"data": 0
-}	"generic": 1
+	"data": 0,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/1c9e-6060
+++ b/package/network/utils/wwan/files/data/1c9e-6060
@@ -1,6 +1,6 @@
 {
 	"desc": "Alcatel X020 & X030",
 	"control": 2,
-	"data": 0
-}	"generic": 1
+	"data": 0,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/1c9e-6061
+++ b/package/network/utils/wwan/files/data/1c9e-6061
@@ -1,6 +1,6 @@
 {
 	"desc": "Alcatel X020 & X030",
 	"control": 2,
-	"data": 0
-}	"generic": 1
+	"data": 0,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/1c9e-9000
+++ b/package/network/utils/wwan/files/data/1c9e-9000
@@ -1,6 +1,6 @@
 {
 	"desc": "4G Systems XS Stick W14",
 	"control": 0,
-	"data": 0
-}	"generic": 1
+	"data": 0,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/1c9e-9603
+++ b/package/network/utils/wwan/files/data/1c9e-9603
@@ -2,4 +2,4 @@
 	"desc": "4G Systems XS Stick W14",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1c9e-9605
+++ b/package/network/utils/wwan/files/data/1c9e-9605
@@ -2,4 +2,4 @@
 	"desc": "4G Systems XS Stick W14",
 	"control": 1,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/1c9e-9607
+++ b/package/network/utils/wwan/files/data/1c9e-9607
@@ -2,4 +2,4 @@
 	"desc": "4G Systems XS Stick W14",
 	"control": 1,
 	"data": 3
-}}
+}

--- a/package/network/utils/wwan/files/data/1c9e-9801
+++ b/package/network/utils/wwan/files/data/1c9e-9801
@@ -1,6 +1,6 @@
 {
 	"desc": "4G Systems XS Stick W21",
 	"control": 2,
-	"data": 1
-}	"generic": 1
+	"data": 1,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/1c9e-9900
+++ b/package/network/utils/wwan/files/data/1c9e-9900
@@ -1,6 +1,6 @@
 {
 	"desc": "Softbank C02LC",
 	"control": 1,
-	"data": 2
-}	"generic": 1
+	"data": 2,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/1e0e-9000
+++ b/package/network/utils/wwan/files/data/1e0e-9000
@@ -2,4 +2,4 @@
 	"desc": "PROLink PHS100, Hyundai MB-810, A-Link 3GU",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1e0e-9100
+++ b/package/network/utils/wwan/files/data/1e0e-9100
@@ -2,4 +2,4 @@
 	"desc": "PROLink PHS300, A-Link 3GU",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1e0e-9200
+++ b/package/network/utils/wwan/files/data/1e0e-9200
@@ -2,4 +2,4 @@
 	"desc": "PROLink PHS100, Hyundai MB-810, A-Link 3GU",
 	"control": 1,
 	"data": 2
-}}
+}

--- a/package/network/utils/wwan/files/data/1e0e-ce16
+++ b/package/network/utils/wwan/files/data/1e0e-ce16
@@ -2,4 +2,4 @@
 	"desc": "D-Link DWM-162-U5, Micromax MMX 300c",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/1e0e-cefe
+++ b/package/network/utils/wwan/files/data/1e0e-cefe
@@ -1,6 +1,6 @@
 {
 	"desc": "D-Link DWM-162-U5, Micromax MMX 300c",
 	"control": 1,
-	"data": 2
-}	"generic": 1
+	"data": 2,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/2001-7d00
+++ b/package/network/utils/wwan/files/data/2001-7d00
@@ -1,6 +1,6 @@
 {
 	"desc": "D-Link DWM-156 A6",
 	"control": 1,
-	"data": 0
-}	"generic": 1
+	"data": 0,
+	"generic": 1
 }

--- a/package/network/utils/wwan/files/data/2001-7d01
+++ b/package/network/utils/wwan/files/data/2001-7d01
@@ -2,4 +2,4 @@
 	"desc": "D-Link DWM-156 A7",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/2001-7d02
+++ b/package/network/utils/wwan/files/data/2001-7d02
@@ -2,4 +2,4 @@
 	"desc": "D-Link DWM-156 A7",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/2001-7d03
+++ b/package/network/utils/wwan/files/data/2001-7d03
@@ -2,4 +2,4 @@
 	"desc": "D-Link DWM-156 A7",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/211f-6801
+++ b/package/network/utils/wwan/files/data/211f-6801
@@ -2,4 +2,4 @@
 	"desc": "Celot K-3000/CT-650/CT-680",
 	"control": 2,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8114
+++ b/package/network/utils/wwan/files/data/413c-8114
@@ -2,4 +2,4 @@
 	"desc": "Dell 5700",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8115
+++ b/package/network/utils/wwan/files/data/413c-8115
@@ -2,4 +2,4 @@
 	"desc": "Dell 5500",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8116
+++ b/package/network/utils/wwan/files/data/413c-8116
@@ -2,4 +2,4 @@
 	"desc": "Dell 5505",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8117
+++ b/package/network/utils/wwan/files/data/413c-8117
@@ -2,4 +2,4 @@
 	"desc": "Dell 5700",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8118
+++ b/package/network/utils/wwan/files/data/413c-8118
@@ -2,4 +2,4 @@
 	"desc": "Dell 5510",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8128
+++ b/package/network/utils/wwan/files/data/413c-8128
@@ -2,4 +2,4 @@
 	"desc": "Dell 5700",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8129
+++ b/package/network/utils/wwan/files/data/413c-8129
@@ -2,4 +2,4 @@
 	"desc": "Dell 5700",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8133
+++ b/package/network/utils/wwan/files/data/413c-8133
@@ -2,4 +2,4 @@
 	"desc": "Dell 5720",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8134
+++ b/package/network/utils/wwan/files/data/413c-8134
@@ -2,4 +2,4 @@
 	"desc": "Dell 5720",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8135
+++ b/package/network/utils/wwan/files/data/413c-8135
@@ -2,4 +2,4 @@
 	"desc": "Dell 5720",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8136
+++ b/package/network/utils/wwan/files/data/413c-8136
@@ -2,4 +2,4 @@
 	"desc": "Dell 5520",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8137
+++ b/package/network/utils/wwan/files/data/413c-8137
@@ -2,4 +2,4 @@
 	"desc": "Dell 5520",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8138
+++ b/package/network/utils/wwan/files/data/413c-8138
@@ -2,4 +2,4 @@
 	"desc": "Dell 5520",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8147
+++ b/package/network/utils/wwan/files/data/413c-8147
@@ -1,6 +1,6 @@
 {
 	"desc": "Dell 5530",
 	"control": 0,
-	"data": 1
-}	"acm": 1
+	"data": 1,
+	"acm": 1
 }

--- a/package/network/utils/wwan/files/data/413c-8180
+++ b/package/network/utils/wwan/files/data/413c-8180
@@ -2,4 +2,4 @@
 	"desc": "Dell 5730",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8181
+++ b/package/network/utils/wwan/files/data/413c-8181
@@ -2,4 +2,4 @@
 	"desc": "Dell 5730",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-8182
+++ b/package/network/utils/wwan/files/data/413c-8182
@@ -2,4 +2,4 @@
 	"desc": "Dell 5730",
 	"control": 1,
 	"data": 0
-}}
+}

--- a/package/network/utils/wwan/files/data/413c-819b
+++ b/package/network/utils/wwan/files/data/413c-819b
@@ -2,4 +2,4 @@
 	"desc": "Dell 5804",
 	"control": 1,
 	"data": 0
-}}
+}


### PR DESCRIPTION
Method used:
```
cd package/network/utils/wwan/files/data
for a in `ls` ; do sed -i $a 's/}}/}/g' ; done
for a in `ls` ; do sed -i $a -e 's/}\t"acm": 1/\t"acm": 1/g' ; done
for a in `ls` ; do sed -i $a -e 's/}\t"generic": 1/\t"generic": 1/g' ; done
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>