### PR TITLE
Make network.*.ip6assign default to 64

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -101,7 +101,7 @@ generate_network() {
 				set network.$1.proto='static'
 				set network.$1.ipaddr='$ipad'
 				set network.$1.netmask='$netm'
-				set network.$1.ip6assign='60'
+				set network.$1.ip6assign='64'
 			EOF
 		;;
 

--- a/target/linux/adm5120/base-files/etc/config/network
+++ b/target/linux/adm5120/base-files/etc/config/network
@@ -19,7 +19,7 @@ config interface lan
 	option proto	static
 	option ipaddr	192.168.1.1
 	option netmask	255.255.255.0
-	option ip6assign 60
+	option ip6assign 64
 
 
 #### WAN configuration

--- a/target/linux/adm8668/base-files/etc/config/network
+++ b/target/linux/adm8668/base-files/etc/config/network
@@ -10,7 +10,7 @@ config interface lan
 	option proto	static
 	option ipaddr	192.168.1.1
 	option netmask	255.255.255.0
-	option ip6assign 60
+	option ip6assign 64
 
 config interface wan
 	option ifname	eth1

--- a/target/linux/rb532/base-files/etc/config/network
+++ b/target/linux/rb532/base-files/etc/config/network
@@ -16,7 +16,7 @@ config interface lan
 	option proto	static
 	option ipaddr	192.168.1.1
 	option netmask	255.255.255.0
-	option ip6assign 60
+	option ip6assign 64
 
 config interface wan6
 	option ifname   eth0

--- a/target/linux/zynq/base-files/etc/config/network
+++ b/target/linux/zynq/base-files/etc/config/network
@@ -11,7 +11,7 @@ config interface lan
 	option proto	static
 	option ipaddr	192.168.1.1
 	option netmask	255.255.255.0
-	option ip6assign 60
+	option ip6assign 64
 
 config globals globals
 	option ula_prefix auto


### PR DESCRIPTION
The IPv6 Adressing Architecture (RFC 4291) mandates that subnet prefixes
must be 64 bit long. More discussion about this requirement is found in RFC
7421.

This updates the default value of network.*.ip6assign correspondingly.

Signed-off-by: Tore Anderson <tore@fud.no>