### PR TITLE
ar71xx: Complete support for RB wAP 2nD

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -325,6 +325,10 @@ rb-mapl-2nd)
 	ucidef_set_led_netdev "lan" "LAN" "rb:green:eth" "eth0"
 	ucidef_set_led_wlan "wlan" "WLAN" "rb:green:wlan" "phy0tpt"
 	;;
+rb-wap-2nd)
+	ucidef_set_led_timer "user" "USER" "rb:green:user" "1000" "1000"
+	ucidef_set_led_wlan "wlan" "WLAN" "rb:green:wlan" "phy0tpt"
+	;;
 dap-2695-a1)
 	ucidef_set_led_default "power" "POWER" "d-link:green:power" "1"
 	ucidef_set_led_default "diag" "DIAG" "d-link:red:power" "0"

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -100,6 +100,7 @@ ar71xx_setup_interfaces()
 	rb-mapl-2nd|\
 	rb-sxt2n|\
 	rb-sxt5n|\
+	rb-wap-2nd|\
 	re450|\
 	rocket-m-xw|\
 	sc300m |\

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -971,6 +971,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD SXT Lite5")
 		name="rb-sxt5n"
 		;;
+	*"RouterBOARD wAP 2nD r2")
+		name="rb-wap-2nd"
+		;;
 	*"RouterStation")
 		name="routerstation"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -664,7 +664,8 @@ platform_check_image() {
 	rb-952ui-5ac2nd|\
 	rb-962uigs-5hact2hnt|\
 	rb-lhg-5nd|\
-	rb-mapl-2nd)
+	rb-mapl-2nd|\
+	rb-wap-2nd)
 		return 0
 		;;
 	esac
@@ -723,7 +724,8 @@ platform_pre_upgrade() {
 	rb-952ui-5ac2nd|\
 	rb-962uigs-5hact2hnt|\
 	rb-lhg-5nd|\
-	rb-mapl-2nd)
+	rb-mapl-2nd|\
+	rb-wap-2nd)
 		# erase firmware if booted from initramfs
 		[ -z "$(rootfs_type)" ] && mtd erase firmware
 		;;

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -1023,7 +1023,7 @@ config ATH79_MACH_RBSPI
 	  MikroTik RouterBOARD LHG 5
 	  MikroTik RouterBOARD cAP (EXPERIMENTAL)
 	  MikroTik RouterBOARD mAP (EXPERIMENTAL)
-	  MikroTik RouterBOARD wAP (EXPERIMENTAL)
+	  MikroTik RouterBOARD wAP
 
 config ATH79_MACH_RBSXTLITE
 	bool "MikroTik RouterBOARD SXT Lite"

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -10,9 +10,9 @@
  *  - MikroTik RouterBOARD 750P-PBr2
  *  - MikroTik RouterBOARD 750 r2
  *  - MikroTik RouterBOARD LHG 5nD
+ *  - MikroTik RouterBOARD wAP2nD
  *
  *  Preliminary support for the following hardware
- *  - MikroTik RouterBOARD wAP2nD
  *  - MikroTik RouterBOARD cAP2nD
  *  - MikroTik RouterBOARD mAP2nD
  *  Furthermore, the cAP lite (cAPL2nD) appears to feature the exact same
@@ -872,7 +872,7 @@ static void __init rblhg_setup(void)
 }
 
 /*
- * Init the wAP hardware (EXPERIMENTAL).
+ * Init the wAP hardware.
  * The wAP 2nD has a single ethernet port.
  */
 static void __init rbwap_setup(void)
@@ -888,6 +888,11 @@ static void __init rbwap_setup(void)
 	rbspi_network_setup(flags, 0, 1, 0);
 
 	ath79_register_leds_gpio(-1, ARRAY_SIZE(rbwap_leds), rbwap_leds);
+	
+	/* wAP has a single reset button as GPIO 16 */
+	ath79_register_gpio_keys_polled(-1, RBSPI_KEYS_POLL_INTERVAL,
+					ARRAY_SIZE(rbspi_gpio_keys_reset16),
+					rbspi_gpio_keys_reset16);
 }
 
 /*

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -30,7 +30,7 @@ define Device/rb-nor-flash-16M
   LOADER_TYPE := elf
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin | lzma | loader-kernel
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-mapl-2nd
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-mapl-2nd rb-wap-2nd
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef

--- a/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,27 @@ void __init prom_init(void)
+@@ -136,6 +136,28 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -20,6 +20,7 @@
 +	    strstr(arcs_cmdline, "board=962") ||
 +	    strstr(arcs_cmdline, "board=lhg") ||
 +	    strstr(arcs_cmdline, "board=map-hb") ||
++	    strstr(arcs_cmdline, "board=wap-hb") ||
 +	    strstr(arcs_cmdline, "board=2011L") ||
 +	    strstr(arcs_cmdline, "board=2011r") ||
 +	    strstr(arcs_cmdline, "board=711Gr100") ||

--- a/target/linux/ar71xx/patches-4.9/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.9/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,27 @@ void __init prom_init(void)
+@@ -136,6 +136,28 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -20,6 +20,7 @@
 +	    strstr(arcs_cmdline, "board=962") ||
 +	    strstr(arcs_cmdline, "board=lhg") ||
 +	    strstr(arcs_cmdline, "board=map-hb") ||
++	    strstr(arcs_cmdline, "board=wap-hb") ||
 +	    strstr(arcs_cmdline, "board=2011L") ||
 +	    strstr(arcs_cmdline, "board=2011r") ||
 +	    strstr(arcs_cmdline, "board=711Gr100") ||


### PR DESCRIPTION
This patch adds support for the MikroTik RouterBOARD wAP
https://mikrotik.com/product/RBwAP2nD

Specifications:
- SoC: Qualcomm QCA9533 (650MHz)
- RAM: 64MB
- Storage: 16MB NOR SPI flash
- Wireless: builtin QCA9533, 2x2:2
- Ethernet: 1x100M (802.3af/at POE IN)

This patch adds missing code to fully support wAP.
Machfile already contained configuration for wAP 2nD but device-specific configuration like LEDs etc was missing.
Installation

1. login to the Mikrotik WebUI to backup your license keys
2. set up a DHCP/BOOTP Server with:
     * DHCP-Option 66 (TFTP server name) pointing to a local TFTP
       Server within the same subnet of the DHCP range
     * DHCP-Option 67 (Bootfile-Name) matching the initramfs file name
       of the to be booted image
3. connect the port labeled internet to your local network
4. keep the reset button pushed down and power on the board

The board should load and start the initramfs image from the TFTP
Server. Login as root/without a password to the started LEDE via ssh
listing on IPv4 address 192.168.1.1. Use sysupgrade to install LEDE.

Revert to RouterOS

Use the "rbcfg" package on in LEDE:
  * rbcfg set boot_protocol bootp
  * rbcfg set boot_device ethnand
  * rbcfg apply

Open Netinstall and reboot routerboard. Now, netinstall sees routerboard
and you can install RouterOS. If NetInstall gets stuck on Sending offer
just wait for it to timeout and then close and open Netinstall again.

Click on install again.

In order for RouterOS to function properly, you need to restore license
for the device. You can do that by including license in NetInstall

Signed-off-by: Robert Marko <robimarko@gmail.com>