### PR TITLE
ramips: add support for Kimax U-25AWF 2.5" SATA WIFI HDD Enclosure

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -368,6 +368,10 @@ tl-wr841n-v13)
 	ucidef_set_led_switch "lan4" "lan4" "$board:green:lan4" "switch0" "0x10"
 	ucidef_set_led_switch "wan" "wan" "$board:green:wan" "switch0" "0x01"
 	;;
+u25awf)
+	set_wifi_led "u25awf:red:wifi"
+	ucidef_set_led_netdev "eth" "eth" "u25awf:green:lan" "eth0"
+	;;
 vocore-8M|\
 vocore-16M)
 	ucidef_set_led_netdev "eth" "ETH" "vocore:orange:eth" "eth0"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -172,6 +172,7 @@ ramips_setup_interfaces()
 	rt-n14u|\
 	tl-wr840n-v4|\
 	tl-wr841n-v13|\
+	u25awf|\
 	ubnt-erx|\
 	ubnt-erx-sfp|\
 	ur-326n4g|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -227,6 +227,9 @@ get_status_led() {
 	tew-638apb-v2|\
 	tew-691gr|\
 	tew-692gr|\
+	u25awf)
+		status_led="$board:red:wifi"
+		;;
 	ur-326n4g|\
 	ur-336un|\
 	wf-2881)

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -505,6 +505,9 @@ ramips_board_detect() {
 	*"TL-WR841N v13")
 		name="tl-wr841n-v13"
 		;;
+	*"U-25AWF")
+		name="u25awf"
+		;;
 	*"UBNT-ERX")
 		name="ubnt-erx"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -144,6 +144,7 @@ platform_check_image() {
 	tew-714tru|\
 	timecloud|\
 	tiny-ac|\
+	u25awf |\
 	ur-326n4g|\
 	ur-336un|\
 	v22rw-2x2|\

--- a/target/linux/ramips/dts/U25AWF.dts
+++ b/target/linux/ramips/dts/U25AWF.dts
@@ -1,0 +1,108 @@
+/dts-v1/;
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/{
+	compatible = "kimax,u25awf","ralink,mt7620n-soc";
+	model = "Kimax U-25AWF";
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+		reset {
+			label = "reset";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		wifi {
+			label = "u25awf:red:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "u25awf:green:lan";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfb0000>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+	ralink,port-map = "wllll";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "wled","ephy";
+			ralink,function = "gpio";
+		};
+	};
+};
+

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -193,6 +193,13 @@ define Device/gl-mt300a
 endef
 TARGET_DEVICES += gl-mt300a
 
+define Device/u25awf
+  DTS := U25AWF
+  IMAGE_SIZE := 16064k
+  DEVICE_TITLE := Kimax U-25AWF (16MB)
+endef
+TARGET_DEVICES += u25awf
+
 define Device/gl-mt300n
   DTS := GL-MT300N
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
Kimax U-25AWF is is a 2,5" HDD Enclosure with Wi-Fi/Eth conection
and battery, based on MediaTek MT7620N. Patch rewritten from:
https://forum.openwrt.org/viewtopic.php?pid=305643

Specification:

- MT7620N CPU
- 64 MB of RAM
- 16 MB of FLASH
- 802.11bgn WiFi
- 1x 10/100 Mbps Ethernet
- USB 2.0 Host
- UART for serial console

more on: https://wikidevi.com/wiki/Kimax_U25AWF

Flash instruction:
1. Download lede-ramips-mt7620-u25awf-squashfs-sysupgrade.bin
2. Open webinterface a upgrade
3. After boot connect via ethernet to ip 192.168.1.1

Tested on:

- Blueendless U-35WF which is the same hardware but without battery
and with 3,5" drive enclosure

Signed-off-by: Daniel Kucera <daniel.kucera@gmail.com>
