### PR TITLE
hostapd: enable fast math library

### DIFF
--- a/package/network/services/hostapd/files/hostapd-full.config
+++ b/package/network/services/hostapd/files/hostapd-full.config
@@ -297,7 +297,7 @@ CONFIG_INTERNAL_LIBTOMMATH=y
 # At the cost of about 4 kB of additional binary size, the internal LibTomMath
 # can be configured to include faster routines for exptmod, sqr, and div to
 # speed up DH and RSA calculation considerably
-#CONFIG_INTERNAL_LIBTOMMATH_FAST=y
+CONFIG_INTERNAL_LIBTOMMATH_FAST=y
 
 # Interworking (IEEE 802.11u)
 # This can be used to enable functionality to improve interworking with


### PR DESCRIPTION
Enable internal math fast library for hostapd-full
like wpa_supplicant-full

Signed-off-by: Lorenzo Santina <lorenzo.santina@edu.unito.it>