### PR TITLE
mpc85xx: Add Aerohive HiveAP-330 to Default Images

### DIFF
--- a/target/linux/mpc85xx/image/Makefile
+++ b/target/linux/mpc85xx/image/Makefile
@@ -85,6 +85,7 @@ define Image/Build/Profile/TLWDR4900
 endef
 
 define Image/Build/Profile/Default
+	$(call Image/Build/Profile/hiveap-330,$(1))
 	$(call Image/Build/Profile/TLWDR4900,$(1))
 endef
 


### PR DESCRIPTION
This is needed to fix the snapshot builds as they are not generating the factory image for this device by default.

Signed-off-by: Chris Blake <chrisrblake93@gmail.com>