### PR TITLE
Get IO Edgeport USB serial firmware from linux-firmware repo instead of kernel

### DIFF
--- a/package/firmware/linux-firmware/edgeport.mk
+++ b/package/firmware/linux-firmware/edgeport.mk
@@ -1,0 +1,12 @@
+Package/edgeport-firmware = $(call Package/firmware-default,USB Inside Out Edgeport Serial Driver firmware)
+define Package/edgeport-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/edgeport
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/edgeport/boot.fw \
+		$(PKG_BUILD_DIR)/edgeport/boot2.fw \
+		$(PKG_BUILD_DIR)/edgeport/down.fw \
+		$(PKG_BUILD_DIR)/edgeport/down2.fw \
+		$(1)/lib/firmware/edgeport
+endef
+
+$(eval $(call BuildPackage,edgeport-firmware))

--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -509,6 +509,7 @@ define KernelPackage/usb-serial-edgeport
   FILES:=$(LINUX_DIR)/drivers/usb/serial/io_edgeport.ko
   AUTOLOAD:=$(call AutoProbe,io_edgeport)
   $(call AddDepends/usb-serial)
+  DEPENDS+=+edgeport-firmware
 endef
 
 define KernelPackage/usb-serial-edgeport/description
@@ -529,14 +530,6 @@ define KernelPackage/usb-serial-edgeport/description
 	Edgeport/2 DIN
 	Edgeport/4 DIN
 	Edgeport/16 Dual
-endef
-
-define KernelPackage/usb-serial-edgeport/install
-	$(INSTALL_DIR) $(1)/lib/firmware/edgeport
-	$(INSTALL_DATA) $(LINUX_DIR)/firmware/edgeport/boot.fw $(1)/lib/firmware/edgeport/
-	$(INSTALL_DATA) $(LINUX_DIR)/firmware/edgeport/boot2.fw $(1)/lib/firmware/edgeport/
-	$(INSTALL_DATA) $(LINUX_DIR)/firmware/edgeport/down.fw $(1)/lib/firmware/edgeport/
-	$(INSTALL_DATA) $(LINUX_DIR)/firmware/edgeport/down2.fw $(1)/lib/firmware/edgeport/
 endef
 
 $(eval $(call KernelPackage,usb-serial-edgeport))


### PR DESCRIPTION
The in-kernel firmware is going away with Linux v4.14. There is no need to wait until the last minute preparing for that.  The edgeport firmware files in the kernel and in the linux-firmware repo are identical, so this is merely a packaging change.  There is no change to the installed firmware.
