### PR TITLE
tools: include sysmacros.h explicitly to fix compilation with future glibc

### DIFF
--- a/tools/findutils/patches/100-include_sysmacros.patch
+++ b/tools/findutils/patches/100-include_sysmacros.patch
@@ -1,0 +1,13 @@
+--- a/gl/lib/mountlist.c
++++ b/gl/lib/mountlist.c
+@@ -17,6 +17,10 @@
+ 
+ #include <config.h>
+ 
++#ifdef MAJOR_IN_SYSMACROS
++# include <sys/sysmacros.h>
++#endif
++
+ #include "mountlist.h"
+ 
+ #include <limits.h>

--- a/tools/mtd-utils/patches/120-include_sysmacros.patch
+++ b/tools/mtd-utils/patches/120-include_sysmacros.patch
@@ -1,0 +1,29 @@
+From 9a06f45ec71116d76ee4b268ebe1b33d45b06fc0 Mon Sep 17 00:00:00 2001
+From: Mike Frysinger <vapier@gentoo.org>
+Date: Sat, 16 Apr 2016 22:10:43 -0400
+Subject: [PATCH mtd-utils] include sys/sysmacros.h for major/minor/makedev
+
+These functions have always been defined in sys/sysmacros.h under
+Linux C libraries.  For some, including sys/types.h implicitly
+includes that as well, but glibc wants to deprecate that, and some
+others already have.  Include the header explicitly for the funcs.
+
+Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+---
+ include/common.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/common.h b/include/common.h
+index fb0ca83..8cb3142 100644
+--- a/include/common.h
++++ b/include/common.h
+@@ -28,6 +28,7 @@
+ #include <errno.h>
+ #include <features.h>
+ #include <inttypes.h>
++#include <sys/sysmacros.h>
+ #include "version.h"
+ 
+ #ifndef PROGRAM_NAME
+-- 
+2.7.4

--- a/tools/squashfs/patches/130-include_sysmacros.patch
+++ b/tools/squashfs/patches/130-include_sysmacros.patch
@@ -1,0 +1,20 @@
+--- a/squashfs-tools/mksquashfs.c
++++ b/squashfs-tools/mksquashfs.c
+@@ -30,6 +30,7 @@
+ #include <unistd.h>
+ #include <stdio.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <errno.h>
+--- a/squashfs-tools/unsquashfs.c
++++ b/squashfs-tools/unsquashfs.c
+@@ -25,6 +25,7 @@
+ #define FALSE 0
+ #include <stdio.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <errno.h>

--- a/tools/squashfs4/patches/130-include_sysmacros.patch
+++ b/tools/squashfs4/patches/130-include_sysmacros.patch
@@ -1,0 +1,20 @@
+--- a/squashfs-tools/mksquashfs.c
++++ b/squashfs-tools/mksquashfs.c
+@@ -36,6 +36,7 @@
+ #include <sys/param.h>
+ #endif
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <errno.h>
+--- a/squashfs-tools/unsquashfs.c
++++ b/squashfs-tools/unsquashfs.c
+@@ -30,6 +30,7 @@
+ #include "xattr.h"
+ 
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ 
+ struct cache *fragment_cache, *data_cache;
+ struct queue *to_reader, *to_deflate, *to_writer, *from_writer;


### PR DESCRIPTION
glibc is moving to remove the include of sys/sysmacros.h from sys/types.h, and some distros have done this early. Other libcs may already lack this include. Include sysmacros.h explicitly.

This fixes compilation on Gentoo with glibc-2.25 at least, and should close bugs 1015, 1016, 1017, 1018, and 1061 on Flyspray.