### PR TITLE
ramips: Correct WAN MAC address for Phicomm K2P

### DIFF
--- a/target/linux/ramips/dts/K2P.dts
+++ b/target/linux/ramips/dts/K2P.dts
@@ -106,7 +106,7 @@
 };
 
 &ethernet {
-	mtd-mac-address = <&factory 0xe000>;
+	mtd-mac-address = <&factory 0xe006>;
 };
 
 &pinctrl {


### PR DESCRIPTION
For example, if the factory partition contains:
000e000 7d74 be24 f287 7d74 be24 f187 ffff ffff

In stock firmware the WAN/LAN MAC addresses are
74-7D-24-BE-87-F1/2
while in LEDE the WAN/LAN MAC addresses are
74-7D-24-BE-87-F3/2

This commit correct it.

Signed-off-by: Jiawei Wang <me@jwang.link>