### PR TITLE
kernel: tune e1000e module parameters

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -495,6 +495,9 @@ define KernelPackage/e1000e
   KCONFIG:=CONFIG_E1000E
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/e1000e/e1000e.ko
   AUTOLOAD:=$(call AutoProbe,e1000e)
+  MODPARAMS.e1000e:= \
+    IntMode=1 \
+    InterruptThrottleRate=4,4,4,4,4,4,4,4
 endef
 
 define KernelPackage/e1000e/description


### PR DESCRIPTION
I think I wrote the original version and then @jow- reworked it.  In any case, here it is now that `include/kernel.mk` has been reworked.