### PR TITLE
ramips: base-files: alphabetical order + merge cases

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -139,6 +139,7 @@ ramips_setup_interfaces()
 		;;
 	ar670w|\
 	ar725w|\
+	kn_rf|\
 	rt-ac51u)
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
@@ -255,10 +256,6 @@ ramips_setup_interfaces()
 	y1s)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5:lan" "0:wan" "6@eth0"
-		;;
-	kn_rf)
-		ucidef_add_switch "switch0" \
-			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6@eth0"
 		;;
 	kng_rc)
 		ucidef_add_switch "switch1" \

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -48,14 +48,14 @@ ramips_setup_interfaces()
 	dcs-930|\
 	dcs-930l-b1|\
 	ht-tm02|\
-	linkits7688 | \
-	linkits7688d | \
+	linkits7688|\
+	linkits7688d|\
 	m2m|\
 	microwrt|\
 	mpr-a2|\
 	ncs601w|\
-	omega2 | \
-	omega2p | \
+	omega2|\
+	omega2p|\
 	timecloud|\
 	w150m|\
 	widora-neo|\
@@ -176,8 +176,8 @@ ramips_setup_interfaces()
 	ubnt-erx-sfp|\
 	ur-326n4g|\
 	wrtnode|\
-	wrtnode2p | \
-	wrtnode2r | \
+	wrtnode2p|\
+	wrtnode2r|\
 	wt3020-4M|\
 	wt3020-8M|\
 	zbt-wa05)
@@ -197,6 +197,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "4:lan" "6@eth0"
 		;;
+	duzun-dm06|\
 	gl-mt300n-v2)
 		ucidef_add_switch "switch0" \
 			"1:lan" "0:wan" "6@eth0"
@@ -244,10 +245,6 @@ ramips_setup_interfaces()
 	wn3000rpv3|\
 	wrh-300cr)
 		ucidef_set_interface_lan "eth0"
-		;;
-	duzun-dm06)
-		ucidef_add_switch "switch0" \
-			"1:lan" "0:wan" "6@eth0"
 		;;
 	e1700|\
 	mt7620a_mt7530)
@@ -417,11 +414,14 @@ ramips_setup_macs()
 		;;
 	kn_rc|\
 	kn_rf|\
-	kng_rc)
+	kng_rc|\
+	wcr-150gn)
 		wan_mac=$(mtd_get_mac_binary factory 40)
 		;;
-	linkits7688 | \
-	linkits7688d)
+	linkits7688|\
+	linkits7688d|\
+	omega2|\
+	omega2p)
 		wan_mac=$(mtd_get_mac_binary factory 4)
 		lan_mac=$(mtd_get_mac_binary factory 46)
 		;;
@@ -447,11 +447,6 @@ ramips_setup_macs()
 	newifi-d1)
 		lan_mac=$(cat /sys/class/net/eth0/address)
 		lan_mac=$(macaddr_add "$lan_mac" 2)
-		;;
-	omega2|\
-	omega2p)
-		wan_mac=$(mtd_get_mac_binary factory 4)
-		lan_mac=$(mtd_get_mac_binary factory 46)
 		;;
 	oy-0001)
 		lan_mac=$(mtd_get_mac_binary factory 40)
@@ -492,9 +487,6 @@ ramips_setup_macs()
 		local index="$(find_mtd_index "board_data")"
 		wan_mac="$(grep -m1 mac= "/dev/mtd${index}" | cut -d= -f2)"
 		lan_mac=$wan_mac
-		;;
-	wcr-150gn)
-		wan_mac=$(mtd_get_mac_binary factory 40)
 		;;
 	whr-1166d|\
 	whr-300hp2|\

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -137,13 +137,6 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:1" "1:lan:2" "2:lan:3" "3:lan:4" "4:wan:5" "6@eth0"
 		;;
-	ar670w|\
-	ar725w|\
-	kn_rf|\
-	rt-ac51u)
-		ucidef_add_switch "switch0" \
-			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
-		;;
 	rt-n15|\
 	wl-351)
 		ucidef_add_switch "switch0" \
@@ -155,6 +148,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
+	ar670w|\
+	ar725w|\
 	atp-52b|\
 	awm002-evb-4M|\
 	awm002-evb-8M|\
@@ -168,8 +163,10 @@ ramips_setup_interfaces()
 	jhr-n805r|\
 	jhr-n825r|\
 	jhr-n926r|\
+	kn_rf|\
 	mzk-wdpr|\
 	rb750gr3|\
+	rt-ac51u|\
 	rt-n14u|\
 	tl-wr840n-v4|\
 	tl-wr841n-v13|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -39,12 +39,16 @@ get_status_led() {
 	tl-wr840n-v4|\
 	tl-wr841n-v13|\
 	vr500|\
+	wcr-1166ds|\
+	whr-300hp2|\
+	wn3000rpv3|\
 	wnce2001|\
 	wndr3700v5|\
+	wsr-1166|\
+	wsr-600|\
 	x5|\
 	x8|\
-	xdxrn502j|\
-	wn3000rpv3)
+	xdxrn502j)
 		status_led="$board:green:power"
 		;;
 	3g-6200nl)
@@ -58,7 +62,10 @@ get_status_led() {
 	jhr-n825r|\
 	mpr-a1|\
 	mpr-a2|\
-	mzk-ex750np)
+	mzk-ex750np|\
+	whr-g300n|\
+	wlr-6000|\
+	zbt-we2026)
 		status_led="$board:red:power"
 		;;
 	ai-br100|\
@@ -85,6 +92,7 @@ get_status_led() {
 	mofi3500-3gn|\
 	rut5xx|\
 	v11st-fe|\
+	vocore2lite|\
 	wmr-300|\
 	zbt-wg2626)
 		status_led="$board:green:status"
@@ -100,7 +108,15 @@ get_status_led() {
 		;;
 	awapn2403|\
 	dir-645|\
+	mzk-ex300np|\
+	rt-n10-plus|\
 	sk-wb8|\
+	tew-638apb-v2|\
+	tew-691gr|\
+	tew-692gr|\
+	ur-326n4g|\
+	ur-336un|\
+	wf-2881|\
 	wrh-300cr)
 		status_led="$board:green:wps"
 		;;
@@ -111,6 +127,7 @@ get_status_led() {
 	psg1208)
 		status_led="$board:white:wps"
 		;;
+	mir3g|\
 	psg1218a|\
 	psg1218b)
 		status_led="$board:yellow:status"
@@ -166,10 +183,11 @@ get_status_led() {
 		;;
 	k2p|\
 	m3|\
-	miwifi-nano)
+	miwifi-nano|\
+	newifi-d1)
 		status_led="$board:blue:status"
 		;;
-	linkits7688| \
+	linkits7688|\
 	linkits7688d)
 		[ "$1" = "upgrade" ] && status_led="mediatek:orange:wifi"
 		;;
@@ -182,9 +200,6 @@ get_status_led() {
 	m4-4M|\
 	m4-8M)
 		status_led="m4:blue:status"
-		;;
-	mir3g)
-		status_led="$board:yellow:status"
 		;;
 	miwifi-mini|\
 	zte-q7)
@@ -199,10 +214,7 @@ get_status_led() {
 	nw718)
 		status_led="$board:amber:cpu"
 		;;
-	newifi-d1)
-		status_led="$board:blue:status"
-		;;
-	omega2| \
+	omega2|\
 	omega2p)
 		status_led="$board:amber:system"
 		;;
@@ -223,16 +235,6 @@ get_status_led() {
 	widora-neo)
 		status_led="$board:orange:wifi"
 		;;
-	mzk-ex300np|\
-	rt-n10-plus|\
-	tew-638apb-v2|\
-	tew-691gr|\
-	tew-692gr|\
-	ur-326n4g|\
-	ur-336un|\
-	wf-2881)
-		status_led="$board:green:wps"
-		;;
 	rb750gr3)
 		status_led="$board:blue:pwr"
 		;;
@@ -252,28 +254,14 @@ get_status_led() {
 	vocore2)
 		status_led="$board:fuchsia:status"
 		;;
-	vocore2lite)
-		status_led="$board:green:status"
-		;;
 	w306r-v20|\
 	witi|\
 	zbt-wr8305rt)
 		status_led="$board:green:sys"
 		;;
-	wcr-1166ds|\
-	whr-300hp2|\
-	wsr-1166|\
-	wsr-600)
-		status_led="$board:green:power"
-		;;
 	wcr-150gn|\
 	wl-351)
 		status_led="$board:amber:power"
-		;;
-	whr-g300n|\
-	wlr-6000|\
-	zbt-we2026)
-		status_led="$board:red:power"
 		;;
 	wzr-agl300nh)
 		status_led="$board:green:router"
@@ -285,9 +273,9 @@ get_status_led() {
 	wr512-3gn-8M)
 		status_led="wr512-3gn:green:wps"
 		;;
-	wrtnode2r | \
-	wrtnode2p | \
-	wrtnode)
+	wrtnode|\
+	wrtnode2r|\
+	wrtnode2p)
 		status_led="wrtnode:blue:indicator"
 		;;
 	wt3020-4M|\

--- a/target/linux/ramips/base-files/etc/hotplug.d/usb/10-motion
+++ b/target/linux/ramips/base-files/etc/hotplug.d/usb/10-motion
@@ -1,1 +1,0 @@
-[ "$ACTION" = "motion" ] && logger webcam motion event

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -217,11 +217,11 @@ ramips_board_detect() {
 	*"GL-MT300N")
 		name="gl-mt300n"
 		;;
-	*"GL-MT750")
-		name="gl-mt750"
-		;;
 	*"GL-MT300N-V2")
 		name="gl-mt300n-v2"
+		;;
+	*"GL-MT750")
+		name="gl-mt750"
 		;;
 	*"HC5661")
 		name="hc5661"
@@ -373,11 +373,11 @@ ramips_board_detect() {
 	*"NBG-419N v2")
 		name="nbg-419n2"
 		;;
-	*"Newifi-D1")
-		name="newifi-d1"
-		;;
 	*"NCS601W")
 		name="ncs601w"
+		;;
+	*"Newifi-D1")
+		name="newifi-d1"
 		;;
 	*"NixcoreX1 (8M)")
 		name="nixcore-x1-8M"
@@ -445,12 +445,6 @@ ramips_board_detect() {
 	*"RP-N53")
 		name="rp-n53"
 		;;
-	*"RT5350F-OLinuXino")
-		name="rt5350f-olinuxino"
-		;;
-	*"RT5350F-OLinuXino-EVB")
-		name="rt5350f-olinuxino-evb"
-		;;
 	*"RT-AC51U")
 		name="rt-ac51u"
 		;;
@@ -471,6 +465,12 @@ ramips_board_detect() {
 		;;
 	*"RT-N56U")
 		name="rt-n56u"
+		;;
+	*"RT5350F-OLinuXino")
+		name="rt5350f-olinuxino"
+		;;
+	*"RT5350F-OLinuXino-EVB")
+		name="rt5350f-olinuxino-evb"
 		;;
 	*"RUT5XX")
 		name="rut5xx"

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -62,8 +62,8 @@ platform_check_image() {
 	gb-pc1|\
 	gl-mt300a|\
 	gl-mt300n|\
-	gl-mt750|\
 	gl-mt300n-v2|\
+	gl-mt750|\
 	hc5*61|\
 	hc5661a|\
 	hg255d|\
@@ -125,8 +125,6 @@ platform_check_image() {
 	rb750gr3|\
 	re6500|\
 	rp-n53|\
-	rt5350f-olinuxino|\
-	rt5350f-olinuxino-evb|\
 	rt-ac51u|\
 	rt-g32-b1|\
 	rt-n10-plus|\
@@ -134,6 +132,8 @@ platform_check_image() {
 	rt-n14u|\
 	rt-n15|\
 	rt-n56u|\
+	rt5350f-olinuxino|\
+	rt5350f-olinuxino-evb|\
 	rut5xx|\
 	sap-g3200u3|\
 	sk-wb8|\
@@ -157,6 +157,7 @@ platform_check_image() {
 	w2914nsv2|\
 	w306r-v20|\
 	w502u|\
+	we1026-5g-16m|\
 	wf-2881|\
 	whr-1166d|\
 	whr-300hp2|\
@@ -194,7 +195,7 @@ platform_check_image() {
 	x8|\
 	y1|\
 	y1s|\
-	we1026-5g-16m|\
+	youku-yk1|\
 	zbt-ape522ii|\
 	zbt-cpe102|\
 	zbt-wa05|\
@@ -206,8 +207,7 @@ platform_check_image() {
 	zbt-wg3526-16M|\
 	zbt-wg3526-32M|\
 	zbt-wr8305rt|\
-	zte-q7|\
-	youku-yk1)
+	zte-q7)
 		[ "$magic" != "27051956" ] && {
 			echo "Invalid image type."
 			return 1


### PR DESCRIPTION
@mkresin  As PR #1457 brought my attention to the base-files of ramips, here comes the alphabetical
re-ordering of the cases in ramips' base-files. Also merge the double cases.
(Btw: learned my lesson on that PR ;-) )

However, there are further things to discuss (I'd merge the commits if applicable):
1.) merge explicitly tagged with (implicitly) tagged switch:
`"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6@eth0"` with
`"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"`
This should be doable without risk - IIRC, there was some discussion going on, that for the first
case (not explicitly tagged), the tag is automatically added for the CPU port.

2.) merge switches with same port configuration in different order:
`"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"` with
`"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6t@eth0"`.
The port numbers are the same, but I'd expect that during first network setup,
WAN is assigned eth0.1 in the first case, and eth0.2 in the second case.
(LAN is the other VLAN vice versa)
Is this ok for a merge, as I do not alter **existing** configs?

3.) In [1], @blogic  added support for two (router) devices and introduced a hotplug script
for usb/motion (?). What's the purpose of this script? (It just prints a line to the syslog)
Maybe this script can be moved to the motion package if it's needed there,
similar to the hotplug script of mjpeg-streamer at [2]

[1]:
https://git.lede-project.org/?p=source.git;a=commit;h=43de7c1cfa8b6afd15c226676ec64a0fa765fc6b

[2]:
https://git.lede-project.org/?p=feed/packages.git;a=blob;f=multimedia/mjpg-streamer/files/mjpg-streamer.hotplug;hb=HEAD