### PR TITLE
build: accept gcc/g++ without minor version

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -28,8 +28,8 @@ $(eval $(call TestHostCommand,proper-umask, \
 
 $(eval $(call SetupHostCommand,gcc, \
 	Please install the GNU C Compiler (gcc) 4.8 or later \
-	$(CC) -dumpversion | grep -E '(4\.[8-9]|5\.[0-9]|6\.[0-9]|7\.[0-9])', \
-	gcc -dumpversion | grep -E '(4\.[8-9]|5\.[0-9]|6\.[0-9]|7\.[0-9])', \
+	$(CC) -dumpversion | grep -E '(4\.[8-9]|5\.?[0-9]?|6\.?[0-9]?|7\.?[0-9]?)', \
+	gcc -dumpversion | grep -E '(4\.[8-9]|5\.?[0-9]?|6\.?[0-9]?|7\.?[0-9]?)', \
 	gcc48 --version | grep gcc, \
 	gcc49 --version | grep gcc, \
 	gcc5 --version | grep gcc, \
@@ -45,8 +45,8 @@ $(eval $(call TestHostCommand,working-gcc, \
 
 $(eval $(call SetupHostCommand,g++, \
 	Please install the GNU C++ Compiler (g++) 4.8 or later \
-	$(CXX) -dumpversion | grep -E '(4\.[8-9]|5\.[0-9]|6\.[0-9]|7\.[0-9])', \
-	g++ -dumpversion | grep -E '(4\.[8-9]|5\.[0-9]|6\.[0-9]|7\.[0-9])', \
+	$(CXX) -dumpversion | grep -E '(4\.[8-9]|5\.?[0-9]?|6\.?[0-9]?|7\.?[0-9]?)', \
+	g++ -dumpversion | grep -E '(4\.[8-9]|5\.?[0-9]?|6\.?[0-9]?|7\.?[0-9]?)', \
 	g++48 --version | grep g++, \
 	g++49 --version | grep g++, \
 	g++5 --version | grep g++, \


### PR DESCRIPTION
Build dependency: Please install the GNU C Compiler (gcc) 4.8 or later cc
  -dumpversion | grep -E '(4\.[8-9]|5\.[0-9]|6\.[0-9]|7\.[0-9])'
Build dependency: Please install the GNU C++ Compiler (g++) 4.8 or later
  g++ -dumpversion | grep -E '(4\.[8-9]|5\.[0-9]|6\.[0-9]|7\.[0-9])'

Prerequisite check failed. Use FORCE=1 to override.

On my Fedora 26 machine gcc and g++ -dumpversion returns a whole number
'7' failing the regex introduced in commit:

b78de6207f6fc1a9db857942cb89f9fcf730a240

This change makes minor versions optional in the build dependency regex
for gcc and g++ whenever any minor version would be accepted and the
whole number version is sufficient as a dependency check. For versions
4.* a minor version is still required.

Signed-off-by: Justin Kilpatrick <jkilpatr@redhat.com>
