### PR TITLE
mpc85xx: Update HiveAP-330 initrd partition

### DIFF
--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/hiveap-330.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/hiveap-330.dts
@@ -42,7 +42,7 @@
 
 			partition@40000 {
 				reg = <0x40000 0x40000>;
-				label = "initramfs";
+				label = "initrd";
 			};
 
 			partition@80000 {


### PR DESCRIPTION
initramfs is not the proper name for this, as it stores a boot ramdisk and not a filesystem. Update the name to reflect it's usage correctly.

@mkresin