### PR TITLE
kernel: coretemp and cpuid packages

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -78,6 +78,21 @@ endef
 $(eval $(call KernelPackage,hwmon-adt7475))
 
 
+define KernelPackage/hwmon-coretemp
+  TITLE:=Pentium thermal monitoring support
+  KCONFIG:=CONFIG_SENSORS_CORETEMP
+  FILES:=$(LINUX_DIR)/drivers/hwmon/coretemp.ko
+  AUTOLOAD:=$(call AutoProbe,coretemp)
+  $(call AddDepends/hwmon)
+endef
+
+define KernelPackage/hwmon-coretemp/description
+ Kernel module for Intel Pentium and above CPU temperature
+endef
+
+$(eval $(call KernelPackage,hwmon-coretemp))
+
+
 define KernelPackage/hwmon-ina209
   TITLE:=INA209 monitoring support
   KCONFIG:=CONFIG_SENSORS_INA209

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -135,6 +135,18 @@ endef
 $(eval $(call KernelPackage,btmrvl))
 
 
+define KernelPackage/cpuid
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Intel CPUID support
+  KCONFIG:=CONFIG_X86_CPUID
+  DEPENDS:=@TARGET_x86
+  FILES:=$(LINUX_DIR)/arch/x86/kernel/cpuid.ko
+  AUTOLOAD:=$(call AutoLoad,20,cpuid)
+endef
+
+$(eval $(call KernelPackage,cpuid))
+
+
 define KernelPackage/dma-buf
   SUBMENU:=$(OTHER_MENU)
   TITLE:=DMA shared buffer support


### PR DESCRIPTION
Add support for the Intel Coretemp (on-CPU thermal sensors) and the CPUID instruction.