### PR TITLE
ar71xx: generate BR region-code factory image for TP-Link TL-WR940N

### DIFF
--- a/target/linux/ar71xx/image/tp-link.mk
+++ b/target/linux/ar71xx/image/tp-link.mk
@@ -1077,9 +1077,10 @@ define Device/tl-wr940n-v4
   BOARDNAME := TL-WR940N-v4
   DEVICE_PROFILE := TLWR941
   TPLINK_HWID := 0x09400004
-  IMAGES += factory-us.bin factory-eu.bin
+  IMAGES += factory-us.bin factory-eu.bin factory-br.bin
   IMAGE/factory-us.bin := append-rootfs | mktplinkfw factory -C US
   IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
+  IMAGE/factory-br.bin := append-rootfs | mktplinkfw factory -C BR
 endef
 
 define Device/tl-wr941nd-v2

--- a/tools/firmware-utils/src/mktplinkfw.c
+++ b/tools/firmware-utils/src/mktplinkfw.c
@@ -170,6 +170,7 @@ static const struct fw_region regions[] = {
 	/* Default region (universal) uses code 0 as well */
 	{"US", 1},
 	{"EU", 0},
+	{"BR", 0},
 };
 
 static const struct fw_region * find_region(const char *country) {


### PR DESCRIPTION
First commit add BR region code to mktplinkfw tool.
Second commit add factory image with BR region code for TP-Link TL-WR940N V4 