### PR TITLE
hostapd: Don't implicitly add WPA2-PSK-SHA256 if PMF is enabled.

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -41,7 +41,6 @@ hostapd_append_wpa_key_mgmt() {
 
 	append wpa_key_mgmt "WPA-$auth_type"
 	[ "${ieee80211r:-0}" -gt 0 ] && append wpa_key_mgmt "FT-${auth_type}"
-	[ "${ieee80211w:-0}" -gt 0 ] && append wpa_key_mgmt "WPA-${auth_type}-SHA256"
 }
 
 hostapd_add_log_config() {


### PR DESCRIPTION
Some older g clients (Notably Apple iDevices) have an issue where if WPA2-PSK-SHA256 is advertised, it mistakenly uses that instead of SHA1.

While both PMF and WPA2-PSK-SHA256 come from the same standard (802.11w), there's no reason for them to be enabled together unless explicitly desired.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

PSK-SHA256 should probably be configurable through UCI.