### PR TITLE
 libiconv-full: fix compile-time linking error GCC7

### DIFF
--- a/package/libs/libiconv-full/Makefile
+++ b/package/libs/libiconv-full/Makefile
@@ -51,7 +51,7 @@ define Package/iconv
   TITLE+= utility
 endef
 
-TARGET_CFLAGS += $(FPIC) -DUSE_DOS
+TARGET_CFLAGS += $(FPIC) -DUSE_DOS -std=gnu89
 
 CONFIGURE_ARGS += \
 	--enable-shared \


### PR DESCRIPTION
[LEDE Flyspray Task 1091](https://bugs.lede-project.org/index.php?do=details&task_id=1091)
Fix libiconv-full 'undefined reference' compile linker error using GCC7 Musl
Tested with targets x86 (i386 and x86_64)
Addition of CFLAGS "std=gnu89" fixes the linker issues, credit to harrylwc
Issue found with 'minidlna' package, which depends on 'libiconv-full'
Error in compile log:
../lib/.libs/libiconv.so: undefined reference to `aliases_lookup'
../lib/.libs/libiconv.so: undefined reference to `aliases2_lookup'
collect2: error: ld returned 1 exit status
Makefile:64: recipe for target 'iconv_no_i18n' failed

Signed-off-by: Jake Staehle <jacob@staehle.us>