### PR TITLE
ipq806x: fix Zyxel NBG6817 WiFi button

### DIFF
--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8065-nbg6817.dts
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8065-nbg6817.dts
@@ -41,7 +41,7 @@
 		pinmux@800000 {
 			button_pins: button_pins {
 				mux {
-					pins = "gpio6", "gpio54", "gpio65";
+					pins = "gpio53", "gpio54", "gpio65";
 					function = "gpio";
 					drive-strength = <2>;
 					bias-pull-up;
@@ -334,8 +334,9 @@
 
 		wifi {
 			label = "wifi";
-			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
+			linux,input-type = <EV_SW>;
 		};
 
 		reset {


### PR DESCRIPTION
Zyxel NBG6817 features a WiFi button, which becomes functional by setting
correct GPIO. It is a switch-type button, so it emits KEY_RFKILL on each ON
and OFF state. This is achieved by setting input-type to EV_SW.

Signed-off-by: Tolga Cakir <tolga@cevel.net>