### PR TITLE
lantiq/xway: add support for FritzBox7312

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/base-files/etc/board.d/01_leds
@@ -53,6 +53,9 @@ BTHOMEHUBV5A)
 DM200)
 	ucidef_set_led_netdev "lan" "lan" "dm200:green:lan" "eth0"
 	;;
+FRITZ7312)
+	ucidef_set_led_netdev "wifi" "wifi" "fritz7312:green:wlan" "wlan0"
+	;;
 FRITZ7320)
 	ucidef_set_led_netdev "wifi" "wifi" "fritz7320:green:wlan" "wlan0"
 	;;

--- a/target/linux/lantiq/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/base-files/etc/board.d/01_leds
@@ -54,6 +54,7 @@ DM200)
 	ucidef_set_led_netdev "lan" "lan" "dm200:green:lan" "eth0"
 	;;
 FRITZ7312)
+	ucidef_set_led_default "power" "power" "fritz7312:green:power" "1"
 	ucidef_set_led_netdev "wifi" "wifi" "fritz7312:green:wlan" "wlan0"
 	;;
 FRITZ7320)

--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -119,6 +119,11 @@ FRITZ3370)
 	wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 2439)" 1)
 	;;
 
+FRITZ7312)
+	wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 2820)" 1)
+	ucidef_set_interface_lan 'eth0'
+	;;
+
 FRITZ7320)
 	wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 2705)" 1)
 	;;

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -138,7 +138,7 @@ case "$FIRMWARE" in
 				ath9k_eeprom_extract "calibration" 61440 0
 				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot-env ethaddr) +2) 524
 				;;
-			FRITZ3370|FRITZ7320|FRITZ7360SL)
+			FRITZ3370|FRITZ7312|FRITZ7320|FRITZ7360SL)
 				ath9k_eeprom_extract "urlader" 2437 0
 				;;
 			TDW8970|TDW8980)

--- a/target/linux/lantiq/dts/FRITZ7312.dts
+++ b/target/linux/lantiq/dts/FRITZ7312.dts
@@ -13,11 +13,7 @@
 
 	aliases {
 		led-boot = &power;
-		led-failsafe = &power;
-		led-running = &power;
-
-		led-internet = &info_green;
-		led-dsl = &power;
+		led-dsl = &info_green;
 		led-wifi = &wlan;
 	};
 

--- a/target/linux/lantiq/dts/FRITZ7312.dts
+++ b/target/linux/lantiq/dts/FRITZ7312.dts
@@ -1,0 +1,140 @@
+/dts-v1/;
+
+#include "ar9.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "FRITZ7312 - 1&1 WLAN-MODEM";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+
+		led-internet = &info_green;
+		led-dsl = &power;
+		led-wifi = &wlan;
+	};
+
+	memory@0 {
+		reg = <0x0 0x4000000>;
+	};
+
+	fpi@10000000 {
+		localbus@0 {
+			nor-boot@0 {
+				compatible = "lantiq,nor";
+				bank-width = <2>;
+				reg = <0 0x0 0x1000000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ath9k_cal: partition@0 {
+						label = "urlader";
+						reg = <0x00000 0x20000>;
+						read-only;
+					};
+
+					partition@20000 {
+						label = "firmware";
+						reg = <0x20000 0xf60000>;
+					};
+
+					partition@f80000 {
+						label = "tffs (1)";
+						reg = <0xf80000 0x40000>;
+						read-only;
+					};
+
+					partition@fc0000 {
+						label = "tffs (2)";
+						reg = <0xfc0000 0x40000>;
+						read-only;
+					};
+				};
+			};
+		};
+
+		gpio: pinmux@E100B10 {
+			pinctrl-names = "default";
+			pinctrl-0 = <&state_default>;
+
+			state_default: pinmux {
+			};
+		};
+
+		etop@E180000 {
+			mtd-mac-address = <&ath9k_cal 0xa91>;
+			mtd-mac-address-increment = <(-2)>;
+		};
+
+		ifxhcd@E101000 {
+			status = "okay";
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <100>;
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+		dect {
+			label = "dect";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_PHONE>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		power: power {
+			label = "fritz7320:green:power";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+		voice {
+			label = "fritz7320:green:fon";
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+		dect {
+			label = "fritz7320:green:dect";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+		};
+		wlan: wlan {
+			label = "fritz7320:green:wlan";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+		info_green: info_green {
+			label = "fritz7320:green:info";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pci0 {
+	status = "okay";
+	req-mask = <0xf>;
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
+
+	wifi@0,0 {
+		compatible = "pci0,0";
+		reg = <0x7000 0 0 0 0>;
+		qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:00:0e.0.bin */
+	};
+};

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -438,6 +438,18 @@ define Device/WBMRB
 endef
 TARGET_DEVICES += WBMRB
 
+define Device/FRITZ7312
+  $(Device/AVM)
+  IMAGE_SIZE := 15744k
+  DEVICE_TITLE := 1&1 WLanModem - FRITZ7312
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-mini \
+	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
+	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
+	ltq-adsl-app ppp-mod-pppoa \
+	kmod-ltq-deu-ar9 kmod-usb-dwc2 -swconfig
+endef
+TARGET_DEVICES += FRITZ7312
+
 define Device/FRITZ7320
   $(Device/AVM)
   IMAGE_SIZE := 15744k


### PR DESCRIPTION
https://wiki.openwrt.org/toh/avm/fritz.box.wlan.7312

Specification:
- SoC: Lantiq Xway ARX188 PSB 50812 EL (MIPS 34Kc), 393MHz
- RAM: DDR1 64MiB @ 196 MHz
- Storage: Macronix MX29GL128EHT2I-90G, 16MiB
- Wireless: internal Atheros AR9227 b/g/n 2x2
- Ethernet: 1x100M
- xDSL: lantiq ADSL2+


Installation (FTP):
set host IP to 192.168.178.3, power on FritzBox, immediately start FTP connection (did not work? - try again connecting a bit later), first 5seconds it accepts ftp connections - ping 192.168.178.1 can help
- ftp 192.168.178.1
- User: adam2
- Pwd: adam2
- bin
- passiv
- quote MEDIA FLSH
- put firmware.image mtd1
- quote REBOOT
- quit
