### PR TITLE
hostapd: don't configure unsupported htmode for wpa_supplicant

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -769,8 +769,6 @@ wpa_supplicant_add_network() {
 		append network_data "mcast_rate=$mc_rate" "$N$T"
 	}
 
-	local ht_str
-
 	cat >> "$_config" <<EOF
 network={
 	$scan_ssid

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -770,8 +770,6 @@ wpa_supplicant_add_network() {
 	}
 
 	local ht_str
-	[[ "$_w_mode" = adhoc ]] || ibss_htmode=
-	[ -n "$ibss_htmode" ] && append network_data "htmode=$ibss_htmode" "$N$T"
 
 	cat >> "$_config" <<EOF
 network={


### PR DESCRIPTION
Hi :-)

```$ uci show wireless.radio0
wireless.radio0=wifi-device
wireless.radio0.type='mac80211'
wireless.radio0.channel='11'
wireless.radio0.hwmode='11g'
wireless.radio0.path='platform/qca953x_wmac'
wireless.radio0.htmode='HT20'

$ uci show wireless.mesh0
wireless.mesh0=wifi-iface
wireless.mesh0.ifname='w-mesh0'
wireless.mesh0.device='radio0'
wireless.mesh0.network='mesh'
wireless.mesh0.mode='adhoc'
wireless.mesh0.encryption='psk2'
wireless.mesh0.ssid='mesh'
wireless.mesh0.bssid='02:BA:CC:22:33:66'
wireless.mesh0.disabled='0'
wireless.mesh0.key='batmesh123'
```
->
```
$ cat /var/run/wpa_supplicant-w-mesh0.conf
ap_scan=2

network={
        scan_ssid=0
        ssid="mesh"
        key_mgmt=WPA-PSK
        mode=1
        fixed_freq=1
        frequency=2462
        disable_ht40=1
        max_oper_chwidth=0
        mode=1
        psk="batmesh123"
        proto=RSN
        bssid=02:BA:CC:11:55:90
        beacon_int=100
        htmode=HT20
}
```

the log entries from netifd
```
Mon Nov 20 10:41:39 2017 daemon.notice netifd: radio0 (14880): Line 17: unknown network field 'htmode'.
Mon Nov 20 10:41:40 2017 daemon.notice netifd: radio0 (14880): Line 18: failed to parse network block.
```
are generated by wpa_supplicant
```
$ wpa_supplicant -i w-mesh0 -c /var/run/wpa_supplicant-w-mesh0.conf
Successfully initialized wpa_supplicant
Line 17: unknown network field 'htmode'.
Line 18: failed to parse network block.
Failed to read or parse configuration '/var/run/wpa_supplicant-w-mesh0.conf'.
```