### PR TITLE
ramips: fix Youku-YK1 support

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -461,9 +461,9 @@ zte-q7)
 	set_wifi_led "$board:blue:status"
 	;;
 youku-yk1)
-	ucidef_set_led_default "power" "power" "$board:blue:power" "1"
 	set_wifi_led "$board:blue:air"
 	set_usb_led "$board:blue:usb"
+	ucidef_set_led_switch "wan" "wan" "$board:blue:wan" "switch0" "0x10"
 	;;
 esac
 

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -134,7 +134,8 @@ get_status_led() {
 	wl-330n3g|\
 	wli-tx4-ag300n|\
 	y1|\
-	y1s)
+	y1s|\
+	youku-yk1)
 		status_led="$board:blue:power"
 		;;
 	db-wrt01|\

--- a/target/linux/ramips/dts/YOUKU-YK1.dts
+++ b/target/linux/ramips/dts/YOUKU-YK1.dts
@@ -104,7 +104,6 @@
 
 &ethernet {
 	pinctrl-names = "default";
-	pinctrl-0 = <&ephy_pins>;
 	mtd-mac-address = <&factory 0x4>;
 	mediatek,portmap = "llllw";
 };

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -504,8 +504,9 @@ TARGET_DEVICES += y1s
 
 define Device/youku-yk1
   DTS := YOUKU-YK1
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
   DEVICE_TITLE := YOUKU YK1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += youku-yk1
 


### PR DESCRIPTION
- Remove the ephy-pins from the ethernet device tree node. The ephy-pins are useed to controll the ePHY LEDs and this board doesn't have these. Instead one of the ePHY pins is used in GPIO mode to control the WAN LED.
- Use the switch LED trigger to control the WAN LED. Move the power LED handling to diag.sh to show the boot status via this LED.
- Add the missing kernel packages for USB and microSD card reader to the default package selection.
- Fix the maximum image saize value. The board has a 32MByte flash chip.

Fixes: FS#1055