### PR TITLE
[RFC] ar71xx: Fix 5GHz wifi for Sitecom WLR-8100 and mac addresses

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -544,6 +544,10 @@ ar71xx_setup_macs()
 	mynet-n750)
 		wan_mac=$(mtd_get_mac_ascii devdata "wanmac")
 		;;
+	wlr8100)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env "ethaddr")
+		wan_mac=$(mtd_get_mac_ascii u-boot-env "wanaddr")
+		;;
 	wpj344|\
 	wpj558)
 		wan_mac=$(mtd_get_mac_binary u-boot 0x2e018)

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -91,6 +91,10 @@ case "$FIRMWARE" in
 		ath9k_eeprom_extract "caldata" 4096 2048
 		ath9k_patch_firmware_mac $(mtd_get_mac_binary caldata 0)
 		;;
+	wlr8100)
+                ath9k_eeprom_extract "art" 8192 2048
+                ath9k_patch_firmware_mac $(mtd_get_mac_ascii u-boot-env "ethaddr")
+                ;;
 	rambutan)
 		ath9k_eeprom_extract "art" 4096 2048
 		;;

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -92,7 +92,7 @@ case "$FIRMWARE" in
 		ath9k_patch_firmware_mac $(mtd_get_mac_binary caldata 0)
 		;;
 	wlr8100)
-                ath9k_eeprom_extract "art" 8192 2048
+                ath9k_eeprom_extract "caldata" 4096 2048
                 ath9k_patch_firmware_mac $(mtd_get_mac_ascii u-boot-env "ethaddr")
                 ;;
 	rambutan)

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -135,6 +135,10 @@ case "$FIRMWARE" in
 	rb-962uigs-5hact2hnt)
 		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
 		;;
+	wlr8100)
+		ath10kcal_extract "art" 24576 2116
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
+		;;
 	esac
 	;;
 "ath10k/pre-cal-pci-0000:00:00.0.bin")

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -136,7 +136,7 @@ case "$FIRMWARE" in
 		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
 		;;
 	wlr8100)
-		ath10kcal_extract "caldata" 2048 2116
+		ath10kcal_extract "caldata" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
 		;;
 	esac

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -136,7 +136,7 @@ case "$FIRMWARE" in
 		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
 		;;
 	wlr8100)
-		ath10kcal_extract "art" 24576 2116
+		ath10kcal_extract "caldata" 2048 2116
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
 		;;
 	esac

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-wlr8100.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-wlr8100.c
@@ -49,11 +49,6 @@
 #define WLR8100_KEYS_POLL_INTERVAL	20	/* msecs */
 #define WLR8100_KEYS_DEBOUNCE_INTERVAL	(3 * WLR8100_KEYS_POLL_INTERVAL)
 
-#define WLR8100_MAC0_OFFSET		0
-#define WLR8100_MAC1_OFFSET		6
-#define WLR8100_WMAC_CALDATA_OFFSET	0x1000
-#define WLR8100_PCIE_CALDATA_OFFSET	0x5000
-
 static struct gpio_led wlr8100_leds_gpio[] __initdata = {
 	{
 		.name		= "wlr8100:amber:status",
@@ -138,7 +133,6 @@ static struct mdio_board_info wlr8100_mdio0_info[] = {
 
 static void __init wlr8100_common_setup(void)
 {
-	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
 
 	ath79_register_m25p80(NULL);
 
@@ -150,13 +144,10 @@ static void __init wlr8100_common_setup(void)
 
 	ath79_register_usb();
 
-	ath79_register_wmac(art + WLR8100_WMAC_CALDATA_OFFSET, NULL);
-
+	ath79_register_wmac_simple();
 	ath79_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN);
 
 	ath79_register_mdio(0, 0x0);
-
-	ath79_init_mac(ath79_eth0_data.mac_addr, art + WLR8100_MAC0_OFFSET, 0);
 
 	mdiobus_register_board_info(wlr8100_mdio0_info,
 				    ARRAY_SIZE(wlr8100_mdio0_info));
@@ -178,8 +169,6 @@ static void __init wlr8100_common_setup(void)
 
 static void __init wlr8100_010_setup(void)
 {
-	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
-
 	/* GMAC0 of the AR8337 switch is connected to GMAC0 via RGMII */
 	wlr8100_ar8327_pad0_cfg.mode = AR8327_PAD_MAC_RGMII;
 	wlr8100_ar8327_pad0_cfg.txclk_delay_en = true;
@@ -196,7 +185,7 @@ static void __init wlr8100_010_setup(void)
 	ath79_eth1_pll_data.pll_1000 = 0x03000101;
 
 	wlr8100_common_setup();
-	ap91_pci_init(art + WLR8100_PCIE_CALDATA_OFFSET, NULL);
+	ap91_pci_init_simple();
 }
 
 MIPS_MACHINE(ATH79_MACH_WLR8100, "WLR8100",

--- a/target/linux/ar71xx/image/legacy-devices.mk
+++ b/target/linux/ar71xx/image/legacy-devices.mk
@@ -145,7 +145,8 @@ LEGACY_DEVICES += TUBE2H16M
 
 define LegacyDevice/WLR8100
   DEVICE_TITLE := Sitecom WLR-8100
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-usb3
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-usb3 \
+	kmod-ath10k ath10k-firmware-qca988x
 endef
 LEGACY_DEVICES += WLR8100
 

--- a/target/linux/ar71xx/image/legacy.mk
+++ b/target/linux/ar71xx/image/legacy.mk
@@ -263,7 +263,7 @@ dlrtdev_mtdlayout=mtdparts=spi0.0:256k(uboot)ro,64k(config)ro,6208k(firmware),64
 dlrtdev_mtdlayout_fat=mtdparts=spi0.0:256k(uboot)ro,64k(config)ro,7168k(firmware),640k(certs),64k(caldata)ro,64k@0x660000(caldata_orig),6208k@0x50000(firmware_orig)
 planex_mtdlayout=mtdparts=spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,7744k(firmware),128k(art)ro
 whrhpg300n_mtdlayout=mtdparts=spi0.0:248k(u-boot)ro,8k(u-boot-env)ro,3712k(firmware),64k(art)ro
-wlr8100_mtdlayout=mtdparts=spi0.0:192k(u-boot)ro,64k(u-boot-env)ro,1408k(kernel),14080k(rootfs),192k(unknown)ro,64k(art)ro,384k(unknown2)ro,15488k@0x40000(firmware)
+wlr8100_mtdlayout=mtdparts=spi0.0:192k(u-boot)ro,64k(u-boot-env)ro,1408k(kernel),14016k(rootfs),256k(manufacture)ro,64k(backup)ro,320k(storage)ro,64k(caldata)ro,15424k@0x40000(firmware)
 wndap360_mtdlayout=mtdparts=spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,7744k(firmware),64k(nvram)ro,64k(art)ro
 wnr2200_mtdlayout=mtdparts=spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,7808k(firmware),64k(art)ro
 wnr2000_mtdlayout=mtdparts=spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,3712k(firmware),64k(art)ro


### PR DESCRIPTION
This patch adds Sitecom WLR-8100 to ath10k caldata extraction list and fix the random MAC
address for LAN, WAN and 5GHz interface by extracting it from the u-boot-env partition.

In the stock firmware 2.4GHZ and LAN interface had the same mac address.

It's stored only in ascii format so it must be obtained using the mtd_get_mac_ascii function.

While this method is quite common for LAN/WAN and 5GHz wireless interface, I didn't found
any device using this method for 2.4GHz interface. So if someone could give me an advice how
to do this, I could add it in a future commit.

(The first part of this patch is similar to https://github.com/lede-project/source/pull/1392
but it isn't still merged so I have to commit again to fix the mac address. I don't know if
it's the right way).

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>