### PR TITLE
ar71xx: fix network setup for UniFi

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -127,6 +127,7 @@ ar71xx_setup_interfaces()
 	tl-wr802n-v2|\
 	tl-wr902ac-v1|\
 	tube2h|\
+	unifi|\
 	unifiac-lite|\
 	wi2a-ac200i|\
 	wndap360|\


### PR DESCRIPTION
Compile tested: n/a
Run tested: Ubiquiti UniFi (LR)

For the UniFi access points, the board.d/02_network has no distinct case,
so execution falls through to the default case, which is eth0=lan, eth1=wan.
Since the UniFi devices just have eth0, we end up with a network configuration
file that references a non-existent interface wan@eth1.

Just add UniFi to the list of devices that only have eth0 for lan.

