### PR TITLE
ar71xx: fix lan ports on ens202ext

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -176,6 +176,7 @@ ar71xx_setup_interfaces()
 	all0315n|\
 	dlan-hotspot|\
 	dlan-pro-500-wp|\
+	ens202ext|\
 	ja76pf2|\
 	rocket-m-ti|\
 	ubnt-unifi-outdoor)


### PR DESCRIPTION
Fixes FS#1084

May require a factory reset, it did in my case after a fresh install from factory.img
from stock firmware.

Signed-off-by: Marty E. Plummer <hanetzer@protonmail.com>