### PR TITLE
kernel: enable eSATA port on Netgear D7800

### DIFF
--- a/target/linux/ipq806x/files-4.4/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-4.4/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -148,6 +148,7 @@
 		};
 
 		sata@29000000 {
+			ports-implemented = <0x1>;
 			status = "ok";
 		};
 

--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -148,6 +148,7 @@
 		};
 
 		sata@29000000 {
+ 			ports-implemented = <0x1>;
 			status = "ok";
 		};
 


### PR DESCRIPTION
Enables eSATA port on Netgear D7800
see https://patchwork.kernel.org/patch/8686761/ for details:

```
On some SOCs PORTS_IMPL register value is never programmed by the BIOS
and left at zero value. Which means that no sata ports are avaiable for
software. AHCI driver used to cope up with this by fabricating the
port_map if the PORTS_IMPL register is read zero, but recent patch
broke this workaround as zero value was valid for nvme disks.

This patch adds ports-implemented dt bindings as workaround for this issue
in a way that DT can dictate the port_map incase where the SOCs does not
program it already.
```