### PR TITLE
ramips: fix default usb support for nexx wt3020-8M

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -485,6 +485,7 @@ define Device/wt3020-8M
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	poray-header -B WT3020 -F 8M
   DEVICE_TITLE := Nexx WT3020 (8MB)
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += wt3020-8M
 


### PR DESCRIPTION
the nexx wt3020-8M has a usb 2.0 port, add usb 2.0 support packages to its default package list.

I discovered the hard way that this device does not have these packages installed by default https://github.com/openwrt/packages/issues/4984#issuecomment-338434466

Might be a good idea to cherry-pick this for LEDE release too.

Signed-off-by: Alberto Bursi alberto.bursi@outlook.it
