### PR TITLE
hostapd: correct IEEE 802.11r options

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -395,32 +395,38 @@ hostapd_set_bss_options() {
 		set_default ieee80211r 0
 
 		if [ "$ieee80211r" -gt "0" ]; then
-			json_get_vars mobility_domain r0_key_lifetime r1_key_holder \
-				reassociation_deadline pmk_r1_push ft_psk_generate_local ft_over_ds
-			json_get_values r0kh r0kh
-			json_get_values r1kh r1kh
-
-			set_default mobility_domain "4f57"
-			set_default r0_key_lifetime 10000
-			set_default reassociation_deadline 1000
-			set_default pmk_r1_push 0
-			set_default ft_psk_generate_local 0
+			json_get_vars mobility_domain ft_psk_generate_local ft_over_ds reassociation_deadline
+			
+			set_default mobility_domain "$(echo "$ssid" | md5sum | head -c 4)"
+			set_default ft_psk_generate_local 1
 			set_default ft_over_ds 1
+			set_default reassociation_deadline 1000
 
 			append bss_conf "mobility_domain=$mobility_domain" "$N"
-			append bss_conf "r0_key_lifetime=$r0_key_lifetime" "$N"
-			[ -n "$r1_key_holder" ] && append bss_conf "r1_key_holder=$r1_key_holder" "$N"
-			append bss_conf "reassociation_deadline=$reassociation_deadline" "$N"
-			append bss_conf "pmk_r1_push=$pmk_r1_push" "$N"
 			append bss_conf "ft_psk_generate_local=$ft_psk_generate_local" "$N"
 			append bss_conf "ft_over_ds=$ft_over_ds" "$N"
+			append bss_conf "reassociation_deadline=$reassociation_deadline" "$N"
+			[ -n "$nasid" ] || append bss_conf "nas_identifier=${macaddr//\:}" "$N"
 
-			for kh in $r0kh; do
-				append bss_conf "r0kh=${kh//,/ }" "$N"
-			done
-			for kh in $r1kh; do
-				append bss_conf "r1kh=${kh//,/ }" "$N"
-			done
+			if [ "$ft_psk_generate_local" -eq "0" ]; then
+				json_get_vars r0_key_lifetime r1_key_holder pmk_r1_push
+				json_get_values r0kh r0kh
+				json_get_values r1kh r1kh
+
+				set_default r0_key_lifetime 10000
+				set_default pmk_r1_push 0
+
+				[ -n "$r1_key_holder" ] && append bss_conf "r1_key_holder=$r1_key_holder" "$N"
+				append bss_conf "r0_key_lifetime=$r0_key_lifetime" "$N"
+				append bss_conf "pmk_r1_push=$pmk_r1_push" "$N"
+
+				for kh in $r0kh; do
+					append bss_conf "r0kh=${kh//,/ }" "$N"
+				done
+				for kh in $r1kh; do
+					append bss_conf "r1kh=${kh//,/ }" "$N"
+				done
+			fi
 		fi
 
 		append bss_conf "wpa_disable_eapol_key_retries=$wpa_disable_eapol_key_retries" "$N"


### PR DESCRIPTION
> SHORT:

for an absolute minimal working IEEE 802.11r, `option ieee80211r '1'` is all that is needed in LEDE

everything else is optional

> LONG:

IEEE 802.11r has *many sub-options* inside it's hostapd block of options

in LEDE, we have a *UCI special option* (option ieee80211r '1') that is not present in hostapd.conf and it *enables* these hostapd.conf sub-options

hostapd.conf sub-options' default values do *not* enable a working IEEE 802.11r configuration

`ft_psk_generate_local 1` from man:

> This avoids use of PMK-R1 push/pull from other APs with FT-PSK networks as the required information (PSK and other session data) is already locally available.

--------------------------------------------------------------------------------

1) it would be logical, that *UCI special option* `option ieee80211r '1'` actually enables a *default working* IEEE 802.11r from the start, with minimal sub-options defined

2) if we agree on this logic, it would be best that we start with a default value of 1 in `ft_psk_generate_local 1`

if it's 0 (previous default), user anyway has to provide unique `r1_key_holder` `r0kh` and `r1kh` as they are not locally generated

if per BSS, `ft_psk_generate_local 1` is the new default value left unchanged by user,
previous default value of `r1_key_holder` is left unchanged by user and `r0kh` and `r1kh` are not provided by user, default configuration of `option ieee80211r '1'` is in a **non-working or kind of working** default state of IEEE 802.11r

3) then default values of these are not wanted/needed anymore (they can only break something):
`r0_key_lifetime 1000`
`r1_key_holder "00004f577274"`

4) also then, this value *wants* to be 0:
`pmk_r1_push 0`

5) also then lastly, these *want* to be left empty:
`r0kh`
`r1kh`

4) `nasid` is mandatory for a working IEEE 802.11r, so a check here would be nice.
nasid needs to be unique per BSS, so it can atleast be made from BSSID per BSS

5) `mobility_domain` is also mandatory for a working IEEE 802.11r, so a default value can be hashed, so it's identical per BSS and also unique if there are multi SSIDs per AP

6) `r1_key_holder` proper default value is BSSID per BSS

7) sum of all mandatory options for a minimal working setup BEFORE this commit:
`option ieee80211r 1`
`option mobility_domain '<unique per BSS>'`
`option nasid '<unique per AP, can be bssid>'`
`option ft_psk_generate_local '1'`
`cannot disable r0kh r1kh` <-- *thats why its a non-working or kind of working setup*

7) sum of all mandatory options for a minimal working setup AFTER this commit:
`option ieee80211r 1`

8) ALL this does NOT break behaviour in our `option ieee80211r '1'`, it only disables mistakes and supercharges it

Signed-off-by: Gospod Nassa <devianca@gmail.com>