### PR TITLE
wpan-tools: add the wpan-ping to test the 6LoWPAN network

### DIFF
--- a/package/network/utils/wpan-tools/Makefile
+++ b/package/network/utils/wpan-tools/Makefile
@@ -31,6 +31,7 @@ endef
 define Package/wpan-tools/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/iwpan $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wpan-ping/wpan-ping $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,wpan-tools))


### PR DESCRIPTION
This patch adds the help tool wpan-ping to test the 6LoWPAN
network to help the user debug network problem.

Signed-off-by: Yunhui Fu <yhfudev@gmail.com>
