### PR TITLE
Bash syntax errors in packages

### DIFF
--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -92,7 +92,7 @@ detect_mac80211() {
 			htmode="VHT80"
 		}
 
-		[ -n $htmode ] && ht_capab="set wireless.radio${devidx}.htmode=$htmode"
+		[ -n "$htmode" ] && ht_capab="set wireless.radio${devidx}.htmode=$htmode"
 
 		if [ -x /usr/bin/readlink -a -h /sys/class/ieee80211/${dev} ]; then
 			path="$(readlink -f /sys/class/ieee80211/${dev}/device)"

--- a/package/network/config/gre/files/gre.sh
+++ b/package/network/config/gre/files/gre.sh
@@ -25,7 +25,7 @@ gre_generic_setup() {
 	json_add_string mode "$mode"
 	json_add_int mtu "${mtu:-1280}"
 	[ -n "$df" ] && json_add_boolean df "$df"
-	[ -n "ttl" ] && json_add_int ttl "$ttl"
+	[ -n "$ttl" ] && json_add_int ttl "$ttl"
 	[ -n "$tos" ] && json_add_string tos "$tos"
 	json_add_boolean multicast "$multicast"
 	json_add_string local "$local"

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -627,7 +627,7 @@ wpa_supplicant_add_network() {
 		scan_ssid=""
 	}
 
-	[[ "$_w_mode" = "adhoc" -o "$_w_mode" = "mesh" ]] && append network_data "$_w_modestr" "$N$T"
+	[ "$_w_mode" = "adhoc" -o "$_w_mode" = "mesh" ] && append network_data "$_w_modestr" "$N$T"
 
 	case "$auth_type" in
 		none) ;;

--- a/package/network/utils/comgt/files/3g.sh
+++ b/package/network/utils/comgt/files/3g.sh
@@ -109,4 +109,4 @@ proto_3g_teardown() {
 	proto_kill_command "$interface"
 }
 
-[ -z "NOT_INCLUDED" ] || add_protocol 3g
+[ -z "$NOT_INCLUDED" ] || add_protocol 3g

--- a/package/network/utils/comgt/files/directip.sh
+++ b/package/network/utils/comgt/files/directip.sh
@@ -44,8 +44,7 @@ proto_directip_setup() {
 		return 1
 	}
 
-	cardinfo=$(gcom -d "$device" -s /etc/gcom/getcardinfo.gcom)
-	[ -n $(echo "$cardinfo" | grep -q "Sierra Wireless") ] || {
+	$(gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | grep -q "Sierra Wireless") || {
 		proto_notify_error "$interface" BAD_DEVICE
 		proto_block_restart "$interface"
 		return 1

--- a/scripts/om-fwupgradecfg-gen.sh
+++ b/scripts/om-fwupgradecfg-gen.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 #
 # Copyright (C) 2011 OpenWrt.org
 #


### PR DESCRIPTION
Fix multiple syntax errors in bash files (of packages only)
These errors were causing many conditions to not working properly

Signed-off-by: Lorenzo Santina <lorenzo.santina@edu.unito.it>
