### PR TITLE
kernel: add NFS4 client support

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -363,6 +363,17 @@ endef
 
 $(eval $(call KernelPackage,crypto-ecb))
 
+define KernelPackage/crypto-cts
+  TITLE:=Cipher Text Stealing CryptoAPI module
+  DEPENDS:=+kmod-crypto-manager
+  KCONFIG:=CONFIG_CRYPTO_CTS
+  FILES:=$(LINUX_DIR)/crypto/cts.ko
+  AUTOLOAD:=$(call AutoLoad,09,cts)
+  $(call AddDepends/crypto)
+endef
+
+$(eval $(call KernelPackage,crypto-cts))
+
 
 define KernelPackage/crypto-hmac
   TITLE:=HMAC digest CryptoAPI module

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -317,24 +317,54 @@ $(eval $(call KernelPackage,fs-msdos))
 
 define KernelPackage/fs-nfs
   SUBMENU:=$(FS_MENU)
-  TITLE:=NFS filesystem support
+  TITLE:=NFS filesystem client support
   DEPENDS:=+kmod-fs-nfs-common +kmod-dnsresolver
   KCONFIG:= \
 	CONFIG_NFS_FS \
 	CONFIG_NFS_USE_LEGACY_DNS=n \
 	CONFIG_NFS_USE_NEW_IDMAPPER=n
   FILES:= \
-	$(LINUX_DIR)/fs/nfs/nfs.ko \
-	$(LINUX_DIR)/fs/nfs/nfsv3.ko
-  AUTOLOAD:=$(call AutoLoad,40,nfs nfsv3)
+	$(LINUX_DIR)/fs/nfs/nfs.ko
+  AUTOLOAD:=$(call AutoLoad,40,nfs)
 endef
 
 define KernelPackage/fs-nfs/description
- Kernel module for NFS support
+ Kernel module for NFS client support
 endef
 
 $(eval $(call KernelPackage,fs-nfs))
 
+define KernelPackage/fs-nfs-v3
+  SUBMENU:=$(FS_MENU)
+  TITLE:=NFS3 filesystem client support
+  DEPENDS:=+kmod-fs-nfs
+  FILES:= \
+	$(LINUX_DIR)/fs/nfs/nfsv3.ko
+  AUTOLOAD:=$(call AutoLoad,41,nfsv3)
+endef
+
+define KernelPackage/fs-nfs-v3/description
+ Kernel module for NFS v3 client support
+endef
+
+$(eval $(call KernelPackage,fs-nfs-v3))
+
+define KernelPackage/fs-nfs-v4
+  SUBMENU:=$(FS_MENU)
+  TITLE:=NFS4 filesystem client support
+  DEPENDS:=+kmod-fs-nfs
+  KCONFIG:= \
+	CONFIG_NFS_V4=y
+  FILES:= \
+	$(LINUX_DIR)/fs/nfs/nfsv4.ko
+  AUTOLOAD:=$(call AutoLoad,41,nfsv4)
+endef
+
+define KernelPackage/fs-nfs-v4/description
+ Kernel module for NFS v4 support
+endef
+
+$(eval $(call KernelPackage,fs-nfs-v4))
 
 define KernelPackage/fs-nfs-common
   SUBMENU:=$(FS_MENU)
@@ -353,23 +383,28 @@ endef
 $(eval $(call KernelPackage,fs-nfs-common))
 
 
-define KernelPackage/fs-nfs-common-v4
+define KernelPackage/fs-nfs-common-rpcsec
   SUBMENU:=$(FS_MENU)
-  TITLE:=Common NFS V4 filesystem modules
+  TITLE:=NFS Secure RPC
+  DEPENDS:=+kmod-fs-nfs-common \
+	+kmod-crypto-des \
+	+kmod-crypto-cbc +kmod-crypto-cts \
+	+kmod-crypto-md5 +kmod-crypto-sha1 \
+	+kmod-crypto-hmac
   KCONFIG+=\
-	CONFIG_SUNRPC_GSS\
-	CONFIG_NFS_V4=y\
-	CONFIG_NFSD_V4=y
-  DEPENDS:= @BROKEN
+	CONFIG_SUNRPC_GSS \
+	CONFIG_RPCSEC_GSS_KRB5
+  FILES+=$(LINUX_DIR)/lib/oid_registry.ko
   FILES+=$(LINUX_DIR)/net/sunrpc/auth_gss/auth_rpcgss.ko
-  AUTOLOAD=$(call AutoLoad,30,auth_rpcgss)
+  FILES+=$(LINUX_DIR)/net/sunrpc/auth_gss/rpcsec_gss_krb5.ko
+  AUTOLOAD:=$(call AutoLoad,31,oid_registry auth_rpcgss rpcsec_gss_krb5)
 endef
 
-define KernelPackage/fs-nfs-common-v4/description
- Kernel modules for NFS V4 & NFSD V4 kernel support
+define KernelPackage/fs-nfs-common-rpcsec/description
+ Kernel modules for NFS Secure RPC
 endef
 
-$(eval $(call KernelPackage,fs-nfs-common-v4))
+$(eval $(call KernelPackage,fs-nfs-common-rpcsec))
 
 
 define KernelPackage/fs-nfsd


### PR DESCRIPTION
Adds NFS4 client support:
 1. Package `kmod-fs-nfs` is split into `kmod-fs-nfs` (`nfs.ko`) and `kmod-fs-nfs-v3` (`nfsv3.ko`).
 2. A new package `kmod-fs-nfs-v4` (`nfsv4.ko`) is created.
 3. Package `kmod-fs-nfs-common-v4` is renamed to `kmod-fs-nfs-rpcsec` and includes additional module `rpcsec_gss_krb5.ko`. `CONFIG_NFS_V4` goes into `kmod-fs-nfs-v4`, `CONFIG_NFSD_V4` (NFS4 server) is removed. Missing kernel module `oid_registry.ko` needed by `auth_rpcgss.ko` is added to the package.

A new package `kmod-crypto-cts` needed by `rpcsec_gss_krb5.ko` is also created.

NFS4 client was compile and runtime tested on ramips (Nexx WT3020) and ar71xx (TP-Link TL-WR710N).
