### PR TITLE
ramips: revised reset button gpios for Omnima Mini Linux boards

### DIFF
--- a/target/linux/ramips/dts/MINIEMBPLUG.dts
+++ b/target/linux/ramips/dts/MINIEMBPLUG.dts
@@ -19,7 +19,7 @@
 
 		mobile {
 			label = "miniembplug:green:mobile";
-			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -29,28 +29,10 @@
 		#size-cells = <0>;
 		poll-interval = <20>;
 
-		wps {
-			label = "wps";
-			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-
 		reset {
 			label = "reset";
-			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-
-		mode-one {
-			label = "mode1";
-			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-
-		mode-two {
-			label = "mode2";
-			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+            linux,code = <KEY_RESTART>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/MINIEMBPLUG.dts
+++ b/target/linux/ramips/dts/MINIEMBPLUG.dts
@@ -32,7 +32,7 @@
 		reset {
 			label = "reset";
 			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-            linux,code = <KEY_RESTART>;
+			linux,code = <KEY_RESTART>;
 		};
 	};
 };


### PR DESCRIPTION
Revised Reset button GPIO, also fixed linux,code = <KEY_RESTART> line.
Removed wps, mode-one and mode-two gpio definitions so that these can be used as general purpose i/o lines.