### PR TITLE
ar71xx: Complete support for RB mAP 2nD

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -320,6 +320,12 @@ rb-lhg-5nd)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "rb:green:rssi3" "wlan0" "60" "100" "-59" "13"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "rb:green:rssi4" "wlan0" "80" "100" "-79" "13"
 	;;
+rb-map-2nd)
+	ucidef_set_led_switch "eth1" "WAN" "rb:green:eth1" "switch0" "0x02"
+	ucidef_set_led_switch "eth2" "LAN" "rb:green:eth2" "switch0" "0x04"
+	ucidef_set_led_gpio "poe" "POE" "rb:red:poe_out" "14" "0"
+	ucidef_set_led_wlan "wlan" "WLAN" "rb:green:wlan" "phy0tpt"
+	;;
 rb-mapl-2nd)
 	ucidef_set_led_default "power" "POWER" "rb:green:power" "1"
 	ucidef_set_led_netdev "lan" "LAN" "rb:green:eth" "eth0"

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -415,6 +415,10 @@ ar71xx_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
 		;;
+	rb-map-2nd)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:wan" "2:lan"
+		;;
 	tellstick-znet-lite)
 		ucidef_set_interface_wan "eth0"
 		ucidef_set_interface_raw "wlan" "wlan0" "dhcp"

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -319,6 +319,7 @@ get_status_led() {
 	rb-952ui-5ac2nd|\
 	rb-962uigs-5hact2hnt|\
 	rb-lhg-5nd|\
+	rb-map-2nd|\
 	rb-mapl-2nd)
 		status_led="rb:green:user"
 		;;

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -962,6 +962,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD LHG 5nD")
 		name="rb-lhg-5nd"
 		;;
+	*"RouterBOARD mAP 2nD")
+		name="rb-map-2nd"
+		;;
 	*"RouterBOARD mAP L-2nD")
 		name="rb-mapl-2nd"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -664,6 +664,7 @@ platform_check_image() {
 	rb-952ui-5ac2nd|\
 	rb-962uigs-5hact2hnt|\
 	rb-lhg-5nd|\
+	rb-map-2nd|\
 	rb-mapl-2nd)
 		return 0
 		;;
@@ -723,6 +724,7 @@ platform_pre_upgrade() {
 	rb-952ui-5ac2nd|\
 	rb-962uigs-5hact2hnt|\
 	rb-lhg-5nd|\
+	rb-map-2nd|\
 	rb-mapl-2nd)
 		# erase firmware if booted from initramfs
 		[ -z "$(rootfs_type)" ] && mtd erase firmware

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -1012,6 +1012,7 @@ config ATH79_MACH_RBSPI
 	select ATH79_ROUTERBOOT
 	help
 	  Say 'Y' here if you want your kernel to support the
+	  MikroTik RouterBOARD mAP
 	  MikroTik RouterBOARD mAP lite
 	  MikroTik RouterBOARD hAP lite
 	  MikroTik RouterBOARD hAP
@@ -1022,7 +1023,6 @@ config ATH79_MACH_RBSPI
 	  MikroTik RouterBOARD Powerbox
 	  MikroTik RouterBOARD LHG 5
 	  MikroTik RouterBOARD cAP (EXPERIMENTAL)
-	  MikroTik RouterBOARD mAP (EXPERIMENTAL)
 	  MikroTik RouterBOARD wAP (EXPERIMENTAL)
 
 config ATH79_MACH_RBSXTLITE

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -1,6 +1,7 @@
 /*
  *  MikroTik SPI-NOR RouterBOARDs support
  *
+ *  - MikroTik RouterBOARD mAP 2nD
  *  - MikroTik RouterBOARD mAP L-2nD
  *  - MikroTik RouterBOARD 941L-2nD
  *  - MikroTik RouterBOARD 951Ui-2nD
@@ -14,7 +15,6 @@
  *  Preliminary support for the following hardware
  *  - MikroTik RouterBOARD wAP2nD
  *  - MikroTik RouterBOARD cAP2nD
- *  - MikroTik RouterBOARD mAP2nD
  *  Furthermore, the cAP lite (cAPL2nD) appears to feature the exact same
  *  hardware as the mAP L-2nD. It is unknown if they share the same board
  *  identifier.
@@ -405,7 +405,7 @@ static struct gpio_led rbmap_leds[] __initdata = {
 		.active_low = 1,
 	}, {
 		.name = "rb:green:eth2",
-		.gpio = RBMAP_GPIO_LED_WLAN,
+		.gpio = RBMAP_GPIO_LED_LAN2,
 		.active_low = 1,
 	}, {
 		.name = "rb:red:poe_out",
@@ -915,13 +915,14 @@ static void __init rbcap_setup(void)
 }
 
 /*
- * Init the mAP hardware (EXPERIMENTAL).
- * The mAP 2nD has two ethernet ports, PoE output and an SSR for LED
- * multiplexing.
+ * Init the mAP hardware.
+ * The mAP 2nD has two ethernet ports, PoE output, SSR for LED
+ * multiplexing and USB port.
  */
 static void __init rbmap_setup(void)
 {
-	u32 flags = RBSPI_HAS_WLAN0 | RBSPI_HAS_SSR | RBSPI_HAS_POE;
+	u32 flags = RBSPI_HAS_USB | RBSPI_HAS_WLAN0 |
+			RBSPI_HAS_SSR | RBSPI_HAS_POE;
 
 	if (rbspi_platform_setup())
 		return;
@@ -934,10 +935,22 @@ static void __init rbmap_setup(void)
 
 	if (flags & RBSPI_HAS_POE)
 		gpio_request_one(RBMAP_GPIO_POE_POWER,
-				GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
+				GPIOF_OUT_INIT_LOW | GPIOF_EXPORT_DIR_FIXED,
 				"POE power");
 
+	/* USB power GPIO is inverted, set GPIOF_ACTIVE_LOW for consistency */
+	if (flags & RBSPI_HAS_USB)
+		gpio_request_one(RBMAP_GPIO_USB_POWER,
+				GPIOF_OUT_INIT_HIGH | GPIOF_ACTIVE_LOW |
+					GPIOF_EXPORT_DIR_FIXED,
+				"USB power");
+
 	ath79_register_leds_gpio(-1, ARRAY_SIZE(rbmap_leds), rbmap_leds);
+
+	/* mAP 2nD has a single reset button as gpio 16 */
+	ath79_register_gpio_keys_polled(-1, RBSPI_KEYS_POLL_INTERVAL,
+					ARRAY_SIZE(rbspi_gpio_keys_reset16),
+					rbspi_gpio_keys_reset16);
 }
 
 

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -25,12 +25,12 @@ TARGET_DEVICES += nand-64m nand-large
 
 define Device/rb-nor-flash-16M
   DEVICE_TITLE := MikroTik RouterBoard (16 MB SPI NOR)
-  DEVICE_PACKAGES := rbcfg rssileds -nand-utils
+  DEVICE_PACKAGES := rbcfg rssileds -nand-utils kmod-ledtrig-gpio
   IMAGE_SIZE := 16000k
   LOADER_TYPE := elf
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin | lzma | loader-kernel
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-mapl-2nd
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-map-2nd rb-mapl-2nd
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef

--- a/target/linux/ar71xx/patches-4.9/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.9/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,27 @@ void __init prom_init(void)
+@@ -136,6 +136,28 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -20,6 +20,7 @@
 +	    strstr(arcs_cmdline, "board=962") ||
 +	    strstr(arcs_cmdline, "board=lhg") ||
 +	    strstr(arcs_cmdline, "board=map-hb") ||
++	    strstr(arcs_cmdline, "board=map2-hb") ||
 +	    strstr(arcs_cmdline, "board=2011L") ||
 +	    strstr(arcs_cmdline, "board=2011r") ||
 +	    strstr(arcs_cmdline, "board=711Gr100") ||


### PR DESCRIPTION
This patch adds support for the MikroTik RouterBOARD mAP 2nD
https://mikrotik.com/product/RBmAP2nD

Specifications:

SoC: Qualcomm QCA9531(650MHz)
RAM: 64MB
Storage: 16MB NOR SPI flash
Wireless: builtin QCA9531, 2x2:2
Ethernet: 2x100M (802.3af/at POE IN and Passive POE out on ETH2)
USB: microUSB type AB port
This patch adds missing code to fully support mAP.
Machfile already contained configuration for mAP 2nD but device-specific configuration like LEDs etc was missing.

Note: The POE LED works but doesn't turn on when POE passthrough is enabled, despite being configured with GPIO trigger.

Installation

login to the Mikrotik WebUI to backup your license keys
set up a DHCP/BOOTP Server with:
DHCP-Option 66 (TFTP server name) pointing to a local TFTP
Server within the same subnet of the DHCP range
DHCP-Option 67 (Bootfile-Name) matching the initramfs file name
of the to be booted image
connect the port labeled internet to your local network
keep the reset button pushed down and power on the board
The board should load and start the initramfs image from the TFTP
Server. Login as root/without a password to the started LEDE via ssh
listing on IPv4 address 192.168.1.1. Use sysupgrade to install LEDE.

Revert to RouterOS

Use the "rbcfg" package on in LEDE:

rbcfg set boot_protocol bootp
rbcfg set boot_device ethnand
rbcfg apply
Open Netinstall and reboot routerboard. Now, netinstall sees routerboard
and you can install RouterOS. If NetInstall gets stuck on Sending offer
just wait for it to timeout and then close and open Netinstall again.

Click on install again.

In order for RouterOS to function properly, you need to restore license
for the device. You can do that by including license in NetInstall

Signed-off-by: Robert Marko robimarko@gmail.com