### PR TITLE
u-boot-zynq: Fix by hardcoding version to openssl 1.0

### DIFF
--- a/package/boot/uboot-zynq/patches/0001-use-libssl1.0.patch
+++ b/package/boot/uboot-zynq/patches/0001-use-libssl1.0.patch
@@ -1,0 +1,11 @@
+--- a/tools/Makefile	2016-03-14 14:20:21.000000000 +0000
++++ b/tools/Makefile	2016-03-14 14:20:21.000000000 +0000
+@@ -128,7 +128,7 @@
+ # MXSImage needs LibSSL
+ ifneq ($(CONFIG_MX23)$(CONFIG_MX28)$(CONFIG_FIT_SIGNATURE),)
+ HOSTLOADLIBES_mkimage += \
+-	$(shell pkg-config --libs libssl libcrypto 2> /dev/null || echo "-lssl -lcrypto")
++	-l:libssl.so.1.0.0 -l:libcrypto.so.1.0.0
+ 
+ # OS X deprecate openssl in favour of CommonCrypto, supress deprecation
+ # warnings on those systems


### PR DESCRIPTION
Currently u-boot-zynq fails to compile on newer linux machines due to
openssl 1.0 being legacy. Linking process fails to resolve symbols due
to API incompatibility.

Code in release is not ported to latest libssl because it's just a tool
to create the binaries, not used inside.
