### PR TITLE
kernel: don't scrimp on memory on big iron

### DIFF
--- a/target/linux/generic/hack-4.9/660-fq_codel_defaults.patch
+++ b/target/linux/generic/hack-4.9/660-fq_codel_defaults.patch
@@ -10,12 +10,15 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/net/sched/sch_fq_codel.c
 +++ b/net/sched/sch_fq_codel.c
-@@ -479,7 +479,7 @@ static int fq_codel_init(struct Qdisc *s
+@@ -479,7 +479,11 @@ static int fq_codel_init(struct Qdisc *s
  
  	sch->limit = 10*1024;
  	q->flows_cnt = 1024;
--	q->memory_limit = 32 << 20; /* 32 MBytes */
++#ifdef CONFIG_X86_64
+ 	q->memory_limit = 32 << 20; /* 32 MBytes */
++#else
 +	q->memory_limit = 4 << 20; /* 4 MBytes */
++#endif
  	q->drop_batch_size = 64;
  	q->quantum = psched_mtu(qdisc_dev(sch));
  	q->perturbation = prandom_u32();


### PR DESCRIPTION
x86_64 platforms typically don't lack memory, so don't needlessly
economize memory if fq_codel on capable platforms.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
