### PR TITLE
dropbear: disable MD5 HMAC and switch to sha1 fingerprints

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2017.75
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \

--- a/package/network/services/dropbear/patches/120-openwrt_options.patch
+++ b/package/network/services/dropbear/patches/120-openwrt_options.patch
@@ -39,7 +39,7 @@
  
  /* Enable "Counter Mode" for ciphers. This is more secure than normal
   * CBC mode against certain attacks. It is recommended for security
-@@ -131,9 +131,9 @@ If you test it please contact the Dropbe
+@@ -131,10 +131,10 @@ If you test it please contact the Dropbe
   * If you disable MD5, Dropbear will fall back to SHA1 fingerprints,
   * which are not the standard form. */
  #define DROPBEAR_SHA1_HMAC
@@ -47,10 +47,12 @@
 +/*#define DROPBEAR_SHA1_96_HMAC*/
  #define DROPBEAR_SHA2_256_HMAC
 -#define DROPBEAR_SHA2_512_HMAC
+-#define DROPBEAR_MD5_HMAC
 +/*#define DROPBEAR_SHA2_512_HMAC*/
- #define DROPBEAR_MD5_HMAC
++/*#define DROPBEAR_MD5_HMAC*/
  
  /* You can also disable integrity. Don't bother disabling this if you're
+  * still using a cipher, it's relatively cheap. If you disable this it's dead
 @@ -146,7 +146,7 @@ If you test it please contact the Dropbe
   * Removing either of these won't save very much space.
   * SSH2 RFC Draft requires dss, recommends rsa */


### PR DESCRIPTION
As MD5 is known weak for many years and more and more
penetration test tools complain about enabled MD5 HMAC
I think it's time to drop it.

By disabling the MD5 HMAC support dropbear  will also
automatically use SHA1 for fingerprints.
This shouldn't be a problem too.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
