### PR TITLE
gcc: libgcj removed in >=gcc 7

### DIFF
--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -57,6 +57,7 @@ config SJLJ_EXCEPTIONS
 config INSTALL_LIBGCJ
 	bool
 	prompt "Build/install java compiler and GNU classpath ?" if TOOLCHAINOPTS
+	depends on !GCC_USE_VERSION_7
 	default n
 	help
 	    Build/install java compiler and GNU classpath ?


### PR DESCRIPTION
Prevent selecting gcc's java compiler when using GCC 7, as it no longer exists in that version.