### PR TITLE
[RFC] [WIP] Mainlining netdev led triggers

### DIFF
--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -70,8 +70,11 @@ load_led() {
 		case "$trigger" in
 		"netdev")
 			[ -n "$dev" ] && {
+				local m
 				echo $dev > /sys/class/leds/${sysfs}/device_name
-				echo $mode > /sys/class/leds/${sysfs}/mode
+				for m in $mode; do
+					echo 1 > /sys/class/leds/${sysfs}/$m
+				done
 			}
 			;;
 

--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -58,7 +58,7 @@ define KernelPackage/ledtrig-netdev
   SUBMENU:=$(LEDS_MENU)
   TITLE:=LED NETDEV Trigger
   KCONFIG:=CONFIG_LEDS_TRIGGER_NETDEV
-  FILES:=$(LINUX_DIR)/drivers/leds/ledtrig-netdev.ko
+  FILES:=$(LED_TRIGGER_DIR)/ledtrig-netdev.ko
   AUTOLOAD:=$(call AutoLoad,50,ledtrig-netdev)
 endef
 

--- a/target/linux/generic/files/drivers/leds/ledtrig-netdev.c
+++ b/target/linux/generic/files/drivers/leds/ledtrig-netdev.c
@@ -413,14 +413,8 @@ static void netdev_trig_deactivate(struct led_classdev *led_cdev)
 
 		cancel_delayed_work_sync(&trigger_data->work);
 
-		spin_lock_bh(&trigger_data->lock);
-
-		if (trigger_data->net_dev) {
+		if (trigger_data->net_dev)
 			dev_put(trigger_data->net_dev);
-			trigger_data->net_dev = NULL;
-		}
-
-		spin_unlock_bh(&trigger_data->lock);
 
 		kfree(trigger_data);
 	}

--- a/target/linux/generic/files/drivers/leds/ledtrig-netdev.c
+++ b/target/linux/generic/files/drivers/leds/ledtrig-netdev.c
@@ -125,15 +125,19 @@ static ssize_t led_device_name_store(struct device *dev,
 	strcpy(trigger_data->device_name, buf);
 	if (size > 0 && trigger_data->device_name[size-1] == '\n')
 		trigger_data->device_name[size-1] = 0;
+
+	if (trigger_data->net_dev)
+		dev_put(trigger_data->net_dev);
+
 	trigger_data->link_up = 0;
 	trigger_data->last_activity = 0;
+	trigger_data->net_dev = NULL;
 
-	if (trigger_data->device_name[0] != 0) {
-		/* check for existing device to update from */
+	if (trigger_data->device_name[0] != 0)
 		trigger_data->net_dev = dev_get_by_name(&init_net, trigger_data->device_name);
-		if (trigger_data->net_dev != NULL)
-			trigger_data->link_up = (dev_get_flags(trigger_data->net_dev) & IFF_LOWER_UP) != 0;
-	}
+
+	if (trigger_data->net_dev != NULL)
+		trigger_data->link_up = (dev_get_flags(trigger_data->net_dev) & IFF_LOWER_UP) != 0;
 
 	set_baseline_state(trigger_data);
 	spin_unlock_bh(&trigger_data->lock);

--- a/target/linux/generic/files/drivers/leds/ledtrig-netdev.c
+++ b/target/linux/generic/files/drivers/leds/ledtrig-netdev.c
@@ -384,10 +384,13 @@ static void netdev_trig_activate(struct led_classdev *led_cdev)
 	rc = device_create_file(led_cdev->dev, &dev_attr_interval);
 	if (rc)
 		goto err_out_mode;
-
-	register_netdevice_notifier(&trigger_data->notifier);
+	rc = register_netdevice_notifier(&trigger_data->notifier);
+	if (rc)
+		goto err_out_interval;
 	return;
 
+err_out_interval:
+	device_remove_file(led_cdev->dev, &dev_attr_interval);
 err_out_mode:
 	device_remove_file(led_cdev->dev, &dev_attr_mode);
 err_out_device_name:

--- a/target/linux/generic/files/drivers/leds/trigger/ledtrig-netdev.c
+++ b/target/linux/generic/files/drivers/leds/trigger/ledtrig-netdev.c
@@ -30,8 +30,6 @@
 #include <linux/atomic.h>
 #include <linux/leds.h>
 
-#include "leds.h"
-
 /*
  * Configurable sysfs attributes:
  *

--- a/target/linux/generic/pending-4.9/831-ledtrig_netdev.patch
+++ b/target/linux/generic/pending-4.9/831-ledtrig_netdev.patch
@@ -51,13 +51,6 @@ Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>
  drivers/leds/trigger/Kconfig | 7 +++++++
  2 files changed, 8 insertions(+)
 
---- a/drivers/leds/Makefile
-+++ b/drivers/leds/Makefile
-@@ -77,3 +77,4 @@ obj-$(CONFIG_LEDS_DAC124S085)		+= leds-d
- 
- # LED Triggers
- obj-$(CONFIG_LEDS_TRIGGERS)		+= trigger/
-+obj-$(CONFIG_LEDS_TRIGGER_NETDEV)	+= ledtrig-netdev.o
 --- a/drivers/leds/trigger/Kconfig
 +++ b/drivers/leds/trigger/Kconfig
 @@ -126,4 +126,11 @@ config LEDS_TRIGGER_PANIC
@@ -72,3 +65,10 @@ Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>
 +	  If unsure, say Y.
 +
  endif # LEDS_TRIGGERS
+--- a/drivers/leds/trigger/Makefile
++++ b/drivers/leds/trigger/Makefile
+@@ -10,3 +10,4 @@ obj-$(CONFIG_LEDS_TRIGGER_DEFAULT_ON)	+=
+ obj-$(CONFIG_LEDS_TRIGGER_TRANSIENT)	+= ledtrig-transient.o
+ obj-$(CONFIG_LEDS_TRIGGER_CAMERA)	+= ledtrig-camera.o
+ obj-$(CONFIG_LEDS_TRIGGER_PANIC)	+= ledtrig-panic.o
++obj-$(CONFIG_LEDS_TRIGGER_NETDEV)	+= ledtrig-netdev.o


### PR DESCRIPTION
This PR is a work in progress cleanup of the netdev led triggers with a view to upstreaming, as such the prefix is wrong atm (and wrong for LEDE).
I have tried to address the various issues raised on the old patch submissions to the mailing list [1] and again [2].
My aim will be to have a round of reviews and tweaks here then go ahead and engage on the netdev/kernel mailing list.

An overview:
- One sysfs entry per parameter raised by Greg KH, for link, tx, and rx.
- Cleaning up the error checking in registration and unwind.
- Some suggestions on reformatting the logic.
- Converted the mode to flags to use atomics and avoid locks.
- Moving trigger to trigger subdirectory in kernel.

What could be looked over
- Locking, needs double checking.

[1] https://lkml.org/lkml/2010/11/14/116
[2] https://lkml.org/lkml/2010/11/28/187
