### PR TITLE
bcm53xx: add USB GPIO for Netgear R6300 V2

### DIFF
--- a/target/linux/bcm53xx/patches-4.4/035-ARM-BCM5301X-Set-vcc-gpio-for-USB-controllers-of-few.patch
+++ b/target/linux/bcm53xx/patches-4.4/035-ARM-BCM5301X-Set-vcc-gpio-for-USB-controllers-of-few.patch
@@ -115,3 +115,17 @@ Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>
  	};
  
  	lcpll0: lcpll0@1800c100 {
+--- a/arch/arm/boot/dts/bcm4708-netgear-r6300-v2.dts
++++ b/arch/arm/boot/dts/bcm4708-netgear-r6300-v2.dts
+@@ -82,3 +82,11 @@
+ 		};
+ 	};
+ };
++
++&usb2 {
++	vcc-gpio = <&chipcommon 0 GPIO_ACTIVE_HIGH>;
++};
++
++&usb3 {
++	vcc-gpio = <&chipcommon 0 GPIO_ACTIVE_HIGH>;
++};


### PR DESCRIPTION
The R6300 V2, like many of the other Netgear BCM53xx routers, has
the USB VCC controlled by a GPIO (#0).  This change allows for the USB
ports to be enabled on startup, and therefore extroot usage.

Signed-off-by: Daniel Sullivan <mumblepins@users.noreply.github.com>
