### PR TITLE
[RFC] hostapd: add IEEE 802.11v support

### DIFF
--- a/package/network/services/hostapd/files/hostapd-full.config
+++ b/package/network/services/hostapd/files/hostapd-full.config
@@ -153,7 +153,7 @@ CONFIG_IEEE80211N=y
 
 # Wireless Network Management (IEEE Std 802.11v-2011)
 # Note: This is experimental and not complete implementation.
-#CONFIG_WNM=y
+CONFIG_WNM=y
 
 # IEEE 802.11ac (Very High Throughput) support
 CONFIG_IEEE80211AC=y

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -184,6 +184,10 @@ hostapd_common_add_bss_config() {
 	config_add_int wps_ap_setup_locked wps_independent
 	config_add_string wps_device_type wps_device_name wps_manufacturer wps_pin
 
+	config_add_boolean ieee80211v wnm_sleep_mode bss_transition
+	config_add_int time_advertisement
+	config_add_string time_zone
+
 	config_add_boolean ieee80211r pmk_r1_push ft_psk_generate_local ft_over_ds
 	config_add_int r0_key_lifetime reassociation_deadline
 	config_add_string mobility_domain r1_key_holder
@@ -381,6 +385,21 @@ hostapd_set_bss_options() {
 		network_get_device ifname "$iapp_interface" || ifname="$iapp_interface"
 		append bss_conf "iapp_interface=$ifname" "$N"
 	}
+
+	json_get_vars ieee80211v
+	set_default ieee80211v 0
+	if [ "$ieee80211v" -eq "1" ]; then
+		json_get_vars time_advertisement time_zone wnm_sleep_mode bss_transition
+
+		set_default time_advertisement 0
+		set_default wnm_sleep_mode 0
+		set_default bss_transition 0
+
+		append bss_conf "time_advertisement=$time_advertisement" "$N"
+		[ -n "$time_zone" ] && append bss_conf "time_zone=$time_zone" "$N"
+		append bss_conf "wnm_sleep_mode=$wnm_sleep_mode" "$N"
+		append bss_conf "bss_transition=$bss_transition" "$N"
+	fi
 
 	if [ "$wpa" -ge "1" ]; then
 		json_get_vars ieee80211r

--- a/package/network/services/hostapd/files/wpa_supplicant-full.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-full.config
@@ -465,7 +465,7 @@ CONFIG_NO_RANDOM_POOL=y
 
 # Wireless Network Management (IEEE Std 802.11v-2011)
 # Note: This is experimental and not complete implementation.
-#CONFIG_WNM=y
+CONFIG_WNM=y
 
 # Interworking (IEEE 802.11u)
 # This can be used to enable functionality to improve interworking with


### PR DESCRIPTION
Add Wireless Network Management (IEEE 802.11v)
support to:
- hostapd-full
- wpa_supplicant-full

It must be enabled at runtime via UCI with:
- option ieee80211v '1'

Add UCI support for:
- time_advertisement
- time_zone
- wnm_sleep_mode
- bss_transition

Signed-off-by: Lorenzo Santina <lorenzo.santina@edu.unito.it>