### PR TITLE
functions.sh: fix default_postinst function

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -240,7 +240,7 @@ default_postinst() {
 		[ -d /tmp/.uci ] || mkdir -p /tmp/.uci
 		for i in $(sed -ne 's!^/etc/uci-defaults/!!p' "/usr/lib/opkg/info/${pkgname}.list"); do (
 			cd /etc/uci-defaults
-			[ -f "$i" ] && . "$i" && rm -f "$i"
+			[ -f "$i" ] && . ./"$i" && rm -f "$i"
 		) done
 		uci commit
 	fi


### PR DESCRIPTION
When we run "opkg install" on a package that installs an uci-defaults
script, functions.sh will fail to evaluate that script in its
default_postinst function.

This happens because there is no "./" present and it searches for the
file in paths specified by the PATH variable. This would work on bash,
but it will not work on ash and some other shells like sh, zsh. This
applys to the ". filename" directive used in this case.

This patch will make the path relative to the /etc/uci-defaults
directory.

Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>