### PR TITLE
build: add menuconfig options for additional LDFLAGS and CFLAGS

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -1,5 +1,6 @@
 # Copyright (C) 2006-2013 OpenWrt.org
 # Copyright (C) 2016 LEDE Project
+# Copyright (C) 2017 Ian Leonard <antonlacon@gmail.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -172,6 +173,29 @@ menu "Global build settings"
 		config USE_LIBSTDCXX
 			bool "libstdc++"
 	endchoice
+
+	comment "Linker options"
+
+	config PKG_LD_HASH_STYLE_GNU
+		bool
+		prompt "Use the gnu hash style for symbol tables"
+		depends on !mips
+		help
+		  By default, ld produces a sysv style hash table. The gnu style supports
+		  faster program launching.
+
+	config PKG_LD_O1
+		bool
+		prompt "Have linker optimize symbol tables"
+		help
+		  Have ld optimize the symbol look up table for faster startup.
+
+	config PKG_LD_SORT_COMMON
+		bool
+		prompt "Have linker sort the symbol table based on size for alignment"
+		help
+		  This option has ld try to avoid creating gaps within the symbol table due
+		  to alignment constraints, for a more efficient layout.
 
 	comment "Hardening build options"
 

--- a/include/package-flags.mk
+++ b/include/package-flags.mk
@@ -14,6 +14,16 @@ PKG_LD_HASH_STYLE ?= 1
 PKG_LD_O1 ?= 1
 PKG_LD_SORT_COMMON ?= 1
 
+# Graphite Options
+
+GCC_USE_GRAPHITE ?= 1
+
+ifdef CONFIG_GCC_USE_GRAPHITE
+  ifeq ($(strip $(GCC_USE_GRAPHITE)),1)
+    TARGET_CFLAGS += -fgraphite-identity -floop-interchange -floop-strip-mine -floop-block
+  endif
+endif
+
 # Hardening Options
 
 ifdef CONFIG_PKG_CHECK_FORMAT_SECURITY

--- a/include/package-flags.mk
+++ b/include/package-flags.mk
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2017 Ian Leonard <antonlacon@gmail.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,6 +10,11 @@ PKG_CHECK_FORMAT_SECURITY ?= 1
 PKG_SSP ?= 1
 PKG_FORTIFY_SOURCE ?= 1
 PKG_RELRO ?= 1
+PKG_LD_HASH_STYLE ?= 1
+PKG_LD_O1 ?= 1
+PKG_LD_SORT_COMMON ?= 1
+
+# Hardening Options
 
 ifdef CONFIG_PKG_CHECK_FORMAT_SECURITY
   ifeq ($(strip $(PKG_CHECK_FORMAT_SECURITY)),1)
@@ -48,3 +54,23 @@ ifdef CONFIG_PKG_RELRO_FULL
   endif
 endif
 
+# Linker Options
+
+ifdef CONFIG_PKG_LD_HASH_STYLE_GNU
+  ifeq ($(strip $(PKG_LD_HASH_STYLE)),1)
+    TARGET_CFLAGS += -Wl,--hash-style=gnu
+    TARGET_LDFLAGS += -Wl,--hash-style=gnu
+  endif
+endif
+ifdef CONFIG_PKG_LD_O1
+  ifeq ($(strip $(PKG_LD_O1)),1)
+    TARGET_CFLAGS += -Wl,-O1
+    TARGET_LDFLAGS += -Wl,-O1
+  endif
+endif
+ifdef CONFIG_PKG_LD_SORT_COMMON
+  ifeq ($(strip $(PKG_LD_SORT_COMMON)),1)
+    TARGET_CFLAGS += -Wl,--sort-common
+    TARGET_LDFLAGS += -Wl,--sort-common
+  endif
+endif

--- a/include/package.mk
+++ b/include/package.mk
@@ -35,7 +35,7 @@ ifeq ($(strip $(PKG_IREMAP)),1)
   TARGET_CFLAGS += $(IREMAP_CFLAGS)
 endif
 
-include $(INCLUDE_DIR)/hardening.mk
+include $(INCLUDE_DIR)/package-flags.mk
 include $(INCLUDE_DIR)/prereq.mk
 include $(INCLUDE_DIR)/unpack.mk
 include $(INCLUDE_DIR)/depends.mk

--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -28,7 +28,19 @@ endchoice
 
 config GCC_USE_GRAPHITE
 	bool
-	prompt "Compile in support for the new Graphite framework in GCC 4.4+" if TOOLCHAINOPTS
+	prompt "Compile in support for GCC's Graphite framework" if TOOLCHAINOPTS
+
+config GCC_GRAPHITE_FLAGS
+	bool
+	depends on GCC_USE_GRAPHITE
+	prompt "Set CFLAGS to include Graphite options" if TOOLCHAINOPTS
+	default n
+	help
+	    Adds the standard Graphite flags to CFLAGS. Not all packages
+	    will compile with these flags set. Submit a patch or choose N
+	    here if you encounter any problems.
+
+	    GCC 6+ recommended.
 
 config EXTRA_GCC_CONFIG_OPTIONS
 	string


### PR DESCRIPTION
These patches:

Rename include/hardening.mk to include/package-flags.mk. This is to repurpose the file from holding only CFLAGS/LDFLAGS relating to hardening to CFLAGS/LDFLAGS related to package building.

The LDFLAGS choices all relate to speeding up the time between calling a program and that program beginning execution. The -O1 choice should be a candidate for becoming default, as it should compatible with everything, only slightly increasing build time, with no change in file size.

The CFLAGS choice is to add the set of flags for GCC's graphite framework. Not all packages will successfully build with it.

Feedback welcome.