### PR TITLE
brcm47xx: fix switch port mapping on D-Link DIR-330

### DIFF
--- a/target/linux/brcm47xx/base-files/etc/board.d/01_detect
+++ b/target/linux/brcm47xx/base-files/etc/board.d/01_detect
@@ -148,6 +148,7 @@ detect_by_model() {
 	"Asus RT-N16"* | \
 	"Asus WL500GP V2" | \
 	"Buffalo WHR-G125" | \
+	"D-Link DIR-330" | \
 	"Motorola WR850G" | \
 	"Siemens SE505 V2")
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
D-Link DIR-330 is clone of ASUS WL500GP2, by default conf the WAN port is eht1, it's not working cus eth1 not soldered and wan port function performs  5th port of the switch.