### PR TITLE
Revert "utils/util-linux: Update to 2.30.1"

### DIFF
--- a/package/utils/util-linux/Makefile
+++ b/package/utils/util-linux/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=util-linux
-PKG_VERSION:=2.30.1
-PKG_RELEASE:=2
+PKG_VERSION:=2.29.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@KERNEL/linux/utils/$(PKG_NAME)/v2.30
-PKG_HASH:=1be4363a91ac428c9e43fc04dc6d2c66a19ec1e36f1105bd4b481540be13b841
+PKG_SOURCE_URL:=@KERNEL/linux/utils/$(PKG_NAME)/v2.29
+PKG_HASH:=accea4d678209f97f634f40a93b7e9fcad5915d1f4749f6c47bee6bf110fe8e3
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=	COPYING					\
@@ -175,7 +175,7 @@ endef
 define Package/fdisk
 $(call Package/util-linux/Default)
   TITLE:=manipulate disk partition table
-  DEPENDS:= +libblkid +libsmartcols +libfdisk +libncursesw
+  DEPENDS:= +libblkid +libsmartcols +libfdisk
   SUBMENU=Disc
 endef
 

--- a/package/utils/util-linux/patches/003-fix_pkgconfig_files.patch
+++ b/package/utils/util-linux/patches/003-fix_pkgconfig_files.patch
@@ -10,7 +10,7 @@
  endif # BUILD_LIBUUID
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2255,18 +2255,23 @@ AC_CONFIG_HEADERS([config.h])
+@@ -2165,18 +2165,23 @@ AC_CONFIG_HEADERS([config.h])
  #
  AC_CONFIG_FILES([
  Makefile
@@ -66,7 +66,7 @@
  endif # BUILD_LIBSMARTCOLS
 --- a/libfdisk/Makemodule.am
 +++ b/libfdisk/Makemodule.am
-@@ -9,7 +9,6 @@ SUBDIRS += libfdisk/docs
+@@ -8,7 +8,6 @@ SUBDIRS += libfdisk/docs
  endif
  
  pkgconfig_DATA += libfdisk/fdisk.pc


### PR DESCRIPTION
This reverts commit e505f59bd946a85c7eb8d5b19d796ed4d45218df.

Fixes inconsistent sysupgrade on targets with f2fs overlayfs on a block device. Reported on x86_64 and mvebu/Turris Omnia (like ClearFog).