### PR TITLE
ipq-wifi: fix missing define of PKG_NAME

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -1,6 +1,7 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/version.mk
 
+PKG_NAME:=ipq-wifi
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
make clean need PKG_NAME
rm -rf build_dir/target...../$PKG_NAME is invoked
missing PKG_NAME cause parent directory being removed
