### PR TITLE
lantiq: add missing macaddr retrieval for Netgear DGN3500

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -116,6 +116,8 @@ DGN1000B)
 	;;
 
 DGN3500*)
+	lan_mac=$(mtd_get_mac_ascii uboot-env ethaddr)
+	wan_mac=$(macaddr_add "$lan_mac" 1)
 	ucidef_add_switch "switch0" \
 		"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5t@eth0"
 	;;


### PR DESCRIPTION
The MAC addresses were not being set for LAN and WAN. This will now use the
same MAC mechanism as the rest of the target.

Signed-off-by: Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>