### PR TITLE
fix spelling in CONFIG_DEVTMPFS

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -254,7 +254,7 @@ config KERNEL_DEVTMPFS
 	default n
 	help
 	  devtmpfs is a simple, kernel-managed /dev filesystem. The kernel creates
-	  devices nodes for all registered devices ti simplify boot, but leaves more
+	  devices nodes for all registered devices to simplify boot, but leaves more
 	  complex tasks to userspace (e.g. udev).
 
 if KERNEL_DEVTMPFS


### PR DESCRIPTION
Changed "ti" to "to", as that's the correct spelling.
Signed-off-by: Sascha Paunovic <azarus@posteo.net>