### PR TITLE
ramips: reduce napi_weight in the ethernet driver.

### DIFF
--- a/target/linux/ramips/files-4.9/drivers/net/ethernet/mtk/mtk_eth_soc.c
+++ b/target/linux/ramips/files-4.9/drivers/net/ethernet/mtk/mtk_eth_soc.c
@@ -1536,7 +1536,7 @@ static int fe_probe(struct platform_device *pdev)
 	priv->rx_ring.rx_ring_size = NUM_DMA_DESC;
 	INIT_WORK(&priv->pending_work, fe_pending_work);
 
-	napi_weight = 32;
+	napi_weight = 16;
 	if (priv->flags & FE_FLAG_NAPI_WEIGHT) {
 		napi_weight *= 4;
 		priv->tx_ring.tx_ring_size *= 4;


### PR DESCRIPTION
Currently dmsg a weight of 128 which is above the kernel limit of 64. Silence the warning.

Signed-off-by: Rosen Penev <rosenp@gmail.com>