### PR TITLE
nbg6817: support booting from and updating the alternate boot partition(s)

### DIFF
--- a/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
@@ -74,11 +74,22 @@ zyxel_do_upgrade() {
 
 	[ -b "${rootfs}" ] || return 1
 	case "$board" in
-	nbg6817)
-		kernel=mmcblk0p4
+		nbg6817)
+			case "$rootfs" in
+				"/dev/mmcblk0p5")
+					kernel=mmcblk0p4
+				;;
+				"/dev/mmcblk0p8")
+					kernel=mmcblk0p7
+				;;
+				*)
+					return 1
+				;;
+			esac
 		;;
-	*)
-		return 1
+		*)
+			return 1
+		;;
 	esac
 
 	zyxel_do_flash $tar_file $board $kernel $rootfs

--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8065-nbg6817.dts
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8065-nbg6817.dts
@@ -33,8 +33,9 @@
 	};
 
 	chosen {
-		bootargs = "root=/dev/mmcblk0p5 rootfstype=squashfs,ext4 rootwait noinitrd";
+		bootargs = "rootfstype=squashfs,ext4 rootwait noinitrd";
 		linux,stdout-path = "serial0:115200n8";
+		append-rootblock = "root=/dev/mmcblk0p";
 	};
 
 	soc {


### PR DESCRIPTION
The nbg6817 is dual-boot capable and holds two independent sets of boot partitions (mmcblk0p[3-5] vs mmcblk0p[6-8]), this pull requests adds support for booting from the alternate and sysupgrading it. It does not yet toggle the bootflag and always (sys)upgrades the currently booted partition set, instead of the non-active one.

Toggling the dual-boot flag from a running system (OEM and LEDE) is [understood,](https://forum.lede-project.org/t/web-ui-to-reboot-to-another-partition-for-linksys-dual-partition-routers-and-to-power-off-power-down/3423/94) however it is not obvious so far how to manually toggle it in the failure case (non-booting firmware, button presses, etc.). Adding support for alternating the sysupgrade targets is trivial (and probably follows in a later pull request), but it would be nice if there'd be a generic configuration/ flag to choose between alternating or writing to the active boot partition set.

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>