### PR TITLE
kernel: kmod-fs-cifs-smb2 and kmod-fs-cifs-smb311

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -125,6 +125,40 @@ endef
 
 $(eval $(call KernelPackage,fs-cifs))
 
+define KernelPackage/fs-cifs-smb2
+  SUBMENU:=$(FS_MENU)
+  TITLE:=SMB2 and SMB3 support
+  KCONFIG:= \
+	CONFIG_CIFS_SMB2=y \
+	CONFIG_CIFS_SMB311=n \
+	CONFIG_KEYS=y
+  DEPENDS+= \
+    +kmod-fs-cifs \
+    +kmod-fs-fscache \
+    +kmod-dnsresolver
+endef
+
+define KernelPackage/fs-cifs-smb2/description
+ Say Y here if you want to include support for
+ the SMB2 and SMB3 protocols in the CIFS module
+endef
+
+$(eval $(call KernelPackage,fs-cifs-smb2))
+
+define KernelPackage/fs-cifs-smb311
+  SUBMENU:=$(FS_MENU)
+  TITLE:=SMB3.1.1 support (experimental)
+  KCONFIG:=CONFIG_CIFS_SMB311=y
+  DEPENDS+=+kmod-fs-cifs-smb2
+endef
+
+define KernelPackage/fs-cifs-smb311/description
+ Say Y here if you want to include support for
+ the SMB3.1.1 protocol in the CIFS module
+endef
+
+$(eval $(call KernelPackage,fs-cifs-smb311))
+
 
 define KernelPackage/fs-configfs
   SUBMENU:=$(FS_MENU)


### PR DESCRIPTION
This will build empty packages while adding the
newer protocol support to the kmod-fs-cifs kernel
module (cifs.ko) package instead.

Note that samba36-server can only support up to
SMB2. From my testing, in order for SMB2 support
to be present, smb.conf template must be modified
to include the following options:

[global]
  min protocol = NT1
  max protocol = SMB2

Signed-off-by: James Christopher Adduono <jc@adduono.com>

I wasn't sure if empty kmod packages were the way to go for this, it seems the system is smart enough to not bother building a package with no files so this worked well enough for me.
Samba 4 support is probably quite a ways away, eh? Perhaps best to only have SMB2 option and remove SMB311 from patch. Thoughts?