### PR TITLE
bcm53xx: Add initial support for PHICOMM K3

### DIFF
--- a/package/firmware/phicommk3-firmware/Config.in
+++ b/package/firmware/phicommk3-firmware/Config.in
@@ -1,7 +1,7 @@
 choice
     prompt "Select the wireless firmware"
     default K3_WF_EA9500
-    depends on PACKAGE_phicomm-k3-firmware
+    depends on PACKAGE_phicommk3-firmware
 
     config K3_WF_AC88U
         bool "AC88U"

--- a/package/firmware/phicommk3-firmware/Config.in
+++ b/package/firmware/phicommk3-firmware/Config.in
@@ -1,0 +1,15 @@
+choice
+    prompt "Select the wireless firmware"
+    default K3_WF_EA9500
+    depends on PACKAGE_phicomm-k3-firmware
+
+    config K3_WF_AC88U
+        bool "AC88U"
+
+    config K3_WF_EA9500
+        bool "EA9500"
+
+    config K3_WF_K3
+        bool "K3"
+
+endchoice

--- a/package/firmware/phicommk3-firmware/Makefile
+++ b/package/firmware/phicommk3-firmware/Makefile
@@ -1,0 +1,41 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=phicommk3-firmware
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/Hill-98/phicommk3-firmware.git
+PKG_SOURCE_VERSION:=15da4c6e4776e51fdd54e67a488fa7c37225fa94
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_SOURCE_SUBDIR).tar.gz
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)
+	SECTION:=firmware
+	CATEGORY:=Firmware
+	TITLE:=PHICOMM K3 available wireless firmware
+	DEPENDS:=@TARGET_bcm53xx_DEVICE_phicomm-k3
+endef
+
+define Package/$(PKG_NAME)/config
+	source "$(SOURCE)/Config.in"
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/lib/firmware/brcm
+	$(if $(CONFIG_K3_WF_AC88U),$(INSTALL_DATA) $(PKG_BUILD_DIR)/brcmfmac4366c-pcie.bin.ac88u $(1)/lib/firmware/brcm/brcmfmac4366c-pcie.bin)
+	$(if $(CONFIG_K3_WF_EA9500),$(INSTALL_DATA) $(PKG_BUILD_DIR)/brcmfmac4366c-pcie.bin.ea9500 $(1)/lib/firmware/brcm/brcmfmac4366c-pcie.bin)
+	$(if $(CONFIG_K3_WF_K3),$(INSTALL_DATA) $(PKG_BUILD_DIR)/brcmfmac4366c-pcie.bin.k3 $(1)/lib/firmware/brcm/brcmfmac4366c-pcie.bin)
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/package/utils/mdadm/Makefile
+++ b/package/utils/mdadm/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mdadm
 PKG_VERSION:=4.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=@KERNEL/linux/utils/raid/mdadm
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -41,16 +41,20 @@ define Package/mdadm/conffiles
 /etc/config/mdadm
 endef
 
-TARGET_CFLAGS += -ffunction-sections -fdata-sections -DNO_COROSYNC -DNO_DLM -DUSE_PTHREADS -DCONFFILE="/var/etc/mdadm.conf" -DMAP_DIR="/var/run/mdadm" -DMDMON_DIR="/var/run/mdadm" -DFAILED_SLOTS_DIR="/var/run/mdadm/failed-slots"
+TARGET_CFLAGS += \
+	-ffunction-sections -fdata-sections \
+	-DHAVE_STDINT_H -DNO_COROSYNC -DNO_DLM -DUSE_PTHREADS \
+	-DCONFFILE='\"/var/etc/mdadm.conf\"' \
+	-DMAP_DIR='\"/var/run/mdadm\"' \
+	-DMDMON_DIR='\"/var/run/mdadm\"' \
+	-DFAILED_SLOTS_DIR='\"/var/run/mdadm/failed-slots\"'
+
 TARGET_LDFLAGS += -Wl,--gc-sections
 
+MAKE_VARS += CHECK_RUN_DIR=0
+
 define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		CC="$(TARGET_CC)" \
-		CFLAGS="$(TARGET_CFLAGS) -DHAVE_STDINT_H" \
-		LDFLAGS="$(TARGET_LDFLAGS)" \
-		CHECK_RUN_DIR=0 \
-		mdadm
+	$(call Build/Compile/Default,mdadm)
 endef
 
 define Package/mdadm/install

--- a/target/linux/bcm53xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm53xx/base-files/etc/board.d/02_network
@@ -24,6 +24,12 @@ buffalo,wzr-1750dhp)
 	board_config_flush
 	exit 0
 	;;
+phicomm,k3)
+	ucidef_add_switch "switch0" \
+		"0:lan:2" "1:lan:1" "2:lan:3" "3:wan:4" "5t@eth0"
+	board_config_flush
+	exit 0
+	;;
 esac
 
 wan_macaddr="$(nvram get wan_hwaddr)"

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -340,7 +340,7 @@ TARGET_DEVICES += tplink-archer-c9-v1
 
 define Device/phicomm-k3
   DEVICE_TITLE := PHICOMM K3
-  DEVICE_PACKAGES := $(BRCMFMAC_4366C0) $(USB3_PACKAGES)
+  DEVICE_PACKAGES := $(BRCMFMAC_4366C0) $(USB3_PACKAGES) phicommk3-firmware
   IMAGES := trx
 endef
 TARGET_DEVICES += phicomm-k3

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -338,4 +338,11 @@ define Device/tplink-archer-c9-v1
 endef
 TARGET_DEVICES += tplink-archer-c9-v1
 
+define Device/phicomm-k3
+  DEVICE_TITLE := PHICOMM K3
+  DEVICE_PACKAGES := $(BRCMFMAC_4366C0) $(USB3_PACKAGES)
+  IMAGES := trx
+endef
+TARGET_DEVICES += phicomm-k3
+
 $(eval $(call BuildImage))

--- a/target/linux/bcm53xx/patches-4.9/036-0001-ARM-dts-BCM5301X-Add-basic-DT-for-PHICOMM-K3.patch
+++ b/target/linux/bcm53xx/patches-4.9/036-0001-ARM-dts-BCM5301X-Add-basic-DT-for-PHICOMM-K3.patch
@@ -1,0 +1,71 @@
+From: Hill <lufanzhong@gmail.com>
+Subject: [PATCH] ARM: dts: BCM5301X: Add basic DT for PHICOMM K3
+
+This router has BCM4709C0, 128MB NAND flash (MX30LF1G18AC-TI),
+and 512MB memory, with 3 x LAN and 1 x WAN. WL chips are
+BCM4366C0 x 2. The router has a small LCD and 3 capactive keys
+driven by a PIC microcontroller, which is in turn wired to
+UART1 of main board.
+
+Everything except the LCD and wireless works.
+
+The founder of the patch is: Tian Hao <haotia@gmail.com>
+
+Flash:
+
+Enter CFE
+CFE Brush Excess LEDE, you can get it from here: https://drive.google.com/file/d/0ByNlqhxfFBArb2owR05VUlVpN0E
+Well, now you can brush into the trx file for the LEDE.
+
+Signed-Off-By: Hill <lufanzhong@gmail.com>
+
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -100,6 +100,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm47094-luxul-xbr-4500.dtb \
+ 	bcm47094-luxul-xwr-3100.dtb \
+ 	bcm47094-netgear-r8500.dtb \
++	bcm47094-phicomm-k3.dtb \
+ 	bcm94708.dtb \
+ 	bcm94709.dtb \
+ 	bcm953012er.dtb \
+--- /dev/null
++++ b/arch/arm/boot/dts/bcm47094-phicomm-k3.dts
+@@ -0,0 +1,37 @@
++/*
++* Copyright (C) 2017 Hamster Tian <haotia@gmail.com>
++*/
++
++/dts-v1/;
++
++#include "bcm47094.dtsi"
++#include "bcm5301x-nand-cs0-bch4.dtsi"
++
++/ {
++	compatible = "phicomm,k3", "brcm,bcm47094", "brcm,bcm4708";
++	model = "PHICOMM K3";
++	
++	chosen {
++		bootargs = "console=ttyS0,115200";
++    	};
++	memory {
++		reg = <0x00000000 0x08000000
++			0x88000000 0x18000000>;
++ 	};
++ 
++ 	gpio-keys {
++		compatible = "gpio-keys";
++		#address-cells = <1>;
++		#size-cells = <0>;
++ 
++ 		restart {
++ 			label = "Reset";
++ 			linux,code = <KEY_RESTART>;
++ 			gpios = <&chipcommon 17 GPIO_ACTIVE_LOW>;
++ 		};
++ 	};
++ };
++ 
++ &uart1 {
++ 	status = "okay";
++ };

--- a/target/linux/bcm53xx/patches-4.9/901-mtd-bcm47xxpart-add-partition-workaround-for-PHICOMM.patch
+++ b/target/linux/bcm53xx/patches-4.9/901-mtd-bcm47xxpart-add-partition-workaround-for-PHICOMM.patch
@@ -1,0 +1,24 @@
+From: Hill <lufanzhong@gmail.com>
+Subject: [PATCH] mtd: bcm47xxpart: add partition workaround for PHICOMM K3
+
+The founder of the patch is: Tian Hao <haotia@gmail.com>
+
+Signed-off-by: Hill <lufanzhong@gmail.com>
+
+--- a/drivers/mtd/bcm47xxpart.c
++++ b/drivers/mtd/bcm47xxpart.c
+@@ -253,6 +253,14 @@ static int bcm47xxpart_parse(struct mtd_
+ 			bcm47xxpart_add_part(&parts[curr_part++], "nvram",
+ 					     offset, 0);
+ 			continue;
++		} else if (of_machine_is_compatible("phicomm,k3") && offset == 0x180000) {
++			/*
++			* This device has nvram_back, res_info, pro_info and dev_info from
++			* 0x180000 (end of nvram) to 0x400000 (start of linux). These partitions
++			* has essential information for original firwamre. We do not want these.
++			*/
++			bcm47xxpart_add_part(&parts[curr_part++], "phicomm", offset, MTD_WRITEABLE);
++			continue;
+ 		}
+ 
+ 		/* Read middle of the block */


### PR DESCRIPTION
This router has BCM4709C0, 128MB NAND flash (MX30LF1G18AC-TI),
and 512MB memory, with 3 x LAN and 1 x WAN. WL chips are
BCM4366C0 x 2. The router has a small LCD and 3 capactive keys
driven by a PIC microcontroller, which is in turn wired to
UART1 of main board, No LED.

Wireless can work properly, but need additional wireless firmware, you
can download from here: https://drive.google.com/drive/folders/0ByNlqhxfFBAreUdGTTVDS1NlWlE
See README.txt for how to use it

Flash:
1. Enter CFE
2. CFE Brush Excess LEDE, you can get it from here: https://drive.google.com/file/d/0ByNlqhxfFBArb2owR05VUlVpN0E
3. Well, now you can brush into the trx file for the LEDE.

Signed-off-by: ZhongLuFan <lufanzhong@gmail.com>
