### PR TITLE
hostapd: enable Automatic Channel Selection

### DIFF
--- a/package/network/services/hostapd/files/hostapd-full.config
+++ b/package/network/services/hostapd/files/hostapd-full.config
@@ -346,7 +346,7 @@ CONFIG_INTERNAL_LIBTOMMATH=y
 # For more details refer to:
 # http://wireless.kernel.org/en/users/Documentation/acs
 #
-#CONFIG_ACS=y
+CONFIG_ACS=y
 
 # Multiband Operation support
 # These extentions facilitate efficient use of multiple frequency bands

--- a/package/network/services/hostapd/files/hostapd-mini.config
+++ b/package/network/services/hostapd/files/hostapd-mini.config
@@ -346,7 +346,7 @@ CONFIG_TLS=internal
 # For more details refer to:
 # http://wireless.kernel.org/en/users/Documentation/acs
 #
-#CONFIG_ACS=y
+CONFIG_ACS=y
 
 # Multiband Operation support
 # These extentions facilitate efficient use of multiple frequency bands


### PR DESCRIPTION
It is already supported by some drivers and
is further enabled by setting channel=0.
It should fall back to the pseudo 'auto' channel behaviour
where driver support isn't there.

Signed-off-by: Shaleen Jain <shaleen@thejains.org.in>