### PR TITLE
hostapd: reduced size of mini versions disabling debug

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/files/hostapd-mini.config
+++ b/package/network/services/hostapd/files/hostapd-mini.config
@@ -167,14 +167,14 @@ CONFIG_IEEE80211AC=y
 # Remove debugging code that is printing out debug messages to stdout.
 # This can be used to reduce the size of the hostapd considerably if debugging
 # code is not needed.
-#CONFIG_NO_STDOUT_DEBUG=y
+CONFIG_NO_STDOUT_DEBUG=y
 
 # Add support for writing debug log to a file: -f /tmp/hostapd.log
 # Disabled by default.
 #CONFIG_DEBUG_FILE=y
 
 # Send debug messages to syslog instead of stdout
-CONFIG_DEBUG_SYSLOG=y
+#CONFIG_DEBUG_SYSLOG=y
 
 # Add support for sending all debug messages (regardless of debug verbosity)
 # to the Linux kernel tracing facility. This helps debug the entire stack by

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -773,7 +773,7 @@ wpa_supplicant_run() {
 
 	_wpa_supplicant_common "$ifname"
 
-	/usr/sbin/wpa_supplicant -B \
+	/usr/sbin/wpa_supplicant -B -s \
 		${network_bridge:+-b $network_bridge} \
 		-P "/var/run/wpa_supplicant-${ifname}.pid" \
 		-D ${_w_driver:-wext} \

--- a/package/network/services/hostapd/files/wpa_supplicant-full.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-full.config
@@ -386,7 +386,7 @@ CONFIG_IEEE80211R=y
 #CONFIG_DEBUG_FILE=y
 
 # Send debug messages to syslog instead of stdout
-#CONFIG_DEBUG_SYSLOG=y
+CONFIG_DEBUG_SYSLOG=y
 # Set syslog facility for debug messages
 #CONFIG_DEBUG_SYSLOG_FACILITY=LOG_DAEMON
 

--- a/package/network/services/hostapd/files/wpa_supplicant-mini.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-mini.config
@@ -213,7 +213,7 @@ CONFIG_CTRL_IFACE=y
 # This can be used to reduce the size of the wpa_supplicant considerably
 # if debugging code is not needed. The size reduction can be around 35%
 # (e.g., 90 kB).
-#CONFIG_NO_STDOUT_DEBUG=y
+CONFIG_NO_STDOUT_DEBUG=y
 
 # Remove WPA support, e.g., for wired-only IEEE 802.1X supplicant, to save
 # 35-50 kB in code size.

--- a/package/network/services/hostapd/patches/610-ignore_syslog_flag_mini_version.patch
+++ b/package/network/services/hostapd/patches/610-ignore_syslog_flag_mini_version.patch
@@ -1,0 +1,32 @@
+--- a/hostapd/main.c
++++ b/hostapd/main.c
+@@ -735,11 +735,11 @@ int main(int argc, char *argv[])
+ 			bss_config = tmp_bss;
+ 			bss_config[num_bss_configs++] = optarg;
+ 			break;
+-#ifdef CONFIG_DEBUG_SYSLOG
+ 		case 's':
++#ifdef CONFIG_DEBUG_SYSLOG
+ 			wpa_debug_syslog = 1;
+-			break;
+ #endif /* CONFIG_DEBUG_SYSLOG */
++			break;
+ 		case 'S':
+ 			start_ifaces_in_sync = 1;
+ 			break;
+--- a/wpa_supplicant/main.c
++++ b/wpa_supplicant/main.c
+@@ -287,11 +287,11 @@ int main(int argc, char *argv[])
+ 		case 'q':
+ 			params.wpa_debug_level++;
+ 			break;
+-#ifdef CONFIG_DEBUG_SYSLOG
+ 		case 's':
++#ifdef CONFIG_DEBUG_SYSLOG
+ 			params.wpa_debug_syslog++;
+-			break;
+ #endif /* CONFIG_DEBUG_SYSLOG */
++			break;
+ #ifdef CONFIG_DEBUG_LINUX_TRACING
+ 		case 'T':
+ 			params.wpa_debug_tracing++;


### PR DESCRIPTION
1) Allows hostapd and wpa_supplicant to be launched with `-s` flag, even when compiled without `CONFIG_DEBUG_SYSLOG` flag.

2) Disable debug log in mini versions to decrease size:
wpa_supplicant-mini: reduced of `21 KB`
hostapd-mini: reduced of `25 KB`
wpa-mini: reduced of `34 KB`