### PR TITLE
ar71xx: fix LED names for GL-AR150

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -387,7 +387,11 @@ gl-mifi)
 	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth1"
 	ucidef_set_led_netdev "3gnet" "3GNET" "$board:green:net" "3g-wan"
 	;;
-gl-ar150|\
+gl-ar150)
+	ucidef_set_led_wlan "wlan" "WLAN" "$board:orange:wlan" "phy0tpt"
+	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
+	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth1"
+	;;
 gl-ar300)
 	ucidef_set_led_wlan "wlan" "WLAN" "$board:wlan" "phy0tpt"
 	;;

--- a/target/linux/ar71xx/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ar71xx/base-files/etc/uci-defaults/04_led_migration
@@ -54,6 +54,10 @@ dr344)
 	migrate_leds ":red:=:green:" ":yellow:=:green:"
 	;;
 
+gl-ar150)
+	migrate_leds "gl-ar150:wlan=gl-ar150:orange:wlan" "gl-ar150:lan=gl-ar150:green:lan" "gl-ar150:wan=gl-ar150:green:wan"
+	;;
+
 wndap360)
 	migrate_leds "wndap360:=netgear:"
 	;;

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar150.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar150.c
@@ -25,7 +25,7 @@
 
 #define GL_AR150_GPIO_LED_WLAN		   0
 #define GL_AR150_GPIO_LED_LAN		   13
-#define GL_AR150_GPIO_LED_WAN		   15 
+#define GL_AR150_GPIO_LED_WAN		   15
 
 #define GL_AR150_GPIO_BIN_USB         6
 #define GL_AR150_GPIO_BTN_MANUAL      7
@@ -42,17 +42,17 @@
 
 static struct gpio_led gl_ar150_leds_gpio[] __initdata = {
 	{
-		.name = "gl-ar150:wlan",
+		.name = "gl-ar150:orange:wlan",
 		.gpio = GL_AR150_GPIO_LED_WLAN,
 		.active_low = 0,
 	},
 	{
-		.name = "gl-ar150:lan",
+		.name = "gl-ar150:green:lan",
 		.gpio = GL_AR150_GPIO_LED_LAN,
 		.active_low = 0,
 	},
 	{
-		.name = "gl-ar150:wan",
+		.name = "gl-ar150:green:wan",
 		.gpio = GL_AR150_GPIO_LED_WAN,
 		.active_low = 0,
  		.default_state = 1,


### PR DESCRIPTION
Compile-tested: n/a
Run-tested: ar71xx/gl-ar150

Add the respective colour to the LED's names for the GL-AR150 to be conform
to the kernel. Also add netdev triggers for the LAN and WAN LED.

NOTE: The other GL-Inet boards still have LED names without colour, but as I just have
the AR150 lying around, I can only test and add colour on this device.
