### PR TITLE
libnl-tiny: export version

### DIFF
--- a/package/libs/libnl-tiny/src/Makefile
+++ b/package/libs/libnl-tiny/src/Makefile
@@ -10,7 +10,7 @@ all: $(LIBNAME)
 %.o: %.c
 	$(CC) $(WFLAGS) -c -o $@ $(INCLUDES) $(CFLAGS) $<
 
-LIBNL_OBJ=nl.o handlers.o msg.o attr.o cache.o cache_mngt.o object.o socket.o error.o
+LIBNL_OBJ=nl.o handlers.o msg.o attr.o cache.o cache_mngt.o object.o socket.o error.o version.o
 GENL_OBJ=genl.o genl_family.o genl_ctrl.o genl_mngt.o unl.o
 
 $(LIBNAME): $(LIBNL_OBJ) $(GENL_OBJ)

--- a/package/libs/libnl-tiny/src/include/netlink/version.h
+++ b/package/libs/libnl-tiny/src/include/netlink/version.h
@@ -15,4 +15,16 @@
 #define LIBNL_STRING "libnl"
 #define LIBNL_VERSION "2.0"
 
+#define LIBNL_VER_NUM ((LIBNL_VER_MAJ) << 16 | (LIBNL_VER_MIN) << 8 | (LIBNL_VER_MIC))
+#define LIBNL_VER_MAJ 2
+#define LIBNL_VER_MIN 0
+#define LIBNL_VER_MIC 0
+
+/* Run-time version information */
+
+extern const int        nl_ver_num;
+extern const int        nl_ver_maj;
+extern const int        nl_ver_min;
+extern const int        nl_ver_mic;
+
 #endif

--- a/package/libs/libnl-tiny/src/version.c
+++ b/package/libs/libnl-tiny/src/version.c
@@ -1,0 +1,36 @@
+/*
+ * lib/version.c	Run-time version information
+ *
+ *	This library is free software; you can redistribute it and/or
+ *	modify it under the terms of the GNU Lesser General Public
+ *	License as published by the Free Software Foundation version 2.1
+ *	of the License.
+ *
+ * Copyright (c) 2003-2012 Thomas Graf <tgraf@suug.ch>
+ */
+
+/**
+ * @ingroup core
+ * @defgroup utils Utilities
+ *
+ * Run-time version information
+ *
+ * @{
+ */
+
+
+/**
+ * @name Run-time version information
+ * @{
+ */
+
+#include <netlink/version.h>
+
+const int      nl_ver_num = LIBNL_VER_NUM;
+const int      nl_ver_maj = LIBNL_VER_MAJ;
+const int      nl_ver_min = LIBNL_VER_MIN;
+const int      nl_ver_mic = LIBNL_VER_MIC;
+
+/** @} */
+
+/** @} */


### PR DESCRIPTION
The different versions of libnl contain different functionalities and APIs. It is necessary to know the version of the library to determine what API and what functionalities are available.

Signed-off-by: Enrique Giraldo <enrique.giraldo@galgus.net>