### PR TITLE
rules.mk: move `mk` folder into STAGING_DIR_HOSTPKG

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -355,7 +355,7 @@ export $(call shvar,$(1))=$$(call $(1))
 endef
 
 define include_mk
-$(eval -include $(if $(DUMP),,$(STAGING_DIR)/mk/$(strip $(1))))
+$(eval -include $(if $(DUMP),,$(STAGING_DIR_HOSTPKG)/mk/$(strip $(1))))
 endef
 
 # Execute commands under flock


### PR DESCRIPTION
The biggest users of the `include_mk` call are the
Python packages, because Python & Python3 export the
`python(3)-package.mk` (and friends) mk files.

These files get installed via the Host/Install & Build/InstallDev
rules. The reason for this, is that some packages have `python/host`
and others have `python` in their PKG_BUILD_DEPENDS.

For packages that just need `PKG_BUILD_DEPENDS:=python/host`
[ well, most would work with just this setting ],
* the mk files get installed on the first run via `make` on a clean checkout
* then, run `make clean`
* then, `make` again would fail, because the Host/Install rule does not
  run [ because it's cached ], and the Build/InstallDev would not
  also run, because it's `python/host`

The fix would be to change `PKG_BUILD_DEPENDS:=python/host` to
`PKG_BUILD_DEPENDS:=python` but that just increases build time
because it would build both Python host and Python for the target.
When all that's needed is Python host.

The mk files [that Python needs/installs] can be moved
to `$(STAGING_DIR_HOSTPKG)/mk`. Since they are `mk` files
they don't need to be installed per-target folder
[i.e. $(STAGING_DIR)/mk ].

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>