### PR TITLE
toolchain/gcc: Set 6.3 as default version

### DIFF
--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -3,7 +3,7 @@
 choice
 	prompt "GCC compiler Version" if TOOLCHAINOPTS
 	default GCC_USE_VERSION_6_3_ARC if arc
-	default GCC_USE_VERSION_5
+	default GCC_USE_VERSION_6
 	help
 	  Select the version of gcc you wish to use.
 

--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -5,9 +5,9 @@ config GCC_VERSION_6_3_ARC
 config GCC_VERSION
 	string
 	default "arc-2017.03-release"   if GCC_VERSION_6_3_ARC
-	default "6.3.0"         if GCC_USE_VERSION_6
+	default "5.5.0"         if GCC_USE_VERSION_5
 	default "7.2.0"         if GCC_USE_VERSION_7
-	default "5.5.0"
+	default "6.3.0"
 
 config GCC_VERSION_6_3
 	bool


### PR DESCRIPTION
Use GCC 6.3 by default

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>