### PR TITLE
layerscape: fix build issue for usb

### DIFF
--- a/target/linux/layerscape/patches-4.9/819-Revert-usb-kconfig-remove-dependency-FSL_SOC-for-ehc.patch
+++ b/target/linux/layerscape/patches-4.9/819-Revert-usb-kconfig-remove-dependency-FSL_SOC-for-ehc.patch
@@ -1,0 +1,33 @@
+From ba4f9dd74ccb9da91195b3570310754716064ef2 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Tue, 10 Oct 2017 15:55:31 +0800
+Subject: [PATCH] Revert "usb: kconfig: remove dependency FSL_SOC for ehci fsl
+ driver"
+
+This reverts commit 92042e8b3622a9bbfce0ebfc90edf6cd14d45708 on
+LSDK linux (https://github.com/qoriq-open-source/linux).
+
+The patch reverted allowed to build ehci-fsl driver for non-PPC
+platforms, but actually the driver was not ready.
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ drivers/usb/host/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/usb/host/Kconfig b/drivers/usb/host/Kconfig
+index a57d95c371be..0b80cee30da4 100644
+--- a/drivers/usb/host/Kconfig
++++ b/drivers/usb/host/Kconfig
+@@ -165,7 +165,7 @@ config XPS_USB_HCD_XILINX
+ 
+ config USB_EHCI_FSL
+ 	tristate "Support for Freescale PPC on-chip EHCI USB controller"
+-	depends on USB_EHCI_HCD
++	depends on FSL_SOC
+ 	select USB_EHCI_ROOT_HUB_TT
+ 	---help---
+ 	  Variation of ARC USB block used in some Freescale chips.
+-- 
+2.14.1
+


### PR DESCRIPTION
When build firmware for layerscape target with CONFIG_ALL_NONSHARED=y,
there would be a compile issue of usb ehci-fsl driver. Actually this
driver was for PPC platforms initially and was not ready for non-PPC
now, but a kernel kconfig patch removed PPC dependency for it. So that
kernel patch should be reverted.
