### PR TITLE
build: remove @ as it's causing an error

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -103,7 +103,7 @@ hash_var = $(if $(filter-out x,$(1)),MD5SUM,HASH)
 endif
 
 define DownloadMethod/unknown
-	@echo "ERROR: No download method available"; false
+	echo "ERROR: No download method available"; false
 endef
 
 define DownloadMethod/default


### PR DESCRIPTION
Since `$(DownloadMethod/unknown)` is being invoked in the expansion of
`$(call locked ...)` anyway, you can't have an `@` because the shell
doesn't know what to do with it.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
