### PR TITLE
mbedtls: Don't override optimization

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -50,6 +50,7 @@ endef
 PKG_INSTALL:=1
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
 
 CMAKE_OPTIONS += \
 	-DCMAKE_BUILD_TYPE:String="Release" \


### PR DESCRIPTION
There's no apparent reason why we should override default release optimization
set by upstream (-O2) as it doesn't save any space. It also provides a very minor
speed increase, verified using OpenVPN.

Runtime tested and verified on ar71xx
Runtime tested on ramips, MT7621

Source: 
https://github.com/ARMmbed/mbedtls/blob/mbedtls-2.6/CMakeLists.txt#L73

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>