### PR TITLE
busybox: enable find -newer

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -1089,7 +1089,7 @@ config BUSYBOX_DEFAULT_FEATURE_FIND_MAXDEPTH
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_NEWER
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_INUM
 	bool
 	default n

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.27.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2


### PR DESCRIPTION
needed for shorewall firewall, no size increase on binary

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
