### PR TITLE
ar71xx: mach-rbspi: fix 74x164 support

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -488,6 +488,7 @@ static struct gpio_keys_button rblhg_gpio_keys[] __initdata = {
 
 static struct gen_74x164_chip_platform_data rbspi_ssr_data = {
 	.base = RBSPI_SSR_GPIO_BASE,
+	.num_registers = 1,
 };
 
 /* the spi-ath79 driver can only natively handle CS0. Other CS are bit-banged */


### PR DESCRIPTION
The platform data was missing the num_registers element which is now
mandatory in linux 4.9

Without this patch, the gpio probing would fail with:
`gpio gpiochip1: (74x164): tried to insert a GPIO chip with zero lines`

Fixes: FS#1106

Signed-off-by: Thibaut VARENE <hacks@slashdirt.org>
Tested-by: Robert Marko <robimarko@gmail.com>