### PR TITLE
kernel: Fix commit a5922f6

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -117,7 +117,7 @@ $(eval $(call KernelPackage,bluetooth_6lowpan))
 define KernelPackage/btmrvl
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Marvell Bluetooth Kernel Module support
-  DEPENDS:=+kmod-bluetooth +mwifiex-sdio-firmware
+  DEPENDS:=@TARGET_mvebu +kmod-mmc +kmod-bluetooth +mwifiex-sdio-firmware
   KCONFIG:= \
 	CONFIG_BT_MRVL \
 	CONFIG_BT_MRVL_SDIO


### PR DESCRIPTION
Add kmod-mmc as dependency and only build this if platform is mvebu

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>