### PR TITLE
lantiq: rename nas0/ptm0 to dsl0

### DIFF
--- a/package/network/config/ltq-vdsl-app/Makefile
+++ b/package/network/config/ltq-vdsl-app/Makefile
@@ -58,10 +58,11 @@ CONFIGURE_ARGS += \
 #CONFIGURE_ARGS += --enable-model=debug
 
 define Package/ltq-vdsl-app/install
-	$(INSTALL_DIR) $(1)/etc/init.d $(1)/sbin $(1)/etc/hotplug.d/dsl
+	$(INSTALL_DIR) $(1)/etc/init.d $(1)/sbin $(1)/etc/hotplug.d/dsl $(1)/etc/hotplug.d/net
 	$(INSTALL_BIN) ./files/dsl_control $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/10_atm.sh $(1)/etc/hotplug.d/dsl
 	$(INSTALL_BIN) ./files/10_ptm.sh $(1)/etc/hotplug.d/dsl
+	$(INSTALL_BIN) ./files/10-xdsl_rename $(1)/etc/hotplug.d/net
 
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/dsl_cpe_control $(1)/sbin/vdsl_cpe_control
 	$(INSTALL_BIN) ./files/dsl_cpe_pipe.sh $(1)/sbin/

--- a/package/network/config/ltq-vdsl-app/files/10-xdsl_rename
+++ b/package/network/config/ltq-vdsl-app/files/10-xdsl_rename
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$ACTION" = add ]; then
+	[ "$DEVICENAME" = "nas0" ] ||[ "$DEVICENAME" = "ptm0" ] || exit
+
+	ip link set $DEVICENAME name dsl0
+fi

--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -199,7 +199,7 @@ ls /lib/modules/$(uname -r)/ltq_atm* 1> /dev/null 2>&1 && \
 	ucidef_add_atm_bridge "$vpi" "$vci" "$encaps" "$payload"
 
 if lantiq_is_vdsl_system; then
-	interface_wan="ptm0"
+	interface_wan="dsl0"
 	ucidef_add_vdsl_modem "$annex" "$tone" "$xfer_mode"
 else
 	interface_wan="nas0"

--- a/target/linux/lantiq/base-files/etc/uci-defaults/02_migrate_xdsl_iface
+++ b/target/linux/lantiq/base-files/etc/uci-defaults/02_migrate_xdsl_iface
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /lib/functions/lantiq.sh
+
+IFNAME_CHANGED=0
+
+rename_xdsl_ifname()
+{
+	local cfg="$1"
+	local section="$2"
+	local option="$3"
+	local name
+
+	config_get name ${section} $option
+	case $name in
+		nas0*)
+			name=${name/nas0/dsl0}
+			;;
+		ptm0*)
+			name=${name/ptm0/dsl0}
+			;;
+		*)
+			return
+			;;
+	esac
+
+	uci set ${cfg}.${section}.$option=$name
+	IFNAME_CHANGED=1
+}
+
+migrate_network_xdsl_ifname()
+{
+	rename_xdsl_ifname network "$1" ifname
+	rename_xdsl_ifname network "$1" name
+}
+
+migrate_led_xdsl_ifname()
+{
+	rename_xdsl_ifname system "$1" dev
+}
+
+lantiq_is_vdsl_system || exit 0
+
+config_load network
+config_foreach migrate_network_xdsl_ifname
+
+[ "$IFNAME_CHANGED" = "1" ] && uci commit network
+
+IFNAME_CHANGED=0
+
+config_load system
+config_foreach migrate_led_xdsl_ifname led
+
+[ "$IFNAME_CHANGED" = "1" ] && uci commit system
+
+exit 0


### PR DESCRIPTION
This change makes it possible to configure the wan/dsl ppp interface
settings independantly from the used TC-Layer (ATM/PTM).

Now you can move a device from an ADSL/ATM port to an VDSL/PTM port
without any configuration changes for example.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
@mkresin 