### PR TITLE
lantiq: Enable PCIe support for ARV7519RW22.dts

### DIFF
--- a/target/linux/lantiq/dts/ARV7519RW22.dts
+++ b/target/linux/lantiq/dts/ARV7519RW22.dts
@@ -91,7 +91,8 @@
 		};
 
 		pcie@d900000 {
-			status = "disabled";
+			status = "okay";
+			gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 		};
 	};
 


### PR DESCRIPTION
PCIe bus must be reset via GPIO in order to be available

Add missing definition

Signed-off-by: Jorge Amorós <joramar76@yahoo.es>

Thanks for your contribution to the LEDE project!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
