### PR TITLE
[refresh of PR #686] add powerpc64 support

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -85,6 +85,8 @@ else ifneq (,$(findstring $(ARCH) , armeb ))
   LINUX_KARCH := arm
 else ifneq (,$(findstring $(ARCH) , mipsel mips64 mips64el ))
   LINUX_KARCH := mips
+else ifneq (,$(findstring $(ARCH) , powerpc64 ))
+  LINUX_KARCH := powerpc
 else ifneq (,$(findstring $(ARCH) , sh2 sh3 sh4 ))
   LINUX_KARCH := sh
 else ifneq (,$(findstring $(ARCH) , i386 x86_64 ))

--- a/include/site/powerpc64
+++ b/include/site/powerpc64
@@ -1,0 +1,26 @@
+#!/bin/sh
+. $TOPDIR/include/site/linux
+ac_cv_c_littleendian=${ac_cv_c_littleendian=no}
+ac_cv_c_bigendian=${ac_cv_c_bigendian=yes}
+
+ac_cv_sizeof_char=${ac_cv_sizeof_char=1}
+ac_cv_sizeof_char_p=${ac_cv_sizeof_char_p=8}
+ac_cv_sizeof_double=${ac_cv_sizeof_double=8}
+ac_cv_sizeof_float=${ac_cv_sizeof_float=4}
+ac_cv_sizeof_int=${ac_cv_sizeof_int=4}
+ac_cv_sizeof_long=${ac_cv_sizeof_long=8}
+ac_cv_sizeof_long_double=${ac_cv_sizeof_long_double=16}
+ac_cv_sizeof_long_int=${ac_cv_sizeof_long_int=8}
+ac_cv_sizeof_long_long=${ac_cv_sizeof_long_long=8}
+ac_cv_sizeof_long_long_int=${ac_cv_sizeof_long_long_int=8}
+ac_cv_sizeof_short=${ac_cv_sizeof_short=2}
+ac_cv_sizeof_short_int=${ac_cv_sizeof_short_int=2}
+ac_cv_sizeof_signed_char=${ac_cv_sizeof_signed_char=1}
+ac_cv_sizeof_unsigned_char=${ac_cv_sizeof_unsigned_char=1}
+ac_cv_sizeof_unsigned_int=${ac_cv_sizeof_unsigned_int=4}
+ac_cv_sizeof_unsigned_long=${ac_cv_sizeof_unsigned_long=8}
+ac_cv_sizeof_unsigned_long_int=${ac_cv_sizeof_unsigned_long_int=8}
+ac_cv_sizeof_unsigned_long_long_int=${ac_cv_sizeof_unsigned_long_long_int=8}
+ac_cv_sizeof_unsigned_short=${ac_cv_sizeof_unsigned_short=2}
+ac_cv_sizeof_unsigned_short_int=${ac_cv_sizeof_unsigned_short_int=2}
+ac_cv_sizeof_void_p=${ac_cv_sizeof_void_p=8}

--- a/include/target.mk
+++ b/include/target.mk
@@ -205,6 +205,10 @@ ifeq ($(DUMP),1)
     CPU_CFLAGS_440:=-mcpu=440
     CPU_CFLAGS_464fp:=-mcpu=464fp
   endif
+  ifeq ($(ARCH),powerpc64)
+    CPU_TYPE ?= powerpc64
+    CPU_CFLAGS_powerpc64:=-mcpu=powerpc64
+  endif
   ifeq ($(ARCH),sparc)
     CPU_TYPE = sparc
     CPU_CFLAGS_ultrasparc = -mcpu=ultrasparc

--- a/target/Config.in
+++ b/target/Config.in
@@ -199,6 +199,7 @@ config ARCH
 	default "mips64"    if mips64
 	default "mips64el"  if mips64el
 	default "powerpc"   if powerpc
+	default "powerpc64" if powerpc64
 	default "sh3"       if sh3
 	default "sh3eb"     if sh3eb
 	default "sh4"       if sh4

--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -168,7 +168,6 @@ menuconfig EXTRA_TARGET_ARCH
 	bool
 	prompt "Enable an extra toolchain target architecture" if TOOLCHAINOPTS
 	depends on !sparc
-	default y	if powerpc64
 	default n
 	help
 	  Some builds may require a 'biarch' toolchain. This option
@@ -178,7 +177,6 @@ menuconfig EXTRA_TARGET_ARCH
 
 	config EXTRA_TARGET_ARCH_NAME
 		string
-		default "powerpc64"	if powerpc64
 		prompt "Extra architecture name" if EXTRA_TARGET_ARCH
 		help
 		  Specify the cpu name (eg powerpc64 or x86_64) of the
@@ -186,7 +184,6 @@ menuconfig EXTRA_TARGET_ARCH
 
 	config EXTRA_TARGET_ARCH_OPTS
 		string
-		default "-m64"		if powerpc64
 		prompt "Extra architecture compiler options" if EXTRA_TARGET_ARCH
 		help
 		  If you're specifying an addition target architecture,

--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -238,6 +238,7 @@ comment "C Library"
 choice
 	prompt "C Library implementation" if TOOLCHAINOPTS
 	default LIBC_USE_UCLIBC if arc
+	default LIBC_USE_GLIBC if powerpc64
 	default LIBC_USE_MUSL
 	help
 	  Select the C library implementation.
@@ -250,13 +251,13 @@ choice
 	config LIBC_USE_UCLIBC
 		select USE_UCLIBC
 		bool "Use uClibc"
-		depends on !(aarch64 || aarch64_be)
+		depends on !(aarch64 || aarch64_be || powerpc64)
 		depends on BROKEN || !(arm || armeb || i386 || x86_64 || mips || mipsel || mips64 || mips64el || powerpc)
 
 	config LIBC_USE_MUSL
 		select USE_MUSL
 		bool "Use musl"
-		depends on !(arc)
+		depends on !(arc || powerpc64)
 
 endchoice
 
@@ -274,6 +275,7 @@ config GDB
 	  Enable if you want to build the gdb.
 
 config USE_GLIBC
+	default y if !TOOLCHAINOPTS && !EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN && (powerpc64)
 	bool
 
 config USE_UCLIBC
@@ -281,7 +283,7 @@ config USE_UCLIBC
 	bool
 
 config USE_MUSL
-	default y if !TOOLCHAINOPTS && !EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN && !(arc)
+	default y if !TOOLCHAINOPTS && !EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN && !(arc || powerpc64)
 	bool
 
 config USE_EXTERNAL_LIBC


### PR DESCRIPTION
From the initial PR #686, I've only removed the addition of the ppc64 subtarget to the `mpc85xx` target.
I've tested this successfully on a T4240 variant ; it booted via a initiramfs image, and I could run a simple `udhcpc -i <iface>`.

Since the initial spin of PR #686, musl added BE support, but with elfv2 ABI only:
https://git.musl-libc.org/cgit/musl/commit/?id=5f3b652afe423dd2bd6f266535f79f685909cf60

Getting that in LEDE master will take a bit more effort: backporting and testing some those patches.
I've started that effort, and it will take me a few weeks to finish.
If anyone has a similar one, please shout-out.

Signed-off-by: Florian Larysch <fl@n621.de>
Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>