### PR TITLE
ramips: add missing reset button for Nexx WT1520

### DIFF
--- a/target/linux/ramips/dts/WT1520.dtsi
+++ b/target/linux/ramips/dts/WT1520.dtsi
@@ -1,5 +1,8 @@
 #include "rt5350.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
 / {
 	compatible = "nexx,wt1520", "ralink,rt5350-soc";
 
@@ -8,21 +11,24 @@
 		reg = <0x0 0x2000000>;
 	};
 
-	chosen {
-		bootargs = "console=ttyS1,57600";
-	};
-};
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
 
-&uart {
-	pinctrl-names = "default";
-	pinctrl-0 = <&uartf_pins>;
-	status = "okay";
+		reset {
+			label = "reset";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
 };
 
 &pinctrl {
 	state_default: pinctrl0 {
 		gpio {
-			ralink,group = "jtag";
+			ralink,group = "jtag", "uartf";
 			ralink,function = "gpio";
 		};
 	};


### PR DESCRIPTION
This commit adds missing the GPIO key used as reset button.
Nexx WT1520 has a GPIO key for factory reset, but it's not defined in
WT1520.dtsi and cannot use it.

GPIO10: reset button

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>

Compile tested: WT1520 (4M)
Run tested: WT1520 (4M)