### PR TITLE
ramips: add support for Vonets VAR11N-300

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -381,6 +381,9 @@ u7628-01-128M-16M)
 	set_usb_led "u7628-01:green:usb"
 	set_wifi_led "u7628-01:green:wlan"
 	;;
+var11n-300)
+	ucidef_set_led_default "power" "power" "$board:blue:system" "1"
+	;;
 vocore-8M|\
 vocore-16M)
 	ucidef_set_led_netdev "eth" "ETH" "vocore:orange:eth" "eth0"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -313,6 +313,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
 		;;
+	var11n-300)
+		ucidef_add_switch "switch0" \
+			"0:lan" "4:wan" "6@eth0"
+		;;
 	vocore2|\
 	vocore2lite)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -159,7 +159,8 @@ get_status_led() {
 	jhr-n805r|\
 	jhr-n926r|\
 	mlw221|\
-	mlwg2)
+	mlwg2|\
+	var11n-300)
 		status_led="$board:blue:system"
 		;;
 	hc5962)

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -535,6 +535,9 @@ ramips_board_detect() {
 	*"V22RW-2X2")
 		name="v22rw-2x2"
 		;;
+	*"VAR11N-300")
+		name="var11n-300"
+		;;
 	*"VoCore (8M)")
 		name="vocore-8M"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -150,6 +150,7 @@ platform_check_image() {
 	ur-326n4g|\
 	ur-336un|\
 	v22rw-2x2|\
+	var11n-300|\
 	vocore-8M|\
 	vocore-16M|\
 	vocore2|\

--- a/target/linux/ramips/dts/VAR11N-300.dts
+++ b/target/linux/ramips/dts/VAR11N-300.dts
@@ -1,0 +1,90 @@
+/dts-v1/;
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "vonets,var11n-300", "ralink,mt7620n-soc";
+	model = "Vonets VAR11N-300";
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		system {
+			label = "var11n-300:blue:system";
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x3b0000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+	mediatek,portmap = "llllw";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "i2c";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -412,6 +412,14 @@ define Device/tiny-ac
 endef
 TARGET_DEVICES += tiny-ac
 
+define Device/var11n-300
+  DTS := VAR11N-300
+  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  BLOCKSIZE := 4k
+  DEVICE_TITLE := Vonets VAR11N-300
+endef
+TARGET_DEVICES += var11n-300
+
 define Device/whr-1166d
   DTS := WHR-1166D
   IMAGE_SIZE := 15040k


### PR DESCRIPTION
The VAR11N-300 is a tiny wireless-N device with a hardwired Ethernet cable, one extra Ethernet port, and an internal antenna, based on the MediaTek MT7620n chipset.

Specs:
- MT7620n WiSoC @ 600MHz
- 32 MB SDRAM
- 4 MB SPI flash
- 2T2R 2.4GHz WiFi-N
- 1 attached 10/100 Ethernet cable (LAN)
- 1 10/100 Ethernet port (WAN)
- 1 attached USB / barrel 5vdc power cable
- 5 LEDs (see notes below)
- 1 reset button
- 1 UART (3 pads on board)

Installation:

The stock firmware does not support uploading new firmware directly, only checking the manufacturer's site for updates.  This process may be possible to spoof, but the update check uses some kind of homebrew encryption that I didn't investigate.  Instead, you can install via a backdoor:

1. Set up a TFTP server to serve the firmware binary (lede-ramips-mt7620-var11n-300-squashfs-sysupgrade.bin)
2. Factory reset the device by holding the reset button for a few seconds.
3. Open the web interface (default IP: 192.168.253.254)
4. Log in with the "super admin" credentials: username `vonets`, password `vonets26642519`.
5. On the "Operative Status" page, click the text "System Uptime", then quickly click the uptime value.
6. If successful, an alert dialog will appear reading "Ated start", and the device will now accept telnet connections.  If the alert does not appear, repeat step 5 until it works (the timing is a bit tricky).
7. Telnet to the device using credentials "admin / admin"
8. Retrieve the firmware binary from the tftp server: `tftp -l lede.bin -r lede-ramips-mt7620-var11n-300-squashfs-sysupgrade.bin -g <tftp-server-ip>`
9. Write the firmware to flash: `mtd_write write lede.bin /dev/mtd4` 
10. Reboot

Tested:
- LAN / WAN ethernet
- WiFi
- LAN / WAN / status LED GPIOs (see notes below)
- Reset button
- Sysupgrade

Notes:

LEDs:

The board has 5 LEDs - two green LEDs for LAN / WAN activity, one blue LED for WiFi, and a pair of "status" LEDs connected to the same GPIO (the blue LED lights when the GPIO is low, and the green when it's high).  I was unable to determine how to operate the WiFi LED, as it does not appear to be controlled by a GPIO directly.

Recovery:

The default U-boot installation will only boot from flash due to a missing environment block.  I generated a valid 4KB env block using U-boot's `fw_setenv` tool and wrote it to flash at 0x30000 using an
external programmer.  After this, it was possible to enter the U-boot commandline interface and download a new image via TFTP (`tftpboot 81b00000 <image-filename>`), but while I could boot this image sucessfully (`bootm`), writing it to flash (`cp.linux`) just corrupted the flash chip.  The sysupgrade file can be written to flash at 0x50000 using an external programmer.

Signed-off-by: Andrew Crawley <acrawley@gmail.com>