### PR TITLE
nbg6817: fix persistent overlayfs and hardware MAC addresses

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -47,8 +47,8 @@ nbg6817)
 	hw_mac_addr=$(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
 	ucidef_add_switch "switch0" \
 		"1:lan" "2:lan" "3:lan" "4:lan" "6@eth1" "5:wan" "0@eth0"
-	ucidef_set_interface_macaddr "lan" "$hw_mac_addr"
-	ucidef_set_interface_macaddr "wan" "$(macaddr_add $hw_mac_addr 1)"
+	ucidef_set_interface_macaddr "lan" "$(macaddr_add $hw_mac_addr 2)"
+	ucidef_set_interface_macaddr "wan" "$(macaddr_add $hw_mac_addr 3)"
 	;;
 *)
 	echo "Unsupported hardware. Network interfaces not intialized"

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -23,6 +23,9 @@ case "$board" in
 	ea8500)
 		echo $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) $(($PHYNBR + 1)) ) > /sys${DEVPATH}/macaddress
 		;;
+	nbg6817)
+		echo $(macaddr_add $(mtd_get_mac_ascii 0:APPSBLENV ethaddr) $((1 - $PHYNBR)) ) > /sys${DEVPATH}/macaddress
+		;;
 	vr2600v)
 		echo $(macaddr_add $(mtd_get_mac_binary default-mac 0)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -230,7 +230,7 @@ define Device/NBG6817
 	BLOCKSIZE := 64k
 	BOARD_NAME := nbg6817
 	DEVICE_TITLE := ZyXEL NBG6817
-	DEVICE_PACKAGES := ath10k-firmware-qca9984 e2fsprogs losetup
+	DEVICE_PACKAGES := ath10k-firmware-qca9984 e2fsprogs kmod-fs-ext4 losetup
 	$(call Device/ZyXELImage)
 endef
 


### PR DESCRIPTION
Include ext4 to devices packages for the nbg6817 to allow mounting the default overlayfs from flash and generate the correct MAC addresses equivalent to those chosen by the OEM firmware.

This makes the overlay persistent, rather than forgetting all settings while rebooting, and fixes randomly changing MAC addresses for both wlan interfaces.

Both patches of this pull request should ideally be cherry-picked to the lede-17.01 branch as well.

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>