### PR TITLE
toolchain/musl: Use upstream configuration

### DIFF
--- a/toolchain/musl/common.mk
+++ b/toolchain/musl/common.mk
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=musl
 PKG_VERSION:=1.1.18
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
@@ -26,6 +26,8 @@ HOST_BUILD_DIR:=$(BUILD_DIR_TOOLCHAIN)/$(PKG_NAME)-$(PKG_VERSION)
 include $(INCLUDE_DIR)/toolchain-build.mk
 include $(INCLUDE_DIR)/hardening.mk
 
+TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
+
 MUSL_CONFIGURE:= \
 	$(TARGET_CONFIGURE_OPTS) \
 	CFLAGS="$(TARGET_CFLAGS)" \
@@ -35,7 +37,8 @@ MUSL_CONFIGURE:= \
 		--host=$(GNU_HOST_NAME) \
 		--target=$(REAL_GNU_TARGET_NAME) \
 		--disable-gcc-wrapper \
-		--enable-debug
+		--enable-debug \
+		--enable-optimize
 
 define Host/Prepare
 	$(call Host/Prepare/Default)


### PR DESCRIPTION
* Strip optimization CFLAGS provided by buildroot
* Use upstream optimization CFLAGS (configure switch)

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
