### PR TITLE
 uboot-ar71xx: backport fix for glibc version 2.26+

### DIFF
--- a/package/boot/uboot-ar71xx/Makefile
+++ b/package/boot/uboot-ar71xx/Makefile
@@ -1,8 +1,7 @@
 #
 # Copyright (C) 2010 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License 
-v2.
+# This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
 
@@ -34,9 +33,7 @@ endef
 
 define uboot/nbg460n_550n_550nh
   TITLE:=U-boot for the NBG460N/550N/550NH routers
-  DEFAULT:=y if (TARGET_ar71xx_generic_DEVICE_NBG_460N_550N_550NH || 
-TARGET_DEVICE_ar71xx_generic_DEVICE_NBG_460N_550N_550NH || 
-TARGET_ar71xx_generic_Default)
+  DEFAULT:=y if (TARGET_ar71xx_generic_DEVICE_NBG_460N_550N_550NH || TARGET_DEVICE_ar71xx_generic_DEVICE_NBG_460N_550N_550NH || TARGET_ar71xx_generic_Default)
 endef
 
 UBOOTS:=nbg460n_550n_550nh
@@ -62,8 +59,7 @@ endef
 ifdef BUILD_VARIANT
 $(eval $(call uboot/$(BUILD_VARIANT)))
 UBOOT_CONFIG:=$(if $(CONFIG),$(CONFIG),$(BUILD_VARIANT))
-UBOOT_IMAGE:=$(if 
-$(IMAGE),$(IMAGE),openwrt-$(BOARD)-$(BUILD_VARIANT)-u-boot.bin)
+UBOOT_IMAGE:=$(if $(IMAGE),$(IMAGE),openwrt-$(BOARD)-$(BUILD_VARIANT)-u-boot.bin)
 endif
 
 define Build/Prepare
@@ -90,13 +86,10 @@ endef
 endef
 
 $(foreach u,$(UBOOTS), \
-	$(eval $(call 
-Package/uboot/install/template,$(u),openwrt-$(BOARD)-$(SUBTARGET)-$(u)-u-boot.bin)) 
-\
+	$(eval $(call Package/uboot/install/template,$(u),openwrt-$(BOARD)-$(SUBTARGET)-$(u)-u-boot.bin)) \
 )
 
 $(foreach u,$(UBOOTS), \
 	$(eval $(call BuildUbootPackage,$(u))) \
 	$(eval $(call BuildPackage,uboot-ar71xx-$(u))) \
 )
-

--- a/package/boot/uboot-ar71xx/Makefile
+++ b/package/boot/uboot-ar71xx/Makefile
@@ -1,33 +1,102 @@
 #
 # Copyright (C) 2010 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
+# This is free software, licensed under the GNU General Public License 
+v2.
 # See /LICENSE for more information.
 #
 
 include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
 
+PKG_NAME:=u-boot
 PKG_VERSION:=2010.03
 PKG_RELEASE:=1
 
+PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_HASH:=902d1b2c15787df55186fae4033685fb0c5a5a12755a08383e97c4a3e255925b
+PKG_SOURCE_URL:= \
+	https://mirror2.openwrt.org/sources \
+	ftp://ftp.denx.de/pub/u-boot
+PKG_TARGETS:=bin
 
-include $(INCLUDE_DIR)/u-boot.mk
+PKG_LICENSE:=GPL-2.0 GPL-2.0+
+PKG_LICENSE_FILES:=Licenses/README
+
 include $(INCLUDE_DIR)/package.mk
 
-define U-Boot/Default
-  BUILD_TARGET:=ar71xx
-  BUILD_SUBTARGET:=generic
+define uboot/Default
+  TITLE:=
+  CONFIG:=
+  IMAGE:=
 endef
 
-define U-Boot/nbg460n_550n_550nh
-  TITLE:=NBG460N/550N/550NH routers
-  BUILD_DEVICES:=NBG_460N_550N_550NH
-  HIDDEN:=y
+define uboot/nbg460n_550n_550nh
+  TITLE:=U-boot for the NBG460N/550N/550NH routers
+  DEFAULT:=y if (TARGET_ar71xx_generic_DEVICE_NBG_460N_550N_550NH || 
+TARGET_DEVICE_ar71xx_generic_DEVICE_NBG_460N_550N_550NH || 
+TARGET_ar71xx_generic_Default)
 endef
 
-UBOOT_MAKE_FLAGS :=
+UBOOTS:=nbg460n_550n_550nh
 
-UBOOT_TARGETS:=nbg460n_550n_550nh
+define Package/uboot/template
+define Package/uboot-ar71xx-$(1)
+  SECTION:=boot
+  CATEGORY:=Boot Loaders
+  TITLE:=$(2)
+  DEPENDS:=@TARGET_ar71xx_generic
+  URL:=http://www.denx.de/wiki/U-Boot
+  VARIANT:=$(1)
+endef
+endef
 
-$(eval $(call BuildPackage/U-Boot))
+define BuildUbootPackage
+	$(eval $(uboot/Default))
+	$(eval $(uboot/$(1)))
+	$(call Package/uboot/template,$(1),$(TITLE))
+endef
+
+
+ifdef BUILD_VARIANT
+$(eval $(call uboot/$(BUILD_VARIANT)))
+UBOOT_CONFIG:=$(if $(CONFIG),$(CONFIG),$(BUILD_VARIANT))
+UBOOT_IMAGE:=$(if 
+$(IMAGE),$(IMAGE),openwrt-$(BOARD)-$(BUILD_VARIANT)-u-boot.bin)
+endif
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(CP) ./files/* $(PKG_BUILD_DIR)
+	find $(PKG_BUILD_DIR) -name .svn | $(XARGS) rm -rf
+endef
+
+define Build/Configure
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		$(UBOOT_CONFIG)_config
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		CROSS_COMPILE=$(TARGET_CROSS)
+endef
+
+define Package/uboot/install/template
+define Package/uboot-ar71xx-$(1)/install
+	$(INSTALL_DIR) $$(1)
+	$(CP) $(PKG_BUILD_DIR)/u-boot.bin $(BIN_DIR)/$(2)
+endef
+endef
+
+$(foreach u,$(UBOOTS), \
+	$(eval $(call 
+Package/uboot/install/template,$(u),openwrt-$(BOARD)-$(SUBTARGET)-$(u)-u-boot.bin)) 
+\
+)
+
+$(foreach u,$(UBOOTS), \
+	$(eval $(call BuildUbootPackage,$(u))) \
+	$(eval $(call BuildPackage,uboot-ar71xx-$(u))) \
+)
+


### PR DESCRIPTION
Fixes  FS#1047 - u-boot-nbg460n_550n_550nh bails out on CONFIG_ENV_SIZE error 

Signed-off-by: Bob Brooks <gitbugged@cool.fr.nf>
