### PR TITLE
prereq-build.mk: add m4 when setup host command

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -143,6 +143,9 @@ $(eval $(call SetupHostCommand,python,Please install Python 2.x, \
 	python2 -V 2>&1 | grep Python, \
 	python -V 2>&1 | grep Python))
 
+$(eval $(call SetupHostCommand,m4,Please install GNU 'm4', \
+	m4 --version | grep m4))
+
 $(eval $(call SetupHostCommand,git,Please install Git (git-core) >= 1.7.12.2, \
 	git --exec-path | xargs -I % -- grep -q -- --recursive %/git-submodule))
 


### PR DESCRIPTION
Since some packages need m4 tool during the building procedure, I add m4 when the sdk setup host command. For more detail see below snapshot.


![deepinscreenshot_20170927121522](https://user-images.githubusercontent.com/3126149/31008363-7165f1fe-a536-11e7-83ff-cdb4f8be450b.png)
