### PR TITLE
TP-Link splitters: code cleanup and improvement

### DIFF
--- a/target/linux/ar71xx/files/drivers/mtd/tplinkpart.c
+++ b/target/linux/ar71xx/files/drivers/mtd/tplinkpart.c
@@ -18,8 +18,8 @@
 #include <linux/version.h>
 
 #define TPLINK_NUM_PARTS	5
-#define TPLINK_HEADER_V1	0x01000000
-#define TPLINK_HEADER_V2	0x02000000
+#define TPLINK_HEADER_V1	1
+#define TPLINK_HEADER_V2	2
 #define MD5SUM_LEN		16
 
 #define TPLINK_ART_LEN		0x10000
@@ -72,7 +72,7 @@ tplink_read_header(struct mtd_info *mtd, size_t offset)
 		goto err_free_header;
 
 	/* sanity checks */
-	t = be32_to_cpu(header->version);
+	t = le32_to_cpu(header->version);
 	if ((t != TPLINK_HEADER_V1) && (t != TPLINK_HEADER_V2))
 		goto err_free_header;
 

--- a/target/linux/ar71xx/files/drivers/mtd/tplinkpart.c
+++ b/target/linux/ar71xx/files/drivers/mtd/tplinkpart.c
@@ -76,10 +76,6 @@ tplink_read_header(struct mtd_info *mtd, size_t offset)
 	if ((t != TPLINK_HEADER_V1) && (t != TPLINK_HEADER_V2))
 		goto err_free_header;
 
-	t = be32_to_cpu(header->kernel_ofs);
-	if (t != header_len)
-		goto err_free_header;
-
 	return header;
 
 err_free_header:
@@ -122,8 +118,9 @@ static int tplink_parse_partitions_offset(struct mtd_info *master,
 	struct tplink_fw_header *header;
 	int nr_parts;
 	size_t art_offset;
-	size_t rootfs_offset;
+	size_t rootfs_offset, rootfs_size;
 	size_t squashfs_offset;
+	size_t kernel_offset, kernel_size;
 	int ret;
 
 	nr_parts = TPLINK_NUM_PARTS;
@@ -149,6 +146,15 @@ static int tplink_parse_partitions_offset(struct mtd_info *master,
 	else
 		rootfs_offset = offset + be32_to_cpu(header->rootfs_ofs);
 
+	rootfs_size = be32_to_cpu(header->rootfs_len);
+	kernel_offset = offset + be32_to_cpu(header->kernel_ofs);
+	kernel_size = be32_to_cpu(header->kernel_len);
+
+	if ((kernel_size + rootfs_size) > master->size) {
+		ret = -EINVAL;
+		goto err_free_parts;
+	}
+
 	art_offset = master->size - TPLINK_ART_LEN;
 
 	parts[0].name = "u-boot";
@@ -157,8 +163,8 @@ static int tplink_parse_partitions_offset(struct mtd_info *master,
 	parts[0].mask_flags = MTD_WRITEABLE;
 
 	parts[1].name = "kernel";
-	parts[1].offset = offset;
-	parts[1].size = rootfs_offset - offset;
+	parts[1].offset = kernel_offset;
+	parts[1].size = kernel_size;
 
 	parts[2].name = "rootfs";
 	parts[2].offset = rootfs_offset;

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_tplink.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_tplink.c
@@ -90,8 +90,8 @@ static int mtdsplit_parse_tplink(struct mtd_info *master,
 				 struct mtd_part_parser_data *data)
 {
 	struct tplink_fw_header hdr;
-	size_t hdr_len, retlen, kernel_size;
-	size_t rootfs_offset;
+	size_t hdr_len, retlen, kernel_size, rootfs_size;
+	size_t kernel_offset, rootfs_offset;
 	struct mtd_partition *parts;
 	int err;
 
@@ -105,25 +105,24 @@ static int mtdsplit_parse_tplink(struct mtd_info *master,
 
 	switch (le32_to_cpu(hdr.version)) {
 	case 1:
-		if (be32_to_cpu(hdr.v1.kernel_ofs) != sizeof(hdr))
-			return -EINVAL;
-
-		kernel_size = sizeof(hdr) + be32_to_cpu(hdr.v1.kernel_len);
+		kernel_offset = be32_to_cpu(hdr.v1.kernel_ofs);
+		kernel_size = be32_to_cpu(hdr.v1.kernel_len);
 		rootfs_offset = be32_to_cpu(hdr.v1.rootfs_ofs);
+		rootfs_size = be32_to_cpu(hdr.v1.rootfs_len);
 		break;
 	case 2:
 	case 3:
-		if (be32_to_cpu(hdr.v2.kernel_ofs) != sizeof(hdr))
-			return -EINVAL;
-
-		kernel_size = sizeof(hdr) + be32_to_cpu(hdr.v2.kernel_len);
+		kernel_offset = be32_to_cpu(hdr.v2.kernel_ofs);
+		kernel_size = be32_to_cpu(hdr.v2.kernel_len);
 		rootfs_offset = be32_to_cpu(hdr.v2.rootfs_ofs);
+		rootfs_size = be32_to_cpu(hdr.v2.rootfs_len);
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	if (kernel_size > master->size)
+	/* minimal sanity check */
+	if ((kernel_size + rootfs_size) > master->size)
 		return -EINVAL;
 
 	/* Find the rootfs */
@@ -144,7 +143,7 @@ static int mtdsplit_parse_tplink(struct mtd_info *master,
 		return -ENOMEM;
 
 	parts[0].name = KERNEL_PART_NAME;
-	parts[0].offset = 0;
+	parts[0].offset = kernel_offset;
 	parts[0].size = kernel_size;
 
 	parts[1].name = ROOTFS_PART_NAME;

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_tplink.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_tplink.c
@@ -28,7 +28,7 @@ struct fw_v1 {
 	char		fw_version[36];
 	uint32_t	hw_id;		/* hardware id */
 	uint32_t	hw_rev;		/* hardware revision */
-	uint32_t	unk1;
+	uint32_t	region_code;	/* region code */
 	uint8_t		md5sum1[MD5SUM_LEN];
 	uint32_t	unk2;
 	uint8_t		md5sum2[MD5SUM_LEN];
@@ -42,14 +42,17 @@ struct fw_v1 {
 	uint32_t	rootfs_len;	/* rootfs data length */
 	uint32_t	boot_ofs;	/* bootloader data offset */
 	uint32_t	boot_len;	/* bootloader data length */
-	uint8_t		pad[360];
+	uint16_t	ver_hi;
+	uint16_t	ver_mid;
+	uint16_t	ver_lo;
+	uint8_t		pad[354];
 } __attribute__ ((packed));
 
 struct fw_v2 {
 	char		fw_version[48]; /* 0x04: fw version string */
 	uint32_t	hw_id;		/* 0x34: hardware id */
 	uint32_t	hw_rev;		/* 0x38: FIXME: hardware revision? */
-	uint32_t	unk1;	        /* 0x3c: 0x00000000 */
+	uint32_t	hw_rev_add;     /* 0x3c: additional hardware version */
 	uint8_t		md5sum1[MD5SUM_LEN]; /* 0x40 */
 	uint32_t	unk2;		/* 0x50: 0x00000000 */
 	uint8_t		md5sum2[MD5SUM_LEN]; /* 0x54 */


### PR DESCRIPTION
These patches clean up the TP-Link splitters by:

- correctly placing the kernel partition at the beginning of the LZMA compressed kernel (skipping the TP-Link header data)
- adding an extra sanity check on the parsed header data
- removing the assertion that the kernel is at a fixed position

Before these patches the splitters would include the TP-Link header at the beginning of the kernel partition, when the actual kernel is 0x200 bytes further (currently all TP-Link images place the kernel immediately after the header, which is 0x200 bytes long).

These patches make it possible to dump valid LZMA data from the kernel partition without further processing.
They align the behavior of these splitters with that of e.g. the trx, seama or fit ones.
If it later becomes possible/desirable to support a different kernel offset, these patches also make the splitters future-proof.

The changes are mostly cosmetic and shouldn't break any of the existing setups but testing is advised.