### PR TITLE
toolchain: Test for supported versions of GCC

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -27,32 +27,36 @@ $(eval $(call TestHostCommand,proper-umask, \
 	umask | grep -xE 00[012][012]))
 
 $(eval $(call SetupHostCommand,gcc, \
-	Please install the GNU C Compiler (gcc), \
-	$(CC) --version | grep gcc, \
-	gcc --version | grep gcc, \
-	gcc49 --version | grep gcc, \
+	Please install the GNU C Compiler (gcc) 4.8 or later \
+	$(CC) -dumpversion | grep -E '(4\.[8-9]|5\.[0-9]|6\.[0-9]|7\.[0-9])', \
+	gcc -dumpversion | grep -E '(4\.[8-9]|5\.[0-9]|6\.[0-9]|7\.[0-9])', \
 	gcc48 --version | grep gcc, \
-	gcc47 --version | grep gcc, \
-	gcc46 --version | grep gcc, \
+	gcc49 --version | grep gcc, \
+	gcc5 --version | grep gcc, \
+	gcc6 --version | grep gcc, \
+	gcc7 --version | grep gcc, \
 	gcc --version | grep Apple.LLVM ))
 
 $(eval $(call TestHostCommand,working-gcc, \
-	Please reinstall the GNU C Compiler - it appears to be broken, \
+	\nPlease reinstall the GNU C Compiler (4.8 or later) - \
+	it appears to be broken, \
 	echo 'int main(int argc, char **argv) { return 0; }' | \
 		gcc -x c -o $(TMP_DIR)/a.out -))
 
 $(eval $(call SetupHostCommand,g++, \
-	Please install the GNU C++ Compiler (g++), \
-	$(CXX) --version | grep g++, \
-	g++ --version | grep g++, \
-	g++49 --version | grep g++, \
+	Please install the GNU C++ Compiler (g++) 4.8 or later \
+	$(CXX) -dumpversion | grep -E '(4\.[8-9]|5\.[0-9]|6\.[0-9]|7\.[0-9])', \
+	g++ -dumpversion | grep -E '(4\.[8-9]|5\.[0-9]|6\.[0-9]|7\.[0-9])', \
 	g++48 --version | grep g++, \
-	g++47 --version | grep g++, \
-	g++46 --version | grep g++, \
+	g++49 --version | grep g++, \
+	g++5 --version | grep g++, \
+	g++6 --version | grep g++, \
+	g++7 --version | grep g++, \
 	g++ --version | grep Apple.LLVM ))
 
 $(eval $(call TestHostCommand,working-g++, \
-	Please reinstall the GNU C++ Compiler - it appears to be broken, \
+	\nPlease reinstall the GNU C++ Compiler (4.8 or later) - \
+	it appears to be broken, \
 	echo 'int main(int argc, char **argv) { return 0; }' | \
 		g++ -x c++ -o $(TMP_DIR)/a.out - -lstdc++ && \
 		$(TMP_DIR)/a.out))


### PR DESCRIPTION
Only test for supported versions of GCC
The version bump requirement for GCC is because gdb doesn't build with older
versions.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>