### PR TITLE
net: uqmi: fix blocking in endless loops when unplugging device

### DIFF
--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -65,6 +65,7 @@ proto_qmi_setup() {
 	[ -n "$delay" ] && sleep "$delay"
 
 	while uqmi -s -d "$device" --get-pin-status | grep '"UIM uninitialized"' > /dev/null; do
+		[ -e "$device" ] || return 1
 		sleep 1;
 	done
 
@@ -102,6 +103,7 @@ proto_qmi_setup() {
 
 	echo "Waiting for network registration"
 	while uqmi -s -d "$device" --get-serving-system | grep '"searching"' > /dev/null; do
+		[ -e "$device" ] || return 1
 		sleep 5;
 	done
 


### PR DESCRIPTION
If you unplug a QMI device, the /dev/cdc-wdmX device
disappears but uqmi will continue to poll it endlessly.

Then, when you plug it back, you have 2 uqmi processes,
and that's bad, because 2 processes talking QMI to the
same device [and the same time] doesn't seem to work well.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>