### PR TITLE
uboot-kirkwood: update to 2017.09

### DIFF
--- a/package/boot/uboot-kirkwood/Makefile
+++ b/package/boot/uboot-kirkwood/Makefile
@@ -7,10 +7,10 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_VERSION:=2017.03
+PKG_VERSION:=2017.09
 PKG_RELEASE:=1
 
-PKG_HASH:=f54baf3f9325bf444c7905f3a5b6f83680edb1e6e1a4d5f8a5ad80abe885113f
+PKG_HASH:=b2d15f2cf5f72e706025cde73d67247c6da8cd35f7e10891eefe7d9095089744
 
 include $(INCLUDE_DIR)/u-boot.mk
 include $(INCLUDE_DIR)/package.mk

--- a/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
@@ -27,23 +27,23 @@ diff --git a/arch/arm/mach-kirkwood/Kconfig b/arch/arm/mach-kirkwood/Kconfig
 index 9205b1e..819bd3b 100644
 --- a/arch/arm/mach-kirkwood/Kconfig
 +++ b/arch/arm/mach-kirkwood/Kconfig
-@@ -53,6 +53,9 @@ config TARGET_GOFLEXHOME
+@@ -56,6 +56,9 @@ config TARGET_GOFLEXHOME
  config TARGET_NAS220
-	bool "BlackArmor NAS220"
-
+ 	bool "BlackArmor NAS220"
+ 
 +config TARGET_NSA310
 +	bool "Zyxel NSA310 Board"
 +
  config TARGET_NSA310S
-	bool "Zyxel NSA310S"
-
-@@ -77,6 +80,7 @@ source "board/raidsonic/ib62x0/Kconfig"
+ 	bool "Zyxel NSA310S"
+ 
+@@ -80,6 +83,7 @@ source "board/raidsonic/ib62x0/Kconfig"
  source "board/Seagate/dockstar/Kconfig"
  source "board/Seagate/goflexhome/Kconfig"
  source "board/Seagate/nas220/Kconfig"
 +source "board/zyxel/nsa310/Kconfig"
  source "board/zyxel/nsa310s/Kconfig"
-
+ 
  endif
 diff --git a/board/zyxel/nsa310/Kconfig b/board/zyxel/nsa310/Kconfig
 new file mode 100644
@@ -528,7 +528,7 @@ new file mode 100644
 index 0000000..d26ef35
 --- /dev/null
 +++ b/configs/nsa310_defconfig
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,34 @@
 +CONFIG_ARM=y
 +CONFIG_KIRKWOOD=y
 +CONFIG_TARGET_NSA310=y
@@ -544,19 +544,31 @@ index 0000000..d26ef35
 +CONFIG_CMD_DHCP=y
 +CONFIG_CMD_MII=y
 +CONFIG_CMD_PING=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_SNTP=y
 +CONFIG_CMD_USB=y
++CONFIG_CMD_DATE=y
 +CONFIG_CMD_EXT2=y
++CONFIG_CMD_EXT4=y
 +CONFIG_CMD_FAT=y
++CONFIG_CMD_JFFS2=y
++CONFIG_CMD_MTDPARTS=y
++CONFIG_CMD_ENV=y
++CONFIG_CMD_NAND=y
 +CONFIG_EFI_PARTITION=y
++CONFIG_ENV_IS_IN_NAND=y
 +CONFIG_CMD_UBI=y
 +CONFIG_USB=y
++CONFIG_USB_EHCI_HCD=y
 +CONFIG_USB_STORAGE=y
++CONFIG_LZMA=y
++CONFIG_LZO=y
 diff --git a/include/configs/nsa310.h b/include/configs/nsa310.h
 new file mode 100644
 index 0000000..86ef825
 --- /dev/null
 +++ b/include/configs/nsa310.h
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,126 @@
 +/* Copyright (C) 2015-2016 bodhi <mibodhi@gmail.com>
 + *
 + * Based on
@@ -594,7 +606,7 @@ index 0000000..86ef825
 + */
 +#define CONFIG_FEROCEON_88FR131		/* CPU Core subversion */
 +#define CONFIG_KW88F6281		/* SOC Name */
-+#define CONFIG_MACH_NSA310		/* Machine type */
++
 +#define CONFIG_SKIP_LOWLEVEL_INIT	/* disable board lowlevel_init */
 +
 +/*
@@ -605,14 +617,8 @@ index 0000000..86ef825
 +/*
 + * Commands configuration
 + */
-+#define CONFIG_CMD_ENV
-+#define CONFIG_CMD_IDE
-+#define CONFIG_CMD_NAND
-+#define CONFIG_CMD_DATE
 +#define CONFIG_SYS_LONGHELP
 +#define CONFIG_PREBOOT
-+#define CONFIG_SYS_HUSH_PARSER
-+#define CONFIG_SYS_PROMPT_HUSH_PS2 "> "
 +
 +/*
 + * mv-common.h should be defined after CMD configs since it used them
@@ -624,10 +630,7 @@ index 0000000..86ef825
 + * Environment variables configurations
 + */
 +#ifdef CONFIG_CMD_NAND
-+#define CONFIG_ENV_IS_IN_NAND           1
 +#define CONFIG_ENV_SECT_SIZE            0x20000         /* 128K */
-+#else
-+#define CONFIG_ENV_IS_NOWHERE           1               /* if env in SDRAM */
 +#endif
 +
 +/* max 4k env size is enough, but in case of nand
@@ -665,7 +668,6 @@ index 0000000..86ef825
 +#define CONFIG_NET_MULTI
 +#define CONFIG_MVGBE_PORTS		{1, 0}	/* enable port 0 only */
 +#define CONFIG_PHY_BASE_ADR		0x1
-+#define CONFIG_PHY_GIGE
 +#define CONFIG_RESET_PHY_R
 +#endif /* CONFIG_CMD_NET */
 +
@@ -680,24 +682,16 @@ index 0000000..86ef825
 +/*
 + * File system
 + */
-+#define CONFIG_CMD_EXT4
-+#define CONFIG_CMD_JFFS2
 +#define CONFIG_JFFS2_NAND
 +#define CONFIG_JFFS2_LZO
-+#define CONFIG_CMD_UBIFS
-+#define CONFIG_RBTREE
 +#define CONFIG_MTD_DEVICE               /* needed for mtdparts commands */
 +#define CONFIG_MTD_PARTITIONS
-+#define CONFIG_CMD_MTDPARTS
-+#define CONFIG_LZO
 +
 +/*
 + *  Date Time
 + */
 +#ifdef CONFIG_CMD_DATE
 +#define CONFIG_RTC_MV
-+#define CONFIG_CMD_SNTP
-+#define CONFIG_CMD_DNS
 +#endif /* CONFIG_CMD_DATE */
 +
 +#endif /* _CONFIG_NSA310_H */

--- a/package/boot/uboot-kirkwood/patches/008-nsa325-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/008-nsa325-uboot-generic.patch
@@ -2,22 +2,22 @@ diff --git a/arch/arm/mach-kirkwood/Kconfig b/arch/arm/mach-kirkwood/Kconfig
 index 819bd3b..6a2d578 100644
 --- a/arch/arm/mach-kirkwood/Kconfig
 +++ b/arch/arm/mach-kirkwood/Kconfig
-@@ -59,6 +59,9 @@ config TARGET_NSA310
+@@ -62,6 +62,9 @@ config TARGET_NSA310
  config TARGET_NSA310S
-	bool "Zyxel NSA310S"
-
+ 	bool "Zyxel NSA310S"
+ 
 +config TARGET_NSA325
 +	bool "Zyxel NSA325 board"
 +
  endchoice
-
+ 
  config SYS_SOC
-@@ -82,5 +85,6 @@ source "board/Seagate/goflexhome/Kconfig"
+@@ -85,5 +88,6 @@ source "board/Seagate/goflexhome/Kconfig
  source "board/Seagate/nas220/Kconfig"
  source "board/zyxel/nsa310/Kconfig"
  source "board/zyxel/nsa310s/Kconfig"
 +source "board/zyxel/nsa325/Kconfig"
-
+ 
  endif
 diff --git a/board/zyxel/nsa325/Kconfig b/board/zyxel/nsa325/Kconfig
 new file mode 100644
@@ -511,7 +511,7 @@ new file mode 100644
 index 0000000..48e09cc
 --- /dev/null
 +++ b/configs/nsa325_defconfig
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,34 @@
 +CONFIG_ARM=y
 +CONFIG_KIRKWOOD=y
 +CONFIG_TARGET_NSA325=y
@@ -527,19 +527,31 @@ index 0000000..48e09cc
 +CONFIG_CMD_DHCP=y
 +CONFIG_CMD_MII=y
 +CONFIG_CMD_PING=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_SNTP=y
 +CONFIG_CMD_USB=y
 +CONFIG_USB=y
++CONFIG_CMD_DATE=y
 +CONFIG_CMD_EXT2=y
++CONFIG_CMD_EXT4=y
 +CONFIG_CMD_FAT=y
++CONFIG_CMD_JFFS2=y
++CONFIG_CMD_MTDPARTS=y
++CONFIG_CMD_ENV=y
++CONFIG_CMD_NAND=y
 +CONFIG_EFI_PARTITION=y
++CONFIG_ENV_IS_IN_NAND=y
 +CONFIG_CMD_UBI=y
++CONFIG_USB_EHCI_HCD=y
 +CONFIG_USB_STORAGE=y
++CONFIG_LZMA=y
++CONFIG_LZO=y
 diff --git a/include/configs/nsa325.h b/include/configs/nsa325.h
 new file mode 100644
 index 0000000..e5a8e2a
 --- /dev/null
 +++ b/include/configs/nsa325.h
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,129 @@
 +/*
 + * (C) Copyright 2016 bodhi <mibodhi@gmail.com>
 + *
@@ -579,7 +591,6 @@ index 0000000..e5a8e2a
 + * High Level Configuration Options (easy to change)
 + */
 +#define CONFIG_FEROCEON_88FR131	1	/* CPU Core subversion */
-+#define CONFIG_KIRKWOOD		1	/* SOC Family Name */
 +#define CONFIG_KW88F6281	1	/* SOC Name */
 +
 +#define CONFIG_SKIP_LOWLEVEL_INIT	/* disable board lowlevel_init */
@@ -592,14 +603,8 @@ index 0000000..e5a8e2a
 +/*
 + * Commands configuration
 + */
-+#define CONFIG_CMD_ENV
-+#define CONFIG_CMD_IDE
-+#define CONFIG_CMD_NAND
-+#define CONFIG_CMD_DATE
 +#define CONFIG_SYS_LONGHELP
 +#define CONFIG_PREBOOT
-+#define CONFIG_SYS_HUSH_PARSER
-+#define CONFIG_SYS_PROMPT_HUSH_PS2 "> "
 +
 +/*
 + * mv-common.h should be defined after CMD configs since it used them
@@ -611,10 +616,7 @@ index 0000000..e5a8e2a
 + *  Environment variables configurations
 + */
 +#ifdef CONFIG_CMD_NAND
-+#define CONFIG_ENV_IS_IN_NAND		1
 +#define CONFIG_ENV_SECT_SIZE		0x20000		/* 128K */
-+#else
-+#define CONFIG_ENV_IS_NOWHERE		1		/* if env in SDRAM */
 +#endif
 +/*
 + * max 4k env size is enough, but in case of nand
@@ -650,7 +652,6 @@ index 0000000..e5a8e2a
 +#ifdef CONFIG_CMD_NET
 +#define CONFIG_MVGBE_PORTS		{1, 0}	/* enable port 0 only */
 +#define CONFIG_PHY_BASE_ADR		0x1
-+#define CONFIG_PHY_GIGE
 +#define CONFIG_NETCONSOLE
 +#endif /* CONFIG_CMD_NET */
 +
@@ -665,24 +666,16 @@ index 0000000..e5a8e2a
 +/*
 + * File system
 + */
-+#define CONFIG_CMD_EXT4
-+#define CONFIG_CMD_JFFS2
 +#define CONFIG_JFFS2_NAND
 +#define CONFIG_JFFS2_LZO
-+#define CONFIG_CMD_UBIFS
-+#define CONFIG_RBTREE
 +#define CONFIG_MTD_DEVICE               /* needed for mtdparts commands */
 +#define CONFIG_MTD_PARTITIONS
-+#define CONFIG_CMD_MTDPARTS
-+#define CONFIG_LZO
 +
 +/*
 + *  Date Time
 + */
 +#ifdef CONFIG_CMD_DATE
 +#define CONFIG_RTC_MV
-+#define CONFIG_CMD_SNTP
-+#define CONFIG_CMD_DNS
 +#endif /* CONFIG_CMD_DATE */
 +
 +#define CONFIG_KIRKWOOD_GPIO /* Enable GPIO Support */

--- a/package/boot/uboot-kirkwood/patches/110-dockstar.patch
+++ b/package/boot/uboot-kirkwood/patches/110-dockstar.patch
@@ -7,8 +7,8 @@
 +#define CONFIG_SYS_MVFS
  
  /*
-  * Commands configuration
-@@ -45,29 +46,29 @@
+  * mv-common.h should be defined after CMD configs since it used them
+@@ -37,29 +38,29 @@
   * it has to be rounded to sector size
   */
  #define CONFIG_ENV_SIZE			0x20000	/* 128k */

--- a/package/boot/uboot-kirkwood/patches/120-iconnect.patch
+++ b/package/boot/uboot-kirkwood/patches/120-iconnect.patch
@@ -1,7 +1,7 @@
 --- a/include/configs/iconnect.h
 +++ b/include/configs/iconnect.h
-@@ -51,30 +51,29 @@
- #define CONFIG_ENV_IS_NOWHERE
+@@ -44,30 +44,29 @@
+ #define CONFIG_ENV_SECT_SIZE	0x20000
  #endif
  #define CONFIG_ENV_SIZE		0x20000
 -#define CONFIG_ENV_OFFSET	0x80000
@@ -42,8 +42,8 @@
   * Ethernet driver configuration
 --- a/configs/iconnect_defconfig
 +++ b/configs/iconnect_defconfig
-@@ -9,6 +9,7 @@ CONFIG_SYS_PROMPT="iconnect => "
- # CONFIG_CMD_FLASH is not set
+@@ -10,6 +10,7 @@ CONFIG_SYS_PROMPT="iconnect => "
+ CONFIG_CMD_NAND=y
  CONFIG_CMD_USB=y
  # CONFIG_CMD_SETEXPR is not set
 +CONFIG_CMD_DHCP=y

--- a/package/boot/uboot-kirkwood/patches/130-ib62x0.patch
+++ b/package/boot/uboot-kirkwood/patches/130-ib62x0.patch
@@ -1,6 +1,6 @@
 --- a/include/configs/ib62x0.h
 +++ b/include/configs/ib62x0.h
-@@ -54,27 +54,22 @@
+@@ -49,27 +49,22 @@
   */
  #define CONFIG_BOOTCOMMAND \
  	"setenv bootargs ${console} ${mtdparts} ${bootargs_root}; "	\

--- a/package/boot/uboot-kirkwood/patches/140-pogoplug_e02.patch
+++ b/package/boot/uboot-kirkwood/patches/140-pogoplug_e02.patch
@@ -1,6 +1,6 @@
 --- a/include/configs/pogo_e02.h
 +++ b/include/configs/pogo_e02.h
-@@ -49,23 +49,30 @@
+@@ -44,23 +44,30 @@
  #endif
  
  #define CONFIG_ENV_SIZE			0x20000	/* 128k */

--- a/package/boot/uboot-kirkwood/patches/150-goflexhome.patch
+++ b/package/boot/uboot-kirkwood/patches/150-goflexhome.patch
@@ -1,16 +1,15 @@
 --- a/include/configs/goflexhome.h
 +++ b/include/configs/goflexhome.h
-@@ -77,20 +77,18 @@
+@@ -70,20 +70,18 @@
   */
  #define CONFIG_BOOTCOMMAND \
  	"setenv bootargs ${console} ${mtdparts} ${bootargs_root}; " \
 -	"ubi part root; " \
 -	"ubifsmount ubi:root; " \
 -	"ubifsload 0x800000 ${kernel}; " \
--	"bootm 0x800000"
 +	"ubi part ubi; " \
 +	"ubi read 0x800000 kernel; " \
-+	"bootm 0x800000"
+ 	"bootm 0x800000"
  
  #define CONFIG_MTDPARTS \
 -	"mtdparts=orion_nand:1m(uboot),6M(uImage),-(root)\0"

--- a/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
+++ b/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
@@ -1,43 +1,43 @@
 --- a/arch/arm/mach-kirkwood/Kconfig
 +++ b/arch/arm/mach-kirkwood/Kconfig
-@@ -87,4 +87,7 @@ source "board/Seagate/nas220/Kconfig"
+@@ -90,4 +90,7 @@ source "board/zyxel/nsa310/Kconfig"
  source "board/zyxel/nsa310s/Kconfig"
  source "board/zyxel/nsa325/Kconfig"
-
+ 
 +config SECOND_STAGE
 +	bool "OpenWrt second stage hack"
 +
  endif
 --- a/include/configs/dockstar.h
 +++ b/include/configs/dockstar.h
-@@ -89,4 +89,6 @@
- #define CONFIG_CMD_MTDPARTS
- #define CONFIG_LZO
-
+@@ -76,4 +76,6 @@
+ #define CONFIG_MTD_DEVICE               /* needed for mtdparts commands */
+ #define CONFIG_MTD_PARTITIONS
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_DOCKSTAR_H */
 --- a/include/configs/ib62x0.h
 +++ b/include/configs/ib62x0.h
-@@ -99,4 +99,6 @@
+@@ -94,4 +94,6 @@
  #define CONFIG_RTC_MV
  #endif /* CONFIG_CMD_DATE */
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_IB62x0_H */
 --- a/include/configs/iconnect.h
 +++ b/include/configs/iconnect.h
-@@ -94,4 +94,6 @@
+@@ -83,4 +83,6 @@
+ #define CONFIG_MTD_DEVICE
  #define CONFIG_MTD_PARTITIONS
- #define CONFIG_CMD_MTDPARTS
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_ICONNECT_H */
 --- /dev/null
 +++ b/include/configs/openwrt-kirkwood-common.h
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,31 @@
 +/*
 + * Copyright (C) 2013 Luka Perkov <luka@openwrt.org>
 + *
@@ -46,9 +46,6 @@
 +
 +#ifndef __OPENWRT_KIRKWOOD_COMMON_H
 +#define __OPENWRT_KIRKWOOD_COMMON_H
-+
-+/* Commands */
-+#define CONFIG_CMD_BOOTZ
 +
 +/* Ethernet */
 +#if defined(CONFIG_CMD_NET)
@@ -63,14 +60,8 @@
 +#define CONFIG_ENV_IS_NOWHERE
 +#endif
 +
-+/* Flattened uImage Tree */
-+#define CONFIG_FIT			1
-+#define CONFIG_FIT_VERBOSE		1
-+
 +/* Various */
 +#define CONFIG_BZIP2
-+#define CONFIG_LZMA
-+#define CONFIG_LZO
 +
 +/* Unnecessary */
 +#undef CONFIG_BOOTM_NETBSD
@@ -80,37 +71,119 @@
 +#endif /* __OPENWRT_KIRKWOOD_COMMON_H */
 --- a/include/configs/pogo_e02.h
 +++ b/include/configs/pogo_e02.h
-@@ -93,4 +93,6 @@
- #define CONFIG_CMD_MTDPARTS
- #define CONFIG_LZO
-
+@@ -83,4 +83,6 @@
+ #define CONFIG_MTD_DEVICE               /* needed for mtdparts commands */
+ #define CONFIG_MTD_PARTITIONS
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_POGO_E02_H */
 --- a/include/configs/sheevaplug.h
 +++ b/include/configs/sheevaplug.h
-@@ -99,4 +99,6 @@
+@@ -96,4 +96,6 @@
  #define CONFIG_SYS_ATA_IDE1_OFFSET	MV_SATA_PORT1_OFFSET
- #endif /* CONFIG_CMD_IDE */
-
+ #endif /* CONFIG_IDE */
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_SHEEVAPLUG_H */
 --- a/include/configs/goflexhome.h
 +++ b/include/configs/goflexhome.h
-@@ -112,4 +112,6 @@
+@@ -105,4 +105,6 @@
  #define CONFIG_RTC_MV
  #endif /* CONFIG_CMD_DATE */
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_GOFLEXHOME_H */
 --- a/include/configs/nsa310.h
 +++ b/include/configs/nsa310.h
-@@ -141,4 +141,6 @@
- #define CONFIG_CMD_DNS
+@@ -123,4 +123,6 @@
+ #define CONFIG_RTC_MV
  #endif /* CONFIG_CMD_DATE */
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_NSA310_H */
+--- a/configs/dockstar_defconfig
++++ b/configs/dockstar_defconfig
+@@ -25,3 +25,8 @@ CONFIG_USB=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_OF_LIBFDT=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_LZMA=y
++CONFIG_LZO=y
+--- a/configs/goflexhome_defconfig
++++ b/configs/goflexhome_defconfig
+@@ -29,3 +29,8 @@ CONFIG_USB=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_OF_LIBFDT=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_LZMA=y
++CONFIG_LZO=y
+--- a/configs/ib62x0_defconfig
++++ b/configs/ib62x0_defconfig
+@@ -27,5 +27,9 @@ CONFIG_SYS_NS16550=y
+ CONFIG_USB=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_STORAGE=y
+-CONFIG_LZMA=y
+ CONFIG_OF_LIBFDT=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_LZMA=y
++CONFIG_LZO=y
+--- a/configs/iconnect_defconfig
++++ b/configs/iconnect_defconfig
+@@ -24,5 +24,9 @@ CONFIG_SYS_NS16550=y
+ CONFIG_USB=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_STORAGE=y
+-CONFIG_LZMA=y
+ CONFIG_OF_LIBFDT=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_LZMA=y
++CONFIG_LZO=y
+--- a/configs/nsa310_defconfig
++++ b/configs/nsa310_defconfig
+@@ -30,5 +30,8 @@ CONFIG_CMD_UBI=y
+ CONFIG_USB=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_STORAGE=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
+ CONFIG_LZMA=y
+ CONFIG_LZO=y
+--- a/configs/pogo_e02_defconfig
++++ b/configs/pogo_e02_defconfig
+@@ -25,3 +25,8 @@ CONFIG_USB=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_OF_LIBFDT=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_LZMA=y
++CONFIG_LZO=y
+--- a/configs/sheevaplug_defconfig
++++ b/configs/sheevaplug_defconfig
+@@ -28,5 +28,8 @@ CONFIG_SYS_NS16550=y
+ CONFIG_USB=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_STORAGE=y
+-CONFIG_LZMA=y
+ CONFIG_OF_LIBFDT=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_LZMA=y
++CONFIG_LZO=y


### PR DESCRIPTION
Compile-tested: kirkwood
Run-tested: kirkwood/dockstar

Upgrade U-Boot for the Kirkwood target to upstream release 2017.09.

A lot of configuration options have been moved from defines in the header files
to Kconfig. Without catching up on this, code would not compile, as dependencies
are not resolved then. Further, we'd have many warnings for re-defines.

My updated logs from the run-test on a Dockstar are given in [1].

@bobafetthotmail Are you willing to test this on your NSA3xx devices, as I touched
rather large parts of your 007 and 008 patches?

[1]:
https://pwassi.privatedns.org/lede/dockstar/#log_uboot
