### PR TITLE
dnsmasq: fix dhcp "ignore" option on wwan interfaces

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -457,7 +457,6 @@ dhcp_add() {
 	config_get networkid "$cfg" networkid
 	[ -n "$networkid" ] || networkid="$net"
 
-	network_get_subnet subnet "$net" || return 0
 	network_get_device ifname "$net" || return 0
 	network_get_protocol proto "$net" || return 0
 
@@ -475,6 +474,7 @@ dhcp_add() {
 	[ static = "$proto" ] || return 0
 
 	# Override interface netmask with dhcp config if applicable
+	network_get_subnet subnet "$net" || return 0
 	config_get netmask "$cfg" netmask "${subnet##*/}"
 
 	#check for an already active dhcp server on the interface, unless 'force' is set


### PR DESCRIPTION
Init script won't append --no-dhcp-interface option if interface
protocol is one of: ncm, directip, qmi, mbim.
This is caused by IP address assigned to dynamically created netifd
interfaces. As a result there's no netmask assigned to the main
interface and dhcp_add() function returns prematurely.

By moving network subnet check we can ensure that --no-dhcp-interface is
properly generated for wwan interfaces.
