### PR TITLE
ramips: add support for TP-Link TL-WR840N v5

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -171,6 +171,7 @@ ramips_setup_interfaces()
 	rb750gr3|\
 	rt-n14u|\
 	tl-wr840n-v4|\
+	tl-wr840n-v5|\
 	tl-wr841n-v13|\
 	ubnt-erx|\
 	ubnt-erx-sfp|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -37,6 +37,7 @@ get_status_led() {
 	pwh2004|\
 	r6220|\
 	tl-wr840n-v4|\
+	tl-wr840n-v5|\
 	tl-wr841n-v13|\
 	vr500|\
 	wnce2001|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -502,6 +502,9 @@ ramips_board_detect() {
 	*"TL-WR840N v4")
 		name="tl-wr840n-v4"
 		;;
+	*"TL-WR840N v5")
+		name="tl-wr840n-v5"
+		;;
 	*"TL-WR841N v13")
 		name="tl-wr841n-v13"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -236,6 +236,7 @@ platform_check_image() {
 	c50|\
 	mr200|\
 	tl-wr840n-v4|\
+	tl-wr840n-v5|\
 	tl-wr841n-v13)
 		[ "$magic" != "03000000" ] && {
 			echo "Invalid image type."

--- a/target/linux/ramips/dts/TL-WR840NV5.dts
+++ b/target/linux/ramips/dts/TL-WR840NV5.dts
@@ -1,0 +1,111 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wr840n-v5", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-WR840N v5";
+
+  	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+	/* LED used is dual-color,dual lead LED */
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "tl-wr840n-v5:green:power";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		orange {
+			label = "tl-wr840n-v5:orange:power";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "boot";
+			reg = <0x0 0x20000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "firmware";
+			reg = <0x20000 0x3c0000>;
+		};
+
+		partition@3e0000 {
+			label = "config";
+			reg = <0x3e0000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@3f0000 {
+			label = "factory";
+			reg = <0x3f0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&wmac {
+	status = "okay";
+	mtd-mac-address = <&factory 0xf100>;
+	mediatek,mtd-eeprom = <&factory 0x10000>;
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xf100>;
+	mediatek,portmap = "wllll";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "p0led_an", "p2led_an", "perst";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -99,6 +99,21 @@ define Device/tl-wr840n-v4
 	check-size $$$$(IMAGE_SIZE)
 endef
 
+define Device/tl-wr840n-v5
+  DTS := TL-WR840NV5
+  IMAGE_SIZE := 3840k
+  DEVICE_TITLE := TP-Link TL-WR840N v5
+  TPLINK_FLASHLAYOUT := 4Mmtk
+  TPLINK_HWID := 0x08400005
+  TPLINK_HWREV := 0x1
+  TPLINK_HWREVADD := 0x5
+  TPLINK_HVERSION := 3
+  KERNEL := $(KERNEL_DTB)
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | tplink-v2-header -e
+  IMAGE/sysupgrade.bin := tplink-v2-image -s -e | append-metadata | \
+	check-size $$$$(IMAGE_SIZE)
+endef
+
 define Device/tl-wr841n-v13
   $(Device/tl-wr840n-v4)
   DTS := TL-WR841NV13
@@ -107,7 +122,7 @@ define Device/tl-wr841n-v13
   TPLINK_HWREV := 0x268
   TPLINK_HWREVADD := 0x13
 endef
-TARGET_DEVICES += tl-wr840n-v4 tl-wr841n-v13
+TARGET_DEVICES += tl-wr840n-v4 tl-wr840n-v5 tl-wr841n-v13
 
 define Device/vocore2
   DTS := VOCORE2

--- a/tools/firmware-utils/src/mktplinkfw2.c
+++ b/tools/firmware-utils/src/mktplinkfw2.c
@@ -123,6 +123,12 @@ char md5salt_boot[MD5SUM_LEN] = {
 
 static struct flash_layout layouts[] = {
 	{
+		.id		= "4Mmtk",
+		.fw_max_len	= 0x3c0000,
+		.kernel_la	= 0x80000000,
+		.kernel_ep	= 0x80000000,
+		.rootfs_ofs	= 0x140000,
+	}, {
 		.id		= "8Mltq",
 		.fw_max_len	= 0x7a0000,
 		.kernel_la	= 0x80002000,


### PR DESCRIPTION
TP-Link TL-WR840N v5 is simple N300 router with
5-port FE switch and non-detachable antennas, based on MediaTek MT7628NN (aka MT7628N) WiSoC.

Specification:

- MT7628N/N (580 MHz)
- 64 MB of RAM (DDR2)
- 4 MB of FLASH
- 2T2R 2.4 GHz
- 5x 10/100 Mbps Ethernet
- 2x external, non-detachable antennas
- UART (J1) header on PCB (115200 8n1)
- 1x LED (GPIO-controlled), 1x button

* LED in TL-WR840N v5 is a dual-color, dual-leads type which isn't
  (fully) supported by the gpio-leds driver. This type of LED requires both
  GPIOs state change at the same time to select a color or turn it off.
  For now, we support/use only the green part of the LED.
 Orange LED is registered so you can later use it for your own purposes.
  
  Flash instruction:
  
  Unlike TL-WR840N v4 flashing through WEB UI works in v5.
  1. Download lede-ramips-mt76x8-tl-wr840n-v5-squashfs-sysupgrade.bin image.
  2. Go to 192.168.0.1
  3. Flash the sysupgrade image through Firmware upgrade section of WEB UI.
  4. Wait until the green LED stops flashing and use the router.

Notes:
TFTP recovery is broken since TP-Link reused bootloader code for v4 and that does not take into account only 4 MB of flash and bricks the device.
So do not use TFTP Recovery or you will have to rewrite SPI flash.
They fixed it in later GPL code, but it is unknown which version of bootloader you have.

After manually compiling and flashing bootloader from GPL sources TFTP recovery works properly.

Signed-off-by: Robert Marko robimarko@gmail.com