### PR TITLE
kernel: allow unpatched builds as workaround

### DIFF
--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -118,3 +118,12 @@ menuconfig DEVEL
 		default "-fno-caller-saves"
 		help
 		  Extra target-independent optimizations to use when building for the target.
+
+	config UNPATCHED_KERNEL
+		bool
+		default n
+		help
+		  Disable kernel patches if you want to generate a baseline image
+		  or suspect a patch might be the source of a regression.  This
+		  may cause some functionality to fail.
+

--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -18,8 +18,10 @@ endif
 
 export HOST_EXTRACFLAGS=-I$(STAGING_DIR_HOST)/include
 
+ifneq ($(CONFIG_UNPATCHED_KERNEL),y)
 # defined in quilt.mk
 Kernel/Patch:=$(Kernel/Patch/Default)
+endif
 
 ifeq ($(strip $(CONFIG_EXTERNAL_KERNEL_TREE)),"")
   ifeq ($(strip $(CONFIG_KERNEL_GIT_CLONE_URI)),"")


### PR DESCRIPTION
Sometimes you want to do a quick build with no patches to see if any of the LEDE-specific patches are causing a regression.  Having an easy way to do this is handy.

Ideally you'd be able to do this with the tree as-is, but there are some incidental problems that interfere with it:

https://bugs.lede-project.org/index.php?do=details&task_id=503

This offers a trivial workaround, and this PR can be reverted when FS#503 gets fixed.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>

