### PR TITLE
build: Allow to get just a subset of packages from feeds

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -198,7 +198,7 @@ sub update_feed_via($$$$$$) {
 	}
 
 	if($filter) {
-		system("cd '$safepath'; find ./[a-zA-Z0-9]* -name Makefile -not -regex '" . $filter . "' -exec dirname \\{\\} \\; | xargs rm -rf");
+		system("cd '$safepath'; find ./[a-zA-Z0-9]* -name Makefile -not -regex '" . $filter . "' -execdir rm -rf . \\;");
 		system("cd '$safepath'; find ./[a-zA-Z0-9]* -empty -exec rmdir \\{\\} \\; 2> /dev/null");
 	}
 

--- a/scripts/feeds
+++ b/scripts/feeds
@@ -50,7 +50,7 @@ sub parse_config() {
 		chomp;
 		s/#.+$//;
 		next unless /\S/;
-		my @line = split /\s+/, $_, 3;
+		my @line = split /\s+/, $_, 4;
 		my @src;
 		$line++;
 
@@ -63,7 +63,7 @@ sub parse_config() {
 		$name{$line[1]} and die "Duplicate feed name '$line[1]', line: $line\n";
 		$name{$line[1]} = 1;
 
-		push @feeds, [$line[0], $line[1], \@src];
+		push @feeds, [$line[0], $line[1], \@src, $line[3]];
 	}
 	close FEEDS;
 }
@@ -163,12 +163,13 @@ my %update_method = (
 # src-git: pull broken
 # src-cpy: broken if `basename $src` != $name
 
-sub update_feed_via($$$$$) {
+sub update_feed_via($$$$$$) {
 	my $type = shift;
 	my $name = shift;
 	my $src = shift;
 	my $relocate = shift;
 	my $force = shift;
+	my $filter = shift;
 
 	my $m = $update_method{$type};
 	my $localpath = "./feeds/$name";
@@ -194,6 +195,11 @@ sub update_feed_via($$$$$) {
 			$update_cmd = $m->{'update_force'};
 		}
 		system("cd '$safepath'; $update_cmd") == 0 or return 1;
+	}
+
+	if($filter) {
+		system("cd '$safepath'; find ./[a-zA-Z0-9]* -name Makefile -not -regex '" . $filter . "' -exec dirname \\{\\} \\; | xargs rm -rf");
+		system("cd '$safepath'; find ./[a-zA-Z0-9]* -empty -exec rmdir \\{\\} \\; 2> /dev/null");
 	}
 
 	return 0;
@@ -671,13 +677,14 @@ sub uninstall {
 	return 0;
 }
 
-sub update_feed($$$$$)
+sub update_feed($$$$$$)
 {
 	my $type=shift;
 	my $name=shift;
 	my $src=shift;
 	my $perform_update=shift;
 	my $force_update=shift;
+	my $filter=shift;
 	my $force_relocate=update_location( $name, "@$src" );
 	my $rv=0;
 
@@ -692,7 +699,7 @@ sub update_feed($$$$$)
 		my $failed = 1;
 		foreach my $feedsrc (@$src) {
 			warn "Updating feed '$name' from '$feedsrc' ...\n";
-			if (update_feed_via($type, $name, $feedsrc, $force_relocate, $force_update) != 0) {
+			if (update_feed_via($type, $name, $feedsrc, $force_relocate, $force_update, $filter) != 0) {
 				if ($force_update) {
 					$rv=1;
 					$failed=0;
@@ -744,17 +751,17 @@ sub update {
 
 	if ( ($#ARGV == -1) or $opts{a}) {
 		foreach my $feed (@feeds) {
-			my ($type, $name, $src) = @$feed;
-			update_feed($type, $name, $src, $perform_update, $opts{f}) == 0 or $failed=1;
+			my ($type, $name, $src, $filter) = @$feed;
+			update_feed($type, $name, $src, $perform_update, $opts{f}, $filter) == 0 or $failed=1;
 		}
 	} else {
 		while ($feed_name = shift @ARGV) {
 			foreach my $feed (@feeds) {
-				my ($type, $name, $src) = @$feed;
+				my ($type, $name, $src, $filter) = @$feed;
 				if($feed_name ne $name) {
 					next;
 				}
-				update_feed($type, $name, $src, $perform_update, $opts{f}) == 0 or $failed=1;
+				update_feed($type, $name, $src, $perform_update, $opts{f}, $filter) == 0 or $failed=1;
 			}
 		}
 	}


### PR DESCRIPTION
Sometimes it is useful to get just some subset of packages from feed. This
commit changes scripts/feeds in a way that you can specify as the last optional
argument which packages should be used from the feed.

Signed-off-by: Michal Hrusecky <michal.hrusecky@nic.cz>