### PR TITLE
ar71xx: C58/C59 fix LAN1 working incorrectly

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
@@ -249,7 +249,7 @@ static void __init archer_c5x_v1_setup(void)
 	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
 	ath79_eth1_data.speed = SPEED_1000;
 	ath79_eth1_data.duplex = DUPLEX_FULL;
-	ath79_switch_data.phy_poll_mask |= BIT(4);
+	ath79_switch_data.phy_poll_mask |= BIT(0);
 	ath79_switch_data.phy4_mii_en = 1;
 	ath79_register_eth(1);
 


### PR DESCRIPTION
This fixes LAN Port 1 not transferring data in case no other LAN Port has active link-state on TP-Link Archer C58/C59.