### PR TITLE
tools: add factory generation tool for Buffalo WHR-300HP2 and WHR-1166

### DIFF
--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -78,6 +78,11 @@ define MkCombineduImage
 	$(call MkImage,lzma,$(KDIR)/vmlinux-$(2).bin.lzma.combined,$(call sysupname,$(1),$(2)),$(6))
 endef
 
+define Build/buffalo-crc
+	$(STAGING_DIR_HOST)/bin/buffalo-crc $(1) $@ $@.new
+	mv $@.new $@
+endef
+
 define Build/umedia-header
 	fix-u-media-header -T 0x46 -B $(1) -i $@ -o $@.new && mv $@.new $@
 endef

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -394,6 +394,11 @@ define Device/whr-1166d
   DTS := WHR-1166D
   IMAGE_SIZE := 15040k
   DEVICE_TITLE := Buffalo WHR-1166D
+  IMAGES += factory-eu.bin factory-us.bin
+  IMAGE/factory-eu.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+	buffalo-crc -m FIRMWARE -i 520 -o 290 -d WRTR-300ACN_EU
+  IMAGE/factory-us.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+	buffalo-crc -m FIRMWARE -i 520 -o 290 -d WRTR-300ACN_US
 endef
 TARGET_DEVICES += whr-1166d
 
@@ -401,6 +406,9 @@ define Device/whr-300hp2
   DTS := WHR-300HP2
   IMAGE_SIZE := 6848k
   DEVICE_TITLE := Buffalo WHR-300HP2
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+	buffalo-crc -m FIRMWARE -i 520 -o 250 -d WRTR-297GN_US
 endef
 TARGET_DEVICES += whr-300hp2
 

--- a/tools/firmware-utils/Makefile
+++ b/tools/firmware-utils/Makefile
@@ -53,6 +53,7 @@ define Host/Compile
 	$(call cc,zyxbcm)
 	$(call cc,trx2edips)
 	$(call cc,xorimage)
+	$(call cc,buffalo-crc, -Wall)
 	$(call cc,buffalo-enc buffalo-lib, -Wall)
 	$(call cc,buffalo-tag buffalo-lib, -Wall)
 	$(call cc,buffalo-tftp buffalo-lib, -Wall)

--- a/tools/firmware-utils/src/buffalo-crc.c
+++ b/tools/firmware-utils/src/buffalo-crc.c
@@ -1,0 +1,182 @@
+/*
+ *  Copyright (C) 2017 Jonathan Thibault <jonathan@navigue.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 as published
+ *  by the Free Software Foundation.
+ *
+ */
+
+#include <stdio.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <libgen.h>
+
+#define BTOI(x) (*(x+3)|(u_int32_t)*(x+2)<<8|(u_int32_t)*(x+1)<<16|(u_int32_t)*(x)<<24)
+#define BTOI_LE(x) (*(x)|(u_int32_t)*(x+1)<<8|(u_int32_t)*(x+2)<<16|(u_int32_t)*(x+3)<<24)
+#define ITOB(x, p) *(p)=(x>>24)&0xff; *(p+1)=(x>>16)&0xff; *(p+2)=(x>>8)&0xff; *(p+3)=(x)&0xff;
+#define ITOB_LE(x, p) *(p)=(x)&0xff; *(p+1)=(x>>8)&0xff; *(p+2)=(x>>16)&0xff; *(p+3)=(x>>24)&0xff;
+
+static const u_int32_t crc32_table[256] = {
+	0x00000000, 0x77073096, 0xee0e612c, 0x990951ba,
+	0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
+	0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
+	0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91,
+	0x1db71064, 0x6ab020f2, 0xf3b97148, 0x84be41de,
+	0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+	0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec,
+	0x14015c4f, 0x63066cd9, 0xfa0f3d63, 0x8d080df5,
+	0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+	0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b,
+	0x35b5a8fa, 0x42b2986c, 0xdbbbc9d6, 0xacbcf940,
+	0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+	0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116,
+	0x21b4f4b5, 0x56b3c423, 0xcfba9599, 0xb8bda50f,
+	0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+	0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d,
+	0x76dc4190, 0x01db7106, 0x98d220bc, 0xefd5102a,
+	0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+	0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818,
+	0x7f6a0dbb, 0x086d3d2d, 0x91646c97, 0xe6635c01,
+	0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
+	0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457,
+	0x65b0d9c6, 0x12b7e950, 0x8bbeb8ea, 0xfcb9887c,
+	0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+	0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2,
+	0x4adfa541, 0x3dd895d7, 0xa4d1c46d, 0xd3d6f4fb,
+	0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+	0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9,
+	0x5005713c, 0x270241aa, 0xbe0b1010, 0xc90c2086,
+	0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+	0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4,
+	0x59b33d17, 0x2eb40d81, 0xb7bd5c3b, 0xc0ba6cad,
+	0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
+	0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683,
+	0xe3630b12, 0x94643b84, 0x0d6d6a3e, 0x7a6a5aa8,
+	0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+	0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe,
+	0xf762575d, 0x806567cb, 0x196c3671, 0x6e6b06e7,
+	0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
+	0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5,
+	0xd6d6a3e8, 0xa1d1937e, 0x38d8c2c4, 0x4fdff252,
+	0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+	0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60,
+	0xdf60efc3, 0xa867df55, 0x316e8eef, 0x4669be79,
+	0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+	0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f,
+	0xc5ba3bbe, 0xb2bd0b28, 0x2bb45a92, 0x5cb36a04,
+	0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+	0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a,
+	0x9c0906a9, 0xeb0e363f, 0x72076785, 0x05005713,
+	0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
+	0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21,
+	0x86d3d2d4, 0xf1d4e242, 0x68ddb3f8, 0x1fda836e,
+	0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+	0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c,
+	0x8f659eff, 0xf862ae69, 0x616bffd3, 0x166ccf45,
+	0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
+	0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db,
+	0xaed16a4a, 0xd9d65adc, 0x40df0b66, 0x37d83bf0,
+	0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+	0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6,
+	0xbad03605, 0xcdd70693, 0x54de5729, 0x23d967bf,
+	0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+	0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d};
+
+u_int32_t crc32(unsigned char *start, size_t len)
+{
+	u_int32_t c = 0xffffffff;
+	unsigned char *end;
+	for(end = start + len; start < end; start++)
+		c = crc32_table[(c ^ *start) & 0xff] ^ (c >> 8);
+	return ~c;
+}
+
+int scramble(unsigned char *data, unsigned char *target, size_t len)
+{
+	while(len) {
+		len--;
+		target[len] = ~*data;
+		if(*data) data++;
+	}
+}
+
+int main(int argc, char **argv)
+{
+	int fd, opt, s = 0;
+	struct stat st = {0};
+	u_int32_t crc, size;
+	unsigned char *buf, *payload,
+		*m = "FIRMWARE", *i = "520", *o = "250", *d = "WRTR-297GN_US";
+
+	while((opt = getopt(argc, argv, "shm:i:o:d:")) != -1) {
+		switch(opt) {
+			case 'm': m = optarg; break;
+			case 'i': i = optarg; break;
+			case 'o': o = optarg; break;
+			case 'd': d = optarg; break;
+			case 's': s = 1; break;
+			case 'h': case '?': goto usage;
+			default: break;
+		}
+	}
+
+	opt = argc-optind;
+	if(opt < 1 || opt > 2) { usage:
+		printf("Usage: %s [OPTIONS...] <input_file> [output_file]\n"
+			"\nOptions:\n"
+			"  -m<MAGIC>  Set MAGIC (Default: FIRMWARE)\n"
+			"  -i<IVER>   Inner version (Default: 520)\n"
+			"  -o<OVER>   Outer version (Default: 250)\n"
+			"  -d<MODEL>  Set model (Default: WRTR-297GN_US\n"
+			"  -s         Output only header (No payload)\n"
+			"  -h         Display this message.\n", basename(argv[0]));
+		return 0;
+	}
+	fd = open(argv[optind], O_RDONLY);
+	if(fd < 0) return 1;
+	if(fstat(fd, &st) < 0) return 2;
+	buf = malloc(st.st_size+52);
+	payload = buf+52;
+	read(fd, payload, st.st_size);
+	close(fd);
+	if(crc32(payload, 48) == BTOI_LE(payload+48)) {
+		size = st.st_size-52;
+		crc = crc32(payload+52, size);
+		scramble(payload+8, buf, 40);
+		printf("File already appears to have a Buffalo header:\n"
+			"  Length (header/payload) : %u/%u\n"
+			"  CRC32 (header/payload)  : %08X/%08X\n"
+			"  Magic                   : %.8s\n"
+			"  Inner version           : %.4s\n"
+			"  Outer version           : %.4s\n"
+			"  Model                   : %.24s\n",
+			~BTOI(payload+4), size, ~BTOI(payload), crc,
+			buf, buf+8, buf+12, buf+16);
+		if(opt == 1) goto end;
+		payload+=52;
+	} else {
+		if(opt == 1) goto end;
+		size = st.st_size;
+		crc = crc32(payload, size);
+	}
+	ITOB(~crc, buf);
+	ITOB(~size, buf+4);
+	scramble(d, buf+8, 24);
+	scramble(o, buf+32, 4);
+	scramble(i, buf+36, 4);
+	scramble(m, buf+40, 8);
+	crc = crc32(buf, 48);
+	ITOB_LE(crc, buf+48);
+	fd = open(argv[optind+1], O_CREAT|O_WRONLY|O_TRUNC, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
+	write(fd, buf, 52);
+	if(s != 1) write(fd, payload, size);
+	close(fd);
+
+	end:
+	free(buf);
+	return 0;
+}


### PR DESCRIPTION
This PR adds a new tool for generating "Buffalo CRC" header used by Buffalo WHR-300HP2 and WHR-1166. Currently does not work on the -D / dd-wrt variants due to an extra signature