### PR TITLE
ar71xx: add support for Mikrotik RB750P-PBr2

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -267,6 +267,7 @@ rb-750)
 	ucidef_set_led_switch "port5" "port5" "rb750:green:port5" "switch0" "0x02"
 	;;
 rb-750-r2|\
+rb-750p-pbr2|\
 rb-750up-r2)
 	ucidef_set_led_timer "user" "USER" "rb:green:user" "1000" "1000"
 	ucidef_set_led_netdev "port1" "port1" "rb:green:port1" "eth0"

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -160,6 +160,7 @@ ar71xx_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
 	rb-750-r2|\
+	rb-750p-pbr2|\
 	rb-750up-r2)
 		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ar71xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ar71xx/base-files/etc/board.d/03_gpio_switches
@@ -32,6 +32,9 @@ rb-952ui-5ac2nd)
 	ucidef_add_gpio_switch "usb_power_switch" "USB Power Switch" "45" "1"
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "14"
 	;;
+rb-750p-pbr2)
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "14"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -316,6 +316,7 @@ get_status_led() {
 		status_led="rb750:green:act"
 		;;
 	rb-750-r2|\
+	rb-750p-pbr2|\
 	rb-750up-r2|\
 	rb-911g-2hpnd|\
 	rb-911g-5hpacd|\

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -911,6 +911,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD 750GL")
 		name="rb-750gl"
 		;;
+	*"RouterBOARD 750P r2")
+		name="rb-750p-pbr2"
+		;;
 	*"RouterBOARD 750UP r2")
 		name="rb-750up-r2"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -655,6 +655,7 @@ platform_check_image() {
 	# these boards use metadata images
 	fritz300e|\
 	rb-750-r2|\
+	rb-750p-pbr2|\
 	rb-750up-r2|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
@@ -712,6 +713,7 @@ platform_pre_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	rb-750-r2|\
+	rb-750p-pbr2|\
 	rb-750up-r2|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -1008,6 +1008,7 @@ config ATH79_MACH_RBSPI
 	  MikroTik RouterBOARD hAP ac lite
 	  MikroTik RouterBOARD hEX PoE lite
 	  MikroTik RouterBOARD hEX lite
+	  MikroTik RouterBOARD Powerbox
 	  MikroTik RouterBOARD LHG 5
 	  MikroTik RouterBOARD cAP (EXPERIMENTAL)
 	  MikroTik RouterBOARD mAP (EXPERIMENTAL)

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -7,6 +7,7 @@
  *  - MikroTik RouterBOARD 952Ui-5ac2nD
  *  - MikroTik RouterBOARD 962UiGS-5HacT2HnT
  *  - MikroTik RouterBOARD 750UP r2
+ *  - MikroTik RouterBOARD 750P-PBr2
  *  - MikroTik RouterBOARD 750 r2
  *  - MikroTik RouterBOARD LHG 5nD
  *
@@ -763,7 +764,8 @@ static void __init rb952_setup(void)
  * Init the hEX (PoE) lite hardware (QCA953x).
  * The 750UP r2 (hEX PoE lite) is nearly identical to the hAP, only without
  * WLAN. The 750 r2 (hEX lite) is nearly identical to the 750UP r2, only
- * without USB and POE. It shares the same bootloader board identifier.
+ * without USB and POE. The 750P Pbr2 (Powerbox) is nearly identical to hEX PoE
+ * lite, only without USB. It shares the same bootloader board identifier.
  */
 static void __init rb750upr2_setup(void)
 {
@@ -775,6 +777,10 @@ static void __init rb750upr2_setup(void)
 	/* differentiate the hEX lite from the hEX PoE lite */
 	if (strstr(mips_get_machine_name(), "750UP r2"))
 		flags |= RBSPI_HAS_USB | RBSPI_HAS_POE;
+	
+	/* differentiate the Powerbox from the hEX lite */
+	else if (strstr(mips_get_machine_name(), "750P r2"))
+		flags |= RBSPI_HAS_POE;
 
 	rbspi_952_750r2_setup(flags);
 }

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -30,7 +30,7 @@ define Device/rb-nor-flash-16M
   LOADER_TYPE := elf
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin | lzma | loader-kernel
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-mapl-2nd
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-mapl-2nd
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef


### PR DESCRIPTION
This PR adds support for the MikroTik RouterBOARD Powerbox
https://mikrotik.com/product/RB750P-PBr2

Specifications:
- SoC: Qualcomm QCA9531 (650MHz)
- RAM: 64MB
- Storage: 16MB NOR SPI flash
- Ethernet: 5x100M (1 PoE in, 4 PoE out)
- Outdoor use ready

This ethernet router is based on the same platform as the hEX PoE lite.

Full installation instructions are included in the commit message.

Signed-off-by: Robert Marko <robimarko@gmail.com>