### PR TITLE
openssl: update to 1.0.2m

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.0.2
-PKG_BUGFIX:=l
+PKG_BUGFIX:=m
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
 PKG_BUILD_PARALLEL:=0
@@ -24,7 +24,7 @@ PKG_SOURCE_URL:= \
 	http://gd.tuwien.ac.at/infosys/security/openssl/source/ \
 	http://www.openssl.org/source/ \
 	http://www.openssl.org/source/old/$(PKG_BASE)/
-PKG_HASH:=ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c
+PKG_HASH:=8c6ff15ec6b319b50788f42c7abc2890c08ba5a1cdcd3810eb9092deada37b0f
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE
@@ -121,7 +121,7 @@ ifndef CONFIG_OPENSSL_WITH_EC2M
 endif
 
 ifndef CONFIG_OPENSSL_WITH_SSL3
-  OPENSSL_OPTIONS += no-ssl3 no-ssl3-method
+  OPENSSL_OPTIONS += no-ssl3
 endif
 
 ifndef CONFIG_OPENSSL_HARDWARE_SUPPORT

--- a/package/libs/openssl/patches/150-no_engines.patch
+++ b/package/libs/openssl/patches/150-no_engines.patch
@@ -1,6 +1,6 @@
 --- a/Configure
 +++ b/Configure
-@@ -2129,6 +2129,11 @@ EOF
+@@ -2130,6 +2130,11 @@ EOF
  	close(OUT);
    }
    


### PR DESCRIPTION
don't set no-ssl3-method when CONFIG_OPENSSL_WITH_SSL3 is disabled otherwise the compile breaks with this error:

../libssl.so: undefined reference to `SSLv3_client_method'

Fixes CVE: CVE-2017-3735, CVE-2017-3736

Signed-off-by: Peter Wagner <tripolar@gmx.at>