### PR TITLE
ar71xx: Add support for TP-LINK Archer C7 v4 RU

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -492,6 +492,7 @@ static struct device_info boards[] = {
 			"SupportList:\n"
 			"{product_name:Archer C7,product_ver:4.0.0,special_id:45550000}\n"
 			"{product_name:Archer C7,product_ver:4.0.0,special_id:55530000}\n"
+			"{product_name:Archer C7,product_ver:4.0.0,special_id:52550000}\n"
 			"{product_name:Archer C7,product_ver:4.0.0,special_id:43410000}\n",
 		.support_trail = '\x00',
 		.soft_ver = "soft_ver:1.0.0\n",


### PR DESCRIPTION
This adds another line to the list of supported versions.
Special ID was extracted from TP-Link firmware for RU version of this
router.

With it firmware file is successfully recognized by router after TFTP upload.
Unfortunately I haven't tested upload from stock Web UI.

@nbd168 can you please take a look at this?