### PR TITLE
ar71xx: base-files: alphabetical reordering

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -137,11 +137,11 @@ bsb)
 	ucidef_set_led_default "sys" "SYS" "$board:red:sys" "1"
 	;;
 bullet-m|\
+loco-m-xw|\
 nanostation-m|\
-rocket-m|\
-rocket-m-xw|\
 nanostation-m-xw|\
-loco-m-xw)
+rocket-m|\
+rocket-m-xw)
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:red:link1" "wlan0" "1" "100" "0" "13"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "ubnt:orange:link2" "wlan0" "26" "100" "-25" "13"
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "ubnt:green:link3" "wlan0" "51" "100" "-50" "13"
@@ -302,8 +302,8 @@ rb-962uigs-5hact2hnt)
 rb-2011il|\
 rb-2011l|\
 rb-2011uas|\
-rb-2011uias|\
 rb-2011uas-2hnd|\
+rb-2011uias|\
 rb-2011uias-2hnd)
 	ucidef_set_led_switch "eth6" "ETH6" "rb:green:eth6" "switch1" "0x20"
 	ucidef_set_led_switch "eth7" "ETH7" "rb:green:eth7" "switch1" "0x10"
@@ -501,13 +501,13 @@ nbg6716)
 	ucidef_set_led_usbdev "usb2" "USB2" "$board:white:usb2" "2-1"
 	;;
 om2p|\
-om2pv2|\
-om2pv4|\
 om2p-hs|\
 om2p-hsv2|\
 om2p-hsv3|\
 om2p-hsv4|\
-om2p-lc)
+om2p-lc|\
+om2pv2|\
+om2pv4)
 	ucidef_set_led_netdev "port1" "port1" "om2p:blue:wan" "eth0"
 	ucidef_set_led_netdev "port2" "port2" "om2p:blue:lan" "eth1"
 	ucidef_set_led_default "wlan-red" "WLAN (red)" "om2p:red:wifi" "0"
@@ -640,8 +640,8 @@ tl-wr941nd-v5)
 	ucidef_set_led_wlan "wlan" "WLAN" "tp-link:green:wlan" "phy0tpt"
 
 	case "$board" in
-	tl-wr842n-v2|\
-	tl-mr3420-v2)
+	tl-mr3420-v2|\
+	tl-wr842n-v2)
 		ucidef_set_led_usbdev "usb" "USB" "tp-link:green:3g" "1-1"
 		;;
 	esac
@@ -686,9 +686,9 @@ tl-wa850re-v2)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:blue:signal5" "wlan0" "80" "100" "-79" "13"
 	;;
 tl-wa701nd-v2|\
-tl-wa860re|\
-tl-wa830re-v2|\
 tl-wa801nd-v2|\
+tl-wa830re-v2|\
+tl-wa860re|\
 tl-wa901nd-v3|\
 tl-wa901nd-v4)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -145,8 +145,8 @@ ar71xx_setup_interfaces()
 	gl-inet|\
 	gl-mifi|\
 	jwap003|\
-	om2pv4|\
 	om2p-hsv4|\
+	om2pv4|\
 	pb42|\
 	pb44|\
 	rb-951ui-2hnd|\

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -23,6 +23,7 @@ get_status_led() {
 	antminer-s1|\
 	antminer-s3|\
 	antminer-r1|\
+	eap120|\
 	minibox-v1|\
 	som9331|\
 	sr3200|\
@@ -73,9 +74,9 @@ get_status_led() {
 	ap90q|\
 	cpe830|\
 	cpe870|\
+	gl-ar300m|\
 	gl-inet|\
-	gl-mifi|\
-	gl-ar300m)
+	gl-mifi)
 		status_led="$board:green:lan"
 		;;
 	ap96)
@@ -93,12 +94,12 @@ get_status_led() {
 		status_led="$board:red:sys"
 		;;
 	bullet-m|\
-	rocket-m|\
-	rocket-m-xw|\
+	loco-m-xw|\
 	nano-m|\
 	nanostation-m|\
 	nanostation-m-xw|\
-	loco-m-xw)
+	rocket-m|\
+	rocket-m-xw)
 		status_led="ubnt:green:link4"
 		;;
 	rocket-m-ti)
@@ -132,9 +133,7 @@ get_status_led() {
 	cpe510)
 		status_led="tp-link:green:link4"
 		;;
-	cr3000)
-		status_led="pcs:amber:power"
-		;;
+	cr3000|\
 	cr5000)
 		status_led="pcs:amber:power"
 		;;
@@ -179,20 +178,18 @@ get_status_led() {
 	dw33d)
 		status_led="$board:blue:status"
 		;;
-	eap120)
-		status_led="$board:green:system"
-		;;
 	eap300v2)
 		status_led="engenius:blue:power"
 		;;
-	ens202ext)
+	ens202ext|\
+	esr900)
 		status_led="engenius:amber:power"
 		;;
 	eap7660d)
 		status_led="$board:green:ds4"
 		;;
-	el-mini|\
-	el-m150)
+	el-m150|\
+	el-mini)
 		status_led="easylink:green:system"
 		;;
 	ew-dorin|\
@@ -205,9 +202,6 @@ get_status_led() {
 	epg5000|\
 	esr1750)
 		status_led="$board:amber:power"
-		;;
-	esr900)
-		status_led="engenius:amber:power"
 		;;
 	hiveap-121|\
 	nbg6716)
@@ -252,9 +246,7 @@ get_status_led() {
 		status_led="mr900:blue:power"
 		;;
 	mynet-n600|\
-	mynet-n750)
-		status_led="wd:blue:power"
-		;;
+	mynet-n750|\
 	mynet-rext)
 		status_led="wd:blue:power"
 		;;
@@ -266,13 +258,13 @@ get_status_led() {
 		status_led="nbg460n:green:power"
 		;;
 	om2p|\
-	om2pv2|\
-	om2pv4|\
 	om2p-hs|\
 	om2p-hsv2|\
 	om2p-hsv3|\
 	om2p-hsv4|\
-	om2p-lc)
+	om2p-lc|\
+	om2pv2|\
+	om2pv4)
 		status_led="om2p:blue:power"
 		;;
 	om5p|\
@@ -367,7 +359,8 @@ get_status_led() {
 	tew-823dru)
 		status_led="trendnet:green:power"
 		;;
-	tl-mr3020)
+	tl-mr3020|\
+	tl-wr2543n)
 		status_led="tp-link:green:wps"
 		;;
 	tl-wa750re)
@@ -390,6 +383,8 @@ get_status_led() {
 	tl-mr3420-v2|\
 	tl-wa701nd-v2|\
 	tl-wa801nd-v2|\
+	tl-wa801nd-v3|\
+	tl-wa830re-v2|\
 	tl-wa901nd|\
 	tl-wa901nd-v2|\
 	tl-wa901nd-v3|\
@@ -403,14 +398,12 @@ get_status_led() {
 	tl-wr740n-v6|\
 	tl-wr741nd|\
 	tl-wr741nd-v4|\
-	tl-wa801nd-v3|\
 	tl-wr840n-v2|\
 	tl-wr840n-v3|\
 	tl-wr841n-v1|\
 	tl-wr841n-v7|\
 	tl-wr841n-v8|\
 	tl-wr841n-v11|\
-	tl-wa830re-v2|\
 	tl-wr842n-v2|\
 	tl-wr842n-v3|\
 	tl-wr941nd|\
@@ -419,11 +412,11 @@ get_status_led() {
 		;;
 	archer-c5|\
 	archer-c7|\
-	tl-wdr4900-v2|\
 	tl-mr10u|\
 	tl-mr12u|\
 	tl-mr13u|\
 	tl-wdr4300|\
+	tl-wdr4900-v2|\
 	tl-wr703n|\
 	tl-wr710n|\
 	tl-wr720n-v3|\
@@ -435,9 +428,6 @@ get_status_led() {
 		;;
 	tl-wr841n-v9)
 		status_led="tp-link:green:qss"
-		;;
-	tl-wr2543n)
-		status_led="tp-link:green:wps"
 		;;
 	tl-wdr6500-v2)
 		status_led="tp-link:white:system"
@@ -496,8 +486,8 @@ get_status_led() {
 	wpj563)
 		status_led="$board:green:sig1"
 		;;
-	wrt400n|\
-	wrt160nl)
+	wrt160nl|\
+	wrt400n)
 		status_led="$board:blue:wps"
 		;;
 	zcn-1523h-2|\

--- a/target/linux/ar71xx/base-files/etc/uci-defaults/03_network-switchX-migration
+++ b/target/linux/ar71xx/base-files/etc/uci-defaults/03_network-switchX-migration
@@ -43,20 +43,18 @@ migrate_switch_name() {
 board=$(board_name)
 
 case "$board" in
-dir-825-c1|\
-wzr-hp-g300nh2|\
-tl-wdr4300|\
-tl-wr1041n-v2|\
-wrt160nl|\
+airrouter|\
 ap121|\
 ap121-mini|\
 ap96|\
-airrouter|\
 dir-600-a1|\
 dir-615-c1|\
 dir-615-e1|\
 dir-615-e4|\
+dir-825-c1|\
 ebr-2310-c1|\
+ew-dorin|\
+ew-dorin-router|\
 ja76pf|\
 rb-750|\
 rb-751|\
@@ -65,17 +63,19 @@ tew-712br|\
 tl-mr3220|\
 tl-mr3220-v2 |\
 tl-mr3420|\
+tl-wdr4300|\
 tl-wr741nd|\
 tl-wr741nd-v4|\
 tl-wr841n-v7|\
+tl-wr1041n-v2|\
 whr-g301n|\
 whr-hp-g300n|\
 whr-hp-gn|\
+wrt160nl|\
 wzr-hp-ag300h|\
+wzr-hp-g300nh2|\
 wzr-hp-g450h|\
-z1|\
-ew-dorin|\
-ew-dorin-router)
+z1)
 	migrate_switch_name "eth0" "switch0"
 	;;
 
@@ -93,8 +93,8 @@ rb-2011uas-2hnd)
 	;;
 
 dir-825-b1|\
-tew-673gru|\
-nbg460n_550n_550nh)
+nbg460n_550n_550nh|\
+tew-673gru)
 	migrate_switch_name "rtl8366s" "switch0"
 	;;
 

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -1049,7 +1049,7 @@ ar71xx_board_detect() {
 	*"TL-MR3420 v2")
 		name="tl-mr3420-v2"
 		;;
-	*TL-MR6400)
+	*"TL-MR6400")
 		name="tl-mr6400"
 		;;
 	*"TL-WA701ND v2")

--- a/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx
+++ b/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx
@@ -36,8 +36,8 @@ set_preinit_iface() {
 	tl-wr720n-v3 |\
 	tl-wr841n-v8 |\
 	tl-wr842n-v2 |\
-	tl-wr941nd-v6 |\
 	tl-wr940n-v4 |\
+	tl-wr941nd-v6 |\
 	wnr2000-v3 |\
 	wnr2200 |\
 	wnr612-v2 |\

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -200,8 +200,8 @@ platform_check_image() {
 	[ "$#" -gt 1 ] && return 1
 
 	case "$board" in
-	airgatewaypro|\
 	airgateway|\
+	airgatewaypro|\
 	airrouter|\
 	ap121f|\
 	ap132|\
@@ -245,8 +245,8 @@ platform_check_image() {
 	epg5000|\
 	esr1750|\
 	esr900|\
-	ew-dorin-router|\
 	ew-dorin|\
+	ew-dorin-router|\
 	gl-ar150|\
 	gl-ar300m|\
 	gl-ar300|\
@@ -260,14 +260,14 @@ platform_check_image() {
 	loco-m-xw|\
 	mzk-w04nu|\
 	mzk-w300nh|\
-	nanostation-m-xw|\
 	nanostation-m|\
+	nanostation-m-xw|\
 	nbg460n_550n_550nh|\
 	pqi-air-pen|\
 	r602n|\
+	rocket-m|\
 	rocket-m-ti|\
 	rocket-m-xw|\
-	rocket-m|\
 	rw2458n|\
 	sc1750|\
 	sc300m|\
@@ -278,10 +278,10 @@ platform_check_image() {
 	tew-732br|\
 	tew-823dru|\
 	tl-wr942n-v1|\
+	unifi|\
 	unifi-outdoor|\
 	unifiac-lite|\
 	unifiac-pro|\
-	unifi|\
 	weio|\
 	whr-g301n|\
 	whr-hp-g300n|\
@@ -297,8 +297,8 @@ platform_check_image() {
 	wrtnode2q|\
 	wzr-450hp2|\
 	wzr-hp-ag300h|\
-	wzr-hp-g300nh2|\
 	wzr-hp-g300nh|\
+	wzr-hp-g300nh2|\
 	wzr-hp-g450h|\
 	xd3200)
 		[ "$magic" != "2705" ] && {
@@ -310,8 +310,8 @@ platform_check_image() {
 		;;
 	alfa-ap96|\
 	alfa-nx|\
-	ap121-mini|\
 	ap121|\
+	ap121-mini|\
 	ap135-020|\
 	ap136-010|\
 	ap136-020|\
@@ -350,14 +350,14 @@ platform_check_image() {
 	all0305|\
 	eap300v2|\
 	eap7660d|\
-	ja76pf2|\
 	ja76pf|\
+	ja76pf2|\
 	jwap003|\
 	ls-sr71|\
 	pb42|\
 	pb44|\
-	routerstation-pro|\
 	routerstation|\
+	routerstation-pro|\
 	wp543|\
 	wpe72)
 		[ "$magic" != "4349" ] && {
@@ -400,12 +400,12 @@ platform_check_image() {
 	tl-mr12u|\
 	tl-mr13u|\
 	tl-mr3020|\
-	tl-mr3040-v2|\
 	tl-mr3040|\
-	tl-mr3220-v2|\
+	tl-mr3040-v2|\
 	tl-mr3220|\
-	tl-mr3420-v2|\
+	tl-mr3220-v2|\
 	tl-mr3420|\
+	tl-mr3420-v2|\
 	tl-mr6400|\
 	tl-wa701nd-v2|\
 	tl-wa7210n-v2|\
@@ -418,10 +418,10 @@ platform_check_image() {
 	tl-wa850re-v2|\
 	tl-wa855re-v1|\
 	tl-wa860re|\
+	tl-wa901nd|\
 	tl-wa901nd-v2|\
 	tl-wa901nd-v3|\
 	tl-wa901nd-v4|\
-	tl-wa901nd|\
 	tl-wdr3320-v2|\
 	tl-wdr3500|\
 	tl-wdr4300|\
@@ -429,33 +429,33 @@ platform_check_image() {
 	tl-wdr6500-v2|\
 	tl-wpa8630|\
 	tl-wr1041n-v2|\
+	tl-wr1043nd|\
 	tl-wr1043nd-v2|\
 	tl-wr1043nd-v4|\
-	tl-wr1043nd|\
 	tl-wr2543n|\
 	tl-wr703n|\
 	tl-wr710n|\
 	tl-wr720n-v3|\
 	tl-wr740n-v6|\
-	tl-wr741nd-v4|\
 	tl-wr741nd|\
+	tl-wr741nd-v4|\
 	tl-wr802n-v1|\
 	tl-wr802n-v2|\
 	tl-wr810n|\
 	tl-wr840n-v2|\
 	tl-wr840n-v3|\
-	tl-wr841n-v11|\
 	tl-wr841n-v1|\
 	tl-wr841n-v7|\
 	tl-wr841n-v8|\
 	tl-wr841n-v9|\
+	tl-wr841n-v11|\
 	tl-wr842n-v2|\
 	tl-wr842n-v3|\
 	tl-wr902ac-v1|\
-	tl-wr941nd-v5|\
-	tl-wr941nd-v6|\
 	tl-wr940n-v4|\
-	tl-wr941nd)
+	tl-wr941nd|\
+	tl-wr941nd-v5|\
+	tl-wr941nd-v6)
 		local magic_ver="0100"
 
 		case "$board" in
@@ -522,8 +522,8 @@ platform_check_image() {
 	rb-2011l|\
 	rb-2011il|\
 	rb-2011uas|\
-	rb-2011uias|\
 	rb-2011uas-2hnd|\
+	rb-2011uias|\
 	rb-2011uias-2hnd|\
 	rb-sxt2n|\
 	rb-sxt5n)
@@ -551,24 +551,24 @@ platform_check_image() {
 		;;
 	a40|\
 	a60|\
-	mr1750v2|\
 	mr1750|\
-	mr600v2|\
+	mr1750v2|\
 	mr600|\
-	mr900v2|\
+	mr600v2|\
 	mr900|\
+	mr900v2|\
+	om2p|\
+	om2p-hs|\
 	om2p-hsv2|\
 	om2p-hsv3|\
 	om2p-hsv4|\
-	om2p-hs|\
 	om2p-lc|\
 	om2pv2|\
 	om2pv4|\
-	om2p|\
-	om5p-acv2|\
+	om5p|\
 	om5p-ac|\
-	om5p-an|\
-	om5p)
+	om5p-acv2|\
+	om5p-an)
 		platform_check_image_openmesh "$magic_long" "$1" && return 0
 		return 1
 		;;
@@ -696,8 +696,8 @@ platform_pre_upgrade() {
 	rb-751|\
 	rb-751g|\
 	rb-911g-2hpnd|\
-	rb-911g-5hpnd|\
 	rb-911g-5hpacd|\
+	rb-911g-5hpnd|\
 	rb-912uag-2hpnd|\
 	rb-912uag-5hpnd|\
 	rb-951g-2hnd|\
@@ -705,8 +705,8 @@ platform_pre_upgrade() {
 	rb-2011il|\
 	rb-2011l|\
 	rb-2011uas|\
-	rb-2011uias|\
 	rb-2011uas-2hnd|\
+	rb-2011uias|\
 	rb-2011uias-2hnd|\
 	rb-sxt2n|\
 	rb-sxt5n|\
@@ -775,14 +775,14 @@ platform_do_upgrade() {
 		;;
 	all0305|\
 	eap7660d|\
-	ja76pf2|\
 	ja76pf|\
+	ja76pf2|\
 	jwap003|\
 	ls-sr71|\
 	pb42|\
 	pb44|\
-	routerstation-pro|\
-	routerstation)
+	routerstation|\
+	routerstation-pro)
 		platform_do_upgrade_combined "$ARGV"
 		;;
 	all0315n)
@@ -799,24 +799,24 @@ platform_do_upgrade() {
 		;;
 	a40|\
 	a60|\
-	mr1750v2|\
 	mr1750|\
-	mr600v2|\
+	mr1750v2|\
 	mr600|\
-	mr900v2|\
+	mr600v2|\
 	mr900|\
+	mr900v2|\
+	om2p|\
+	om2p-hs|\
 	om2p-hsv2|\
 	om2p-hsv3|\
 	om2p-hsv4|\
-	om2p-hs|\
 	om2p-lc|\
 	om2pv2|\
 	om2pv4|\
-	om2p|\
-	om5p-acv2|\
+	om5p|\
 	om5p-ac|\
-	om5p-an|\
-	om5p)
+	om5p-acv2|\
+	om5p-an)
 		platform_do_upgrade_openmesh "$ARGV"
 		;;
 	uap-pro|\


### PR DESCRIPTION
Re-order the cases of base-files/* alphabetically.
Actually, not the cases themselves are ordered, but the multiple options
in each single case.