### PR TITLE
ar71xx: Fix MAC partition of Meraki MR12/MR16

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr12.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr12.c
@@ -42,7 +42,9 @@
 
 #define MR12_WAN_PHYMASK    BIT(4)
 
-#define MR12_CALDATA0_OFFSET            0x21000
+#define MR12_MAC			0xbf090000
+#define MR12_ART			0xbfff0000
+#define MR12_CALDATA0_OFFSET		0x1000
 
 static struct gpio_led MR12_leds_gpio[] __initdata = {
 	{
@@ -89,8 +91,10 @@ static struct gpio_keys_button MR12_gpio_keys[] __initdata = {
 
 static void __init MR12_setup(void)
 {
-	u8 *mac = (u8 *) KSEG1ADDR(0xbffd0000);
-	u8 wlan_mac[ETH_ALEN];
+	u8 *mac = (u8 *) KSEG1ADDR(MR12_MAC);
+	u8 *art = (u8 *) KSEG1ADDR(MR12_ART);
+
+	u8 wlan0_mac[ETH_ALEN];
 
 	ath79_register_mdio(0,0x0);
 
@@ -98,6 +102,8 @@ static void __init MR12_setup(void)
 	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;
 	ath79_eth0_data.phy_mask = MR12_WAN_PHYMASK;
 	ath79_register_eth(0);
+
+	ath79_init_mac(wlan0_mac, mac, 1);
 
 	ath79_register_m25p80(NULL);
 
@@ -107,8 +113,8 @@ static void __init MR12_setup(void)
 					ARRAY_SIZE(MR12_gpio_keys),
 					MR12_gpio_keys);
 
-	ath79_init_mac(wlan_mac, mac, 1);
-	ap91_pci_init(mac + MR12_CALDATA0_OFFSET, wlan_mac);
+	ap91_pci_init(art + MR12_CALDATA0_OFFSET, wlan0_mac);
+
 }
 
 MIPS_MACHINE(ATH79_MACH_MR12, "MR12", "Meraki MR12", MR12_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr16.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr16.c
@@ -42,8 +42,10 @@
 
 #define MR16_WAN_PHYMASK    BIT(0)
 
-#define MR16_CALDATA0_OFFSET		0x21000
-#define MR16_CALDATA1_OFFSET		0x25000
+#define MR16_MAC			0xbf080066
+#define MR16_ART			0xbfff0000
+#define MR16_CALDATA0_OFFSET		0x1000
+#define MR16_CALDATA1_OFFSET		0x5000
 
 static struct gpio_led MR16_leds_gpio[] __initdata = {
 	{
@@ -90,7 +92,9 @@ static struct gpio_keys_button MR16_gpio_keys[] __initdata = {
 
 static void __init MR16_setup(void)
 {
-	u8 *mac = (u8 *) KSEG1ADDR(0xbffd0000);
+	u8 *mac = (u8 *) KSEG1ADDR(MR16_MAC);
+	u8 *art = (u8 *) KSEG1ADDR(MR16_ART);
+
 	u8 wlan0_mac[ETH_ALEN];
 	u8 wlan1_mac[ETH_ALEN];
 
@@ -101,6 +105,9 @@ static void __init MR16_setup(void)
 	ath79_eth0_data.phy_mask = MR16_WAN_PHYMASK;
 	ath79_register_eth(0);
 
+	ath79_init_mac(wlan0_mac, mac, 1);
+	ath79_init_mac(wlan1_mac, mac, 2);
+
 	ath79_register_m25p80(NULL);
 
 	ath79_register_leds_gpio(-1, ARRAY_SIZE(MR16_leds_gpio),
@@ -109,10 +116,8 @@ static void __init MR16_setup(void)
 					ARRAY_SIZE(MR16_gpio_keys),
 					MR16_gpio_keys);
 
-	ath79_init_mac(wlan0_mac, mac, 1);
-	ath79_init_mac(wlan1_mac, mac, 2);
-	ap94_pci_init(mac + MR16_CALDATA0_OFFSET, wlan0_mac,
-		    mac + MR16_CALDATA1_OFFSET, wlan1_mac);
+	ap94_pci_init(art + MR16_CALDATA0_OFFSET, wlan0_mac,
+					art + MR16_CALDATA1_OFFSET, wlan1_mac);
 }
 
 MIPS_MACHINE(ATH79_MACH_MR16, "MR16", "Meraki MR16", MR16_setup);

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -333,9 +333,9 @@ define Device/mr12
   DEVICE_TITLE := Meraki MR12
   DEVICE_PACKAGES := kmod-spi-gpio
   BOARDNAME := MR12
-  ROOTFS_SIZE := 13440k
-  IMAGE_SIZE := 15680k
-  MTDPARTS := spi0.0:256k(u-boot)ro,256k(u-boot-env)ro,13440k(rootfs),2240k(kernel),64k(mac),128k(art)ro,15680k@0x80000(firmware)
+  ROOTFS_SIZE := 13312k
+  IMAGE_SIZE := 15616k
+  MTDPARTS := spi0.0:256k(u-boot)ro,256k(u-boot-env)ro,128k(config)ro,13312k(rootfs),2304k(kernel),128k(art)ro,15616k@0xa0000(firmware)
   IMAGE/kernel.bin := append-kernel
   IMAGE/rootfs.bin := append-rootfs | pad-rootfs
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size $$$$(IMAGE_SIZE)


### PR DESCRIPTION
Introduced by Chris Blake in 28dd52b079d39fa80dd801e2864bea42251fd50b,
LEDE uses a custom partition to store the MAC address.
That solution required setting the device's primary MAC address manually.

With this patch, an additional partition (config) with the correct location
of the MAC address stored in the SPI is used.

Because the new MAC / config partition is within the old rootfs / firmware
area, you need to reinstall LEDE when upgrading.
To install LEDE within the changed flash layout, use to following commands
on the serial console:

	tftpboot 0x80010000 lede-mr16-squashfs-sysupgrade.bin
	erase 0xbf0a0000 +0xf40000
	cp.b 0x80010000 0xbf0a0000 0xf40000
	setenv bootcmd bootm 0xbfda0000; saveenv; boot

When upgrading from Chris's workaround with the MAC address set manually,
you are also required to copy it to the right location using these commands
_before_ copying the firmware. The config partition is marked read-only:

	erase 0xbf080000 +0x20000
	cp.b 0xbffd0000 0x80010066 0x20000
	cp.b 0x80010000 0xbf080000 0x20000

But because installation is currently only possible with access to the
serial console and that has never been different,
these steps look acceptable to me.

This was tested, and confirmed working only on the MR16.