### PR TITLE
ramips: fix a typo in 02_network

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -100,7 +100,7 @@ ramips_setup_interfaces()
 	psg1208|\
 	psg1218a|\
 	r6220|\
-	rt-n12p)
+	rt-n12p|\
 	sap-g3200u3|\
 	sk-wb8|\
 	u7621-06-256M-16M|\


### PR DESCRIPTION
There's is a typo in network defaults script in ramips target that prevents defaults to initialize.