### PR TITLE
adb: fix package description

### DIFF
--- a/package/utils/adb/Makefile
+++ b/package/utils/adb/Makefile
@@ -28,7 +28,7 @@ define Package/adb
   DEPENDS:=+zlib +libopenssl +libpthread
 endef
 
-define Package/bridge/description
+define Package/adb/description
  Android Debug Bridge (adb) is a versatile command line tool that lets you communicate with an emulator instance or connected Android-powered device.
 endef
 


### PR DESCRIPTION
Fixed a syntax error in the package Makefile.

Signed-off-by: Matt Mets <matt@blinkinlabs.com>
