### PR TITLE
lantiq: VR200v: enable WAV300 PCI device

### DIFF
--- a/target/linux/lantiq/dts/VR200v.dts
+++ b/target/linux/lantiq/dts/VR200v.dts
@@ -78,6 +78,10 @@
 			status = "okay";
 			gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 		};
+		pci0: pci@E105400 {
+			status = "okay";
+			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		};
 	};
 
 	gphy-xrx200 {


### PR DESCRIPTION
Enable WAV300 PCI device as has been commented for VR200v
on https://forum.openwrt.org/viewtopic.php?id=45047

Signed-off-by: Vittorio Alfieri <vittorio88@gmail.com>