### PR TITLE
kernel: enable eSATA port on Netgear D7800 on 4.4 kernel

### DIFF
--- a/target/linux/ipq806x/files-4.4/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-4.4/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -148,6 +148,7 @@
 		};
 
 		sata@29000000 {
+			ports-implemented = <0x1>;
 			status = "ok";
 		};
 


### PR DESCRIPTION
Inserted correct eSATA port mapping for Netgear D7800 to enable eSATA port to function. See https://patchwork.kernel.org/patch/8686761/ for more details:
```
On some SOCs PORTS_IMPL register value is never programmed by the BIOS and left at zero value.
```