### PR TITLE
mktplinkfw* implement kernel offset

### DIFF
--- a/tools/firmware-utils/src/mktplinkfw-lib.c
+++ b/tools/firmware-utils/src/mktplinkfw-lib.c
@@ -33,6 +33,7 @@
 extern char *ofname;
 extern char *progname;
 extern uint32_t kernel_len;
+extern uint32_t kernel_ofs;
 extern struct file_info kernel_info;
 extern struct file_info rootfs_info;
 extern struct flash_layout *layout;
@@ -207,7 +208,6 @@ inline void inspect_fw_pmd5sum(const char *label, const uint8_t *val, const char
 	printf(" %s\n", text);
 }
 
-// header_size = sizeof(struct fw_header)
 int build_fw(size_t header_size)
 {
 	int buflen;
@@ -216,7 +216,7 @@ int build_fw(size_t header_size)
 	int ret = EXIT_FAILURE;
 	int writelen = 0;
 
-	writelen = header_size + kernel_len;
+	writelen = kernel_ofs + kernel_len;
 
 	if (combined)
 		buflen = writelen;
@@ -230,7 +230,7 @@ int build_fw(size_t header_size)
 	}
 
 	memset(buf, 0xff, buflen);
-	p = buf + header_size;
+	p = buf + kernel_ofs;
 	ret = read_to_buf(&kernel_info, p);
 	if (ret)
 		goto out_free_buf;


### PR DESCRIPTION
Several (all?) images built with mktplinkfw or mktplinkfw2 currently shipped in snapshot (and some in **17.01** release) will **soft brick** TP-Link devices because in the image header the end of the kernel binary collides with rootfs data. I suspect this causes a partial or invalid load with the bootloader, but couldn't confirm this hypothesis.

This patch attempts to address the issue, but I **couldn't test it yet**. One user on IRC is attempting to unbrick his C50 and will test and report if/when he can.

I have found one FS bug that appears to be directly related [(872)](https://bugs.lede-project.org/index.php?do=details&task_id=872) but there might be others
