### PR TITLE
Fix 5Ghz wifi for Sitecom WLR-8100

### DIFF
--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -133,6 +133,9 @@ case "$FIRMWARE" in
 	rb-962uigs-5hact2hnt)
 		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
 		;;
+	wlr8100)
+                ath10kcal_extract "art" 24576 2116
+                ;;
 	esac
 	;;
 "ath10k/pre-cal-pci-0000:00:00.0.bin")

--- a/target/linux/ar71xx/image/legacy-devices.mk
+++ b/target/linux/ar71xx/image/legacy-devices.mk
@@ -163,7 +163,8 @@ LEGACY_DEVICES += TUBE2H16M
 
 define LegacyDevice/WLR8100
   DEVICE_TITLE := Sitecom WLR-8100
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-usb3
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-usb3 \
+	kmod-ath10k ath10k-firmware-qca988x
 endef
 LEGACY_DEVICES += WLR8100
 


### PR DESCRIPTION
Fix the 5Ghz wireless by adding the right calibration data.

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>