### PR TITLE
kernel: add  i2c-smbus module package

### DIFF
--- a/package/kernel/linux/modules/i2c.mk
+++ b/package/kernel/linux/modules/i2c.mk
@@ -143,13 +143,12 @@ $(eval $(call KernelPackage,i2c-piix4))
 
 
 I2C_I801_MODULES:= \
-  CONFIG_I2C_I801:drivers/i2c/busses/i2c-i801 \
-  CONFIG_I2C_SMBUS:drivers/i2c/i2c-smbus
+  CONFIG_I2C_I801:drivers/i2c/busses/i2c-i801
 
 define KernelPackage/i2c-i801
   $(call i2c_defaults,$(I2C_I801_MODULES),59)
   TITLE:=Intel I801 and compatible I2C interfaces
-  DEPENDS:=@PCI_SUPPORT @TARGET_x86 kmod-i2c-core
+  DEPENDS:=@PCI_SUPPORT @TARGET_x86 kmod-i2c-core +kmod-i2c-smbus
 endef
 
 define KernelPackage/i2c-i801/description
@@ -166,6 +165,22 @@ define KernelPackage/i2c-i801/description
 endef
 
 $(eval $(call KernelPackage,i2c-i801))
+
+
+I2C_SMBUS_MODULES:= \
+  CONFIG_I2C_SMBUS:drivers/i2c/i2c-smbus
+
+define KernelPackage/i2c-smbus
+  $(call i2c_defaults,$(I2C_SMBUS_MODULES),58)
+  TITLE:=SMBus-specific protocols helper
+  DEPENDS:=kmod-i2c-core
+endef
+
+define KernelPackage/i2c-smbus/description
+ Support for the SMBus extensions to the I2C specification.
+endef
+
+$(eval $(call KernelPackage,i2c-smbus))
 
 
 I2C_MUX_MODULES:= \


### PR DESCRIPTION
kernel: add i2c-smbus module package

Intel motherboards (as well as the Cavium ThunderX SoC) use a superset of the I2C protocol called SMBus.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
