### PR TITLE
treewide: add only one device when appending to TARGET_DEVICES

### DIFF
--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -341,13 +341,14 @@ define Device/mr12
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size $$$$(IMAGE_SIZE)
   IMAGES := kernel.bin rootfs.bin sysupgrade.bin
 endef
+TARGET_DEVICES += mr12
 
 define Device/mr16
   $(Device/mr12)
   DEVICE_TITLE := Meraki MR16
   BOARDNAME := MR16
 endef
-TARGET_DEVICES += mr12 mr16
+TARGET_DEVICES += mr16
 
 define Device/dr342
   DEVICE_TITLE := Wallys DR342
@@ -392,6 +393,7 @@ define Device/wndr3700
   IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory-NA.img := $$(IMAGE/default) | netgear-dni NA | check-size $$$$(IMAGE_SIZE)
 endef
+TARGET_DEVICES += wndr3700
 
 define Device/wndr3700v2
   $(Device/wndr3700)
@@ -403,6 +405,7 @@ define Device/wndr3700v2
   MTDPARTS := spi0.0:320k(u-boot)ro,128k(u-boot-env)ro,15872k(firmware),64k(art)ro
   IMAGES := sysupgrade.bin factory.img
 endef
+TARGET_DEVICES += wndr3700v2
 
 define Device/wndr3800
   $(Device/wndr3700v2)
@@ -410,25 +413,28 @@ define Device/wndr3800
   NETGEAR_BOARD_ID := WNDR3800
   NETGEAR_HW_ID := 29763654+16+128
 endef
+TARGET_DEVICES += wndr3800
 
 define Device/wndr3800ch
   $(Device/wndr3800)
   DEVICE_TITLE := NETGEAR WNDR3800 (Ch)
   NETGEAR_BOARD_ID := WNDR3800CH
 endef
+TARGET_DEVICES += wndr3800ch
 
 define Device/wndrmac
   $(Device/wndr3700v2)
   DEVICE_TITLE := NETGEAR WNDRMAC
   NETGEAR_BOARD_ID := WNDRMAC
 endef
+TARGET_DEVICES += wndrmac
 
 define Device/wndrmacv2
   $(Device/wndr3800)
   DEVICE_TITLE := NETGEAR WNDRMAC v2
   NETGEAR_BOARD_ID := WNDRMACv2
 endef
-TARGET_DEVICES += wndr3700 wndr3700v2 wndr3800 wndr3800ch wndrmac wndrmacv2
+TARGET_DEVICES += wndrmacv2
 
 define Device/cap324
   DEVICE_TITLE := PowerCloud CAP324 Cloud AP
@@ -505,6 +511,7 @@ define Device/antminer-s1
   TPLINK_HWID := 0x04440101
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += antminer-s1
 
 define Device/antminer-s3
   $(Device/tplink-8mlzma)
@@ -515,6 +522,7 @@ define Device/antminer-s3
   TPLINK_HWID := 0x04440301
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += antminer-s3
 
 define Device/antrouter-r1
   $(Device/tplink-8mlzma)
@@ -525,6 +533,7 @@ define Device/antrouter-r1
   TPLINK_HWID := 0x44440101
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += antrouter-r1
 
 define Device/el-m150
   $(Device/tplink-8mlzma)
@@ -535,6 +544,7 @@ define Device/el-m150
   TPLINK_HWID := 0x01500101
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += el-m150
 
 define Device/el-mini
   $(Device/tplink-8mlzma)
@@ -545,7 +555,7 @@ define Device/el-mini
   TPLINK_HWID := 0x01530001
   CONSOLE := ttyATH0,115200
 endef
-TARGET_DEVICES += antminer-s1 antminer-s3 antrouter-r1 el-m150 el-mini
+TARGET_DEVICES += el-mini
 
 define Device/gl-inet-6408A-v1
   $(Device/tplink-8mlzma)
@@ -556,6 +566,7 @@ define Device/gl-inet-6408A-v1
   TPLINK_HWID := 0x08000001
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += gl-inet-6408A-v1
 
 define Device/gl-inet-6416A-v1
   $(Device/tplink-16mlzma)
@@ -566,7 +577,7 @@ define Device/gl-inet-6416A-v1
   TPLINK_HWID := 0x08000001
   CONSOLE := ttyATH0,115200
 endef
-TARGET_DEVICES += gl-inet-6408A-v1 gl-inet-6416A-v1
+TARGET_DEVICES += gl-inet-6416A-v1
 
 define Device/jwap230
   DEVICE_TITLE := jjPlus JWAP230
@@ -625,6 +636,7 @@ define Device/omy-g1
   DEVICE_PROFILE := OMYG1
   TPLINK_HWID := 0x06660101
 endef
+TARGET_DEVICES += omy-g1
 
 define Device/omy-x1
   $(Device/tplink-8mlzma)
@@ -633,7 +645,7 @@ define Device/omy-x1
   DEVICE_PROFILE := OMYX1
   TPLINK_HWID := 0x06660201
 endef
-TARGET_DEVICES += omy-g1 omy-x1
+TARGET_DEVICES += omy-x1
 
 define Device/onion-omega
   $(Device/tplink-16mlzma)
@@ -826,6 +838,7 @@ define Device/dir-869-a1
 	seama | seama-seal -m "signature=$$$$(SEAMA_SIGNATURE)" | \
 	check-size $$$$(IMAGE_SIZE)
 endef
+TARGET_DEVICES += dir-869-a1
 
 define Device/mynet-n600
   $(Device/seama)
@@ -836,6 +849,7 @@ define Device/mynet-n600
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,64k(devdata)ro,64k(devconf)ro,15872k(firmware),64k(radiocfg)ro
   SEAMA_SIGNATURE := wrgnd16_wd_db600
 endef
+TARGET_DEVICES += mynet-n600
 
 define Device/mynet-n750
   $(Device/seama)
@@ -846,6 +860,7 @@ define Device/mynet-n750
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,64k(devdata)ro,64k(devconf)ro,15872k(firmware),64k(radiocfg)ro
   SEAMA_SIGNATURE := wrgnd13_wd_av
 endef
+TARGET_DEVICES += mynet-n750
 
 define Device/qihoo-c301
   $(Device/seama)
@@ -856,7 +871,7 @@ define Device/qihoo-c301
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(devdata),64k(devconf),15744k(firmware),64k(warm_start),64k(action_image_config),64k(radiocfg)ro;spi0.1:15360k(upgrade2),1024k(privatedata)
   SEAMA_SIGNATURE := wrgac26_qihoo360_360rg
 endef
-TARGET_DEVICES += dir-869-a1 mynet-n600 mynet-n750 qihoo-c301
+TARGET_DEVICES += qihoo-c301
 
 define Device/dap-2695-a1
   DEVICE_TITLE := D-Link DAP-2695 rev. A1
@@ -897,6 +912,7 @@ define Device/wpj342
   DEVICE_TITLE := Compex WPJ342 (16MB flash)
   BOARDNAME := WPJ342
 endef
+TARGET_DEVICES += wpj342
 
 define Device/wpj344
   $(Device/wpj-16m)
@@ -906,12 +922,14 @@ define Device/wpj344
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
+TARGET_DEVICES += wpj344
 
 define Device/wpj531
   $(Device/wpj-16m)
   DEVICE_TITLE := Compex WPJ531 (16MB flash)
   BOARDNAME := WPJ531
 endef
+TARGET_DEVICES += wpj531
 
 define Device/wpj558
   $(Device/wpj-16m)
@@ -921,13 +939,14 @@ define Device/wpj558
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
+TARGET_DEVICES += wpj558
 
 define Device/wpj563
   $(Device/wpj-16m)
   DEVICE_TITLE := Compex WPJ563 (16MB flash)
   BOARDNAME := WPJ563
 endef
-TARGET_DEVICES += wpj342 wpj344 wpj531 wpj558 wpj563
+TARGET_DEVICES += wpj563
 
 define Device/wrtnode2q
   DEVICE_TITLE := WRTnode2Q

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -15,13 +15,14 @@ define Device/nand-64m
   DEVICE_TITLE := MikroTik RouterBoard (64 MB NAND)
   KERNEL := kernel-bin | kernel2minor -s 512 -e -c
 endef
+TARGET_DEVICES += nand-64m
 
 define Device/nand-large
   $(Device/mikrotik)
   DEVICE_TITLE := MikroTik RouterBoard (>= 128 MB NAND)
   KERNEL := kernel-bin | kernel2minor -s 2048 -e -c
 endef
-TARGET_DEVICES += nand-64m nand-large
+TARGET_DEVICES += nand-large
 
 define Device/rb-nor-flash-16M
   DEVICE_TITLE := MikroTik RouterBoard (16 MB SPI NOR)
@@ -34,10 +35,11 @@ define Device/rb-nor-flash-16M
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
+TARGET_DEVICES += rb-nor-flash-16M
 
 define Device/rb-nor-flash-16M-ac
   $(Device/rb-nor-flash-16M)
   DEVICE_TITLE := MikroTik RouterBoard (16 MB SPI NOR, 802.11ac)
   DEVICE_PACKAGES += kmod-ath10k ath10k-firmware-qca988x ath10k-firmware-qca9887
 endef
-TARGET_DEVICES += rb-nor-flash-16M rb-nor-flash-16M-ac
+TARGET_DEVICES += rb-nor-flash-16M-ac

--- a/target/linux/ar71xx/image/tp-link.mk
+++ b/target/linux/ar71xx/image/tp-link.mk
@@ -114,6 +114,7 @@ define Device/archer-c25-v1
   MTDPARTS := spi0.0:128k(factory-uboot)ro,64k(u-boot)ro,1536k(kernel),6272k(rootfs),128k(config)ro,64k(art)ro,7808k@0x30000(firmware)
   SUPPORTED_DEVICES := archer-c25-v1
 endef
+TARGET_DEVICES += archer-c25-v1
 
 define Device/archer-c58-v1
   $(Device/archer-cxx)
@@ -126,6 +127,7 @@ define Device/archer-c58-v1
   MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,7936k(firmware),64k(tplink)ro,64k(art)ro
   SUPPORTED_DEVICES := archer-c58-v1
 endef
+TARGET_DEVICES += archer-c58-v1
 
 define Device/archer-c59-v1
   $(Device/archer-cxx)
@@ -138,6 +140,7 @@ define Device/archer-c59-v1
   MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1536k(kernel),12992k(rootfs),1664k(tplink)ro,64k(art)ro,14528k@0x20000(firmware)
   SUPPORTED_DEVICES := archer-c59-v1
 endef
+TARGET_DEVICES += archer-c59-v1
 
 define Device/archer-c60-v1
   $(Device/archer-cxx)
@@ -150,7 +153,7 @@ define Device/archer-c60-v1
   MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,7936k(firmware),64k(tplink)ro,64k(art)ro
   SUPPORTED_DEVICES := archer-c60-v1
 endef
-TARGET_DEVICES += archer-c25-v1 archer-c58-v1 archer-c59-v1 archer-c60-v1
+TARGET_DEVICES += archer-c60-v1
 
 define Device/archer-c5-v1
   $(Device/tplink-16mlzma)
@@ -160,6 +163,7 @@ define Device/archer-c5-v1
   DEVICE_PROFILE := ARCHERC7
   TPLINK_HWID := 0xc5000001
 endef
+TARGET_DEVICES += archer-c5-v1
 
 define Device/archer-c7-v1
   $(Device/tplink-8mlzma)
@@ -169,6 +173,7 @@ define Device/archer-c7-v1
   DEVICE_PROFILE := ARCHERC7
   TPLINK_HWID := 0x75000001
 endef
+TARGET_DEVICES += archer-c7-v1
 
 define Device/archer-c7-v2
   $(Device/tplink-16mlzma)
@@ -181,6 +186,7 @@ define Device/archer-c7-v2
   IMAGE/factory-us.bin := append-rootfs | mktplinkfw factory -C US
   IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
 endef
+TARGET_DEVICES += archer-c7-v2
 
 define Device/archer-c7-v2-il
   $(Device/tplink-16mlzma)
@@ -191,6 +197,7 @@ define Device/archer-c7-v2-il
   TPLINK_HWID := 0xc7000002
   TPLINK_HWREV := 0x494c0001
 endef
+TARGET_DEVICES += archer-c7-v2-il
 
 define Device/tl-wdr7500-v3
   $(Device/tplink-8mlzma)
@@ -200,6 +207,7 @@ define Device/tl-wdr7500-v3
   DEVICE_PROFILE := ARCHERC7
   TPLINK_HWID := 0x75000003
 endef
+TARGET_DEVICES += tl-wdr7500-v3
 
 define Device/archer-c7-v4
   $(Device/archer-cxx)
@@ -212,8 +220,7 @@ define Device/archer-c7-v4
   MTDPARTS := spi0.0:128k(factory-uboot)ro,128k(u-boot)ro,1536k(kernel),13568k(rootfs),960k(config)ro,64k(art)ro,15104k@0x40000(firmware)
   SUPPORTED_DEVICES := archer-c7-v4
 endef
-
-TARGET_DEVICES += archer-c5-v1 archer-c7-v1 archer-c7-v2 archer-c7-v2-il tl-wdr7500-v3 archer-c7-v4
+TARGET_DEVICES += archer-c7-v4
 
 define Device/cpe510-520-v1
   DEVICE_TITLE := TP-LINK CPE510/520 v1
@@ -229,6 +236,7 @@ define Device/cpe510-520-v1
   IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
 endef
+TARGET_DEVICES += cpe510-520-v1
 
 define Device/cpe210-220-v1
   $(Device/cpe510-520-v1)
@@ -236,6 +244,7 @@ define Device/cpe210-220-v1
   BOARDNAME := CPE210
   TPLINK_BOARD_ID := CPE210
 endef
+TARGET_DEVICES += cpe210-220-v1
 
 define Device/wbs210-v1
   $(Device/cpe510-520-v1)
@@ -243,6 +252,7 @@ define Device/wbs210-v1
   BOARDNAME := WBS210
   TPLINK_BOARD_ID := WBS210
 endef
+TARGET_DEVICES += wbs210-v1
 
 define Device/wbs510-v1
   $(Device/cpe510-520-v1)
@@ -250,7 +260,7 @@ define Device/wbs510-v1
   BOARDNAME := WBS510
   TPLINK_BOARD_ID := WBS510
 endef
-TARGET_DEVICES += cpe210-220-v1 cpe510-520-v1 wbs210-v1 wbs510-v1
+TARGET_DEVICES += wbs510-v1
 
 define Device/eap120-v1
   DEVICE_TITLE := TP-LINK EAP120 v1
@@ -295,6 +305,7 @@ define Device/tl-mr10u-v1
   TPLINK_HWID := 0x00100101
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-mr10u-v1
 
 define Device/tl-mr11u-v1
   $(Device/tplink-4mlzma)
@@ -305,12 +316,14 @@ define Device/tl-mr11u-v1
   TPLINK_HWID := 0x00110101
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-mr11u-v1
 
 define Device/tl-mr11u-v2
   $(Device/tl-mr11u-v1)
   DEVICE_TITLE := TP-LINK TL-MR11U v2
   TPLINK_HWID := 0x00110102
 endef
+TARGET_DEVICES += tl-mr11u-v2
 
 define Device/tl-mr12u-v1
   $(Device/tplink-4mlzma)
@@ -321,6 +334,7 @@ define Device/tl-mr12u-v1
   TPLINK_HWID := 0x00120101
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-mr12u-v1
 
 define Device/tl-mr13u-v1
   $(Device/tl-mr12u-v1)
@@ -328,7 +342,7 @@ define Device/tl-mr13u-v1
   DEVICE_PROFILE := TLMR13U
   TPLINK_HWID := 0x00130101
 endef
-TARGET_DEVICES += tl-mr10u-v1 tl-mr11u-v1 tl-mr11u-v2 tl-mr12u-v1 tl-mr13u-v1
+TARGET_DEVICES += tl-mr13u-v1
 
 define Device/tl-mr3020-v1
   $(Device/tplink-4mlzma)
@@ -339,6 +353,7 @@ define Device/tl-mr3020-v1
   TPLINK_HWID := 0x30200001
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-mr3020-v1
 
 define Device/tl-mr3040-v1
   $(Device/tl-mr3020-v1)
@@ -347,6 +362,7 @@ define Device/tl-mr3040-v1
   DEVICE_PROFILE := TLMR3040
   TPLINK_HWID := 0x30400001
 endef
+TARGET_DEVICES += tl-mr3040-v1
 
 define Device/tl-mr3040-v2
   $(Device/tl-mr3040-v1)
@@ -354,6 +370,7 @@ define Device/tl-mr3040-v2
   BOARDNAME := TL-MR3040-v2
   TPLINK_HWID := 0x30400002
 endef
+TARGET_DEVICES += tl-mr3040-v2
 
 define Device/tl-mr3220-v1
   $(Device/tplink-4m)
@@ -363,6 +380,7 @@ define Device/tl-mr3220-v1
   DEVICE_PROFILE := TLMR3220
   TPLINK_HWID := 0x32200001
 endef
+TARGET_DEVICES += tl-mr3220-v1
 
 define Device/tl-mr3220-v2
   $(Device/tplink-4mlzma)
@@ -373,6 +391,7 @@ define Device/tl-mr3220-v2
   TPLINK_HWID := 0x32200002
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-mr3220-v2
 
 define Device/tl-mr3420-v1
   $(Device/tplink-4m)
@@ -382,6 +401,7 @@ define Device/tl-mr3420-v1
   DEVICE_PROFILE := TLMR3420
   TPLINK_HWID := 0x34200001
 endef
+TARGET_DEVICES += tl-mr3420-v1
 
 define Device/tl-mr3420-v2
   $(Device/tplink-4mlzma)
@@ -391,7 +411,7 @@ define Device/tl-mr3420-v2
   DEVICE_PROFILE := TLMR3420
   TPLINK_HWID := 0x34200002
 endef
-TARGET_DEVICES += tl-mr3020-v1 tl-mr3040-v1 tl-mr3040-v2 tl-mr3220-v1 tl-mr3220-v2 tl-mr3420-v1 tl-mr3420-v2
+TARGET_DEVICES += tl-mr3420-v2
 
 define Device/tl-mr6400-v1
   $(Device/tplink-8mlzma)
@@ -410,6 +430,7 @@ define Device/tl-wa701nd-v1
   DEVICE_PROFILE := TLWA701
   TPLINK_HWID := 0x07010001
 endef
+TARGET_DEVICES += tl-wa701nd-v1
 
 define Device/tl-wa701nd-v2
   $(Device/tplink-4mlzma)
@@ -419,6 +440,7 @@ define Device/tl-wa701nd-v2
   TPLINK_HWID := 0x07010002
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-wa701nd-v2
 
 define Device/tl-wa7210n-v2
   $(Device/tplink-4mlzma)
@@ -429,6 +451,7 @@ define Device/tl-wa7210n-v2
   TPLINK_HWID := 0x72100002
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-wa7210n-v2
 
 define Device/tl-wa730re-v1
   $(Device/tplink-4m)
@@ -437,6 +460,7 @@ define Device/tl-wa730re-v1
   DEVICE_PROFILE := TLWA730RE
   TPLINK_HWID := 0x07300001
 endef
+TARGET_DEVICES += tl-wa730re-v1
 
 define Device/tl-wa750re-v1
   $(Device/tplink-4mlzma)
@@ -446,6 +470,7 @@ define Device/tl-wa750re-v1
   DEVICE_PROFILE := TLWA750
   TPLINK_HWID := 0x07500001
 endef
+TARGET_DEVICES += tl-wa750re-v1
 
 define Device/tl-wa7510n-v1
   $(Device/tplink-4m)
@@ -454,7 +479,7 @@ define Device/tl-wa7510n-v1
   DEVICE_PROFILE := TLWA7510
   TPLINK_HWID := 0x75100001
 endef
-TARGET_DEVICES += tl-wa701nd-v1 tl-wa701nd-v2 tl-wa7210n-v2 tl-wa730re-v1 tl-wa750re-v1 tl-wa7510n-v1
+TARGET_DEVICES += tl-wa7510n-v1
 
 define Device/tl-wa801nd-v1
   $(Device/tplink-4m)
@@ -463,6 +488,7 @@ define Device/tl-wa801nd-v1
   DEVICE_PROFILE := TLWA801
   TPLINK_HWID := 0x08010001
 endef
+TARGET_DEVICES += tl-wa801nd-v1
 
 define Device/tl-wa801nd-v2
   $(Device/tplink-4mlzma)
@@ -471,6 +497,7 @@ define Device/tl-wa801nd-v2
   DEVICE_PROFILE := TLWA801
   TPLINK_HWID := 0x08010002
 endef
+TARGET_DEVICES += tl-wa801nd-v2
 
 define Device/tl-wa801nd-v3
   $(Device/tplink-4mlzma)
@@ -479,6 +506,7 @@ define Device/tl-wa801nd-v3
   DEVICE_PROFILE := TLWA801
   TPLINK_HWID := 0x08010003
 endef
+TARGET_DEVICES += tl-wa801nd-v3
 
 define Device/tl-wa830re-v1
   $(Device/tplink-4m)
@@ -487,6 +515,7 @@ define Device/tl-wa830re-v1
   DEVICE_PROFILE := TLWA830
   TPLINK_HWID := 0x08300010
 endef
+TARGET_DEVICES += tl-wa830re-v1
 
 define Device/tl-wa830re-v2
   $(Device/tplink-4mlzma)
@@ -495,6 +524,7 @@ define Device/tl-wa830re-v2
   DEVICE_PROFILE := TLWA830
   TPLINK_HWID := 0x08300002
 endef
+TARGET_DEVICES += tl-wa830re-v2
 
 define Device/tl-wa850re-v1
   $(Device/tplink-4mlzma)
@@ -504,6 +534,7 @@ define Device/tl-wa850re-v1
   DEVICE_PROFILE := TLWA850
   TPLINK_HWID := 0x08500001
 endef
+TARGET_DEVICES += tl-wa850re-v1
 
 define Device/tl-wa85xre
   $(Device/tplink)
@@ -523,6 +554,7 @@ define Device/tl-wa850re-v2
   TPLINK_BOARD_ID := TLWA850REV2
   TPLINK_HWID := 0x08500002
 endef
+TARGET_DEVICES += tl-wa850re-v2
 
 define Device/tl-wa855re-v1
   $(Device/tl-wa85xre)
@@ -532,6 +564,8 @@ define Device/tl-wa855re-v1
   TPLINK_HWID := 0x08550001
   TPLINK_BOARD_ID := TLWA855REV1
 endef
+TARGET_DEVICES += tl-wa855re-v1
+
 
 define Device/tl-wa860re-v1
   $(Device/tplink-4mlzma)
@@ -540,7 +574,7 @@ define Device/tl-wa860re-v1
   DEVICE_PROFILE := TLWA860
   TPLINK_HWID := 0x08600001
 endef
-TARGET_DEVICES += tl-wa801nd-v1 tl-wa801nd-v2 tl-wa801nd-v3 tl-wa830re-v1 tl-wa830re-v2 tl-wa850re-v1 tl-wa850re-v2 tl-wa855re-v1 tl-wa860re-v1
+TARGET_DEVICES += tl-wa860re-v1
 
 define Device/tl-wa901nd-v1
   $(Device/tplink-4m)
@@ -549,6 +583,7 @@ define Device/tl-wa901nd-v1
   DEVICE_PROFILE := TLWA901
   TPLINK_HWID := 0x09010001
 endef
+TARGET_DEVICES += tl-wa901nd-v1
 
 define Device/tl-wa901nd-v2
   $(Device/tplink-4m)
@@ -557,6 +592,7 @@ define Device/tl-wa901nd-v2
   DEVICE_PROFILE := TLWA901
   TPLINK_HWID := 0x09010002
 endef
+TARGET_DEVICES += tl-wa901nd-v2
 
 define Device/tl-wa901nd-v3
   $(Device/tplink-4mlzma)
@@ -565,6 +601,7 @@ define Device/tl-wa901nd-v3
   DEVICE_PROFILE := TLWA901
   TPLINK_HWID := 0x09010003
 endef
+TARGET_DEVICES += tl-wa901nd-v3
 
 define Device/tl-wa901nd-v4
   $(Device/tplink-4mlzma)
@@ -574,6 +611,7 @@ define Device/tl-wa901nd-v4
   TPLINK_HWID := 0x09010004
   IMAGE/factory.bin := append-rootfs | mktplinkfw factory -C EU
 endef
+TARGET_DEVICES += tl-wa901nd-v4
 
 define Device/tl-wa901nd-v5
   $(Device/tl-wa901nd-v4)
@@ -581,7 +619,7 @@ define Device/tl-wa901nd-v5
   BOARDNAME := TL-WA901ND-v5
   TPLINK_HWID := 0x09010005
 endef
-TARGET_DEVICES += tl-wa901nd-v1 tl-wa901nd-v2 tl-wa901nd-v3 tl-wa901nd-v4 tl-wa901nd-v5
+TARGET_DEVICES += tl-wa901nd-v5
 
 define Device/tl-wdr3320-v2
   $(Device/tplink-4mlzma)
@@ -592,6 +630,7 @@ define Device/tl-wdr3320-v2
   TPLINK_HWID := 0x33200002
   TPLINK_HEADER_VERSION := 2
 endef
+TARGET_DEVICES += tl-wdr3320-v2
 
 define Device/tl-wdr3500-v1
   $(Device/tplink-8mlzma)
@@ -601,6 +640,7 @@ define Device/tl-wdr3500-v1
   DEVICE_PROFILE := TLWDR4300
   TPLINK_HWID := 0x35000001
 endef
+TARGET_DEVICES += tl-wdr3500-v1
 
 define Device/tl-wdr3600-v1
   $(Device/tl-wdr3500-v1)
@@ -609,12 +649,14 @@ define Device/tl-wdr3600-v1
   TPLINK_HWID := 0x36000001
   IMAGE/factory.bin := append-rootfs | mktplinkfw factory -C US
 endef
+TARGET_DEVICES += tl-wdr3600-v1
 
 define Device/tl-wdr4300-v1
   $(Device/tl-wdr3600-v1)
   DEVICE_TITLE := TP-LINK TL-WDR4300 v1
   TPLINK_HWID := 0x43000001
 endef
+TARGET_DEVICES += tl-wdr4300-v1
 
 define Device/tl-wdr4300-v1-il
   $(Device/tl-wdr3500-v1)
@@ -622,12 +664,14 @@ define Device/tl-wdr4300-v1-il
   BOARDNAME := TL-WDR4300
   TPLINK_HWID := 0x43008001
 endef
+TARGET_DEVICES += tl-wdr4300-v1-il
 
 define Device/tl-wdr4310-v1
   $(Device/tl-wdr4300-v1-il)
   DEVICE_TITLE := TP-LINK TL-WDR4310 v1
   TPLINK_HWID := 0x43100001
 endef
+TARGET_DEVICES += tl-wdr4310-v1
 
 define Device/tl-wdr4900-v2
   $(Device/tplink-8mlzma)
@@ -637,6 +681,7 @@ define Device/tl-wdr4900-v2
   DEVICE_PROFILE := TLWDR4900V2
   TPLINK_HWID := 0x49000002
 endef
+TARGET_DEVICES += tl-wdr4900-v2
 
 define Device/tl-wdr6500-v2
   $(Device/tplink-8mlzma)
@@ -649,13 +694,14 @@ define Device/tl-wdr6500-v2
   TPLINK_HWID := 0x65000002
   TPLINK_HEADER_VERSION := 2
 endef
+TARGET_DEVICES += tl-wdr6500-v2
 
 define Device/mw4530r-v1
   $(Device/tl-wdr4300-v1)
   DEVICE_TITLE := Mercury MW4530R v1
   TPLINK_HWID := 0x45300001
 endef
-TARGET_DEVICES += tl-wdr3320-v2 tl-wdr3500-v1 tl-wdr3600-v1 tl-wdr4300-v1 tl-wdr4300-v1-il tl-wdr4310-v1 tl-wdr4900-v2 tl-wdr6500-v2 mw4530r-v1
+TARGET_DEVICES += mw4530r-v1
 
 define Device/tl-wpa8630-v1
   $(Device/tplink-8mlzma)
@@ -686,6 +732,7 @@ define Device/tl-wr1043n-v5
   IMAGE_SIZE := 15104k
   TPLINK_BOARD_ID := TLWR1043NV5
 endef
+TARGET_DEVICES += tl-wr1043n-v5
 
 define Device/tl-wr1043nd-v1
   $(Device/tplink-8m)
@@ -695,6 +742,7 @@ define Device/tl-wr1043nd-v1
   DEVICE_PROFILE := TLWR1043
   TPLINK_HWID := 0x10430001
 endef
+TARGET_DEVICES += tl-wr1043nd-v1
 
 define Device/tl-wr1043nd-v2
   $(Device/tplink-8mlzma)
@@ -704,12 +752,14 @@ define Device/tl-wr1043nd-v2
   DEVICE_PROFILE := TLWR1043
   TPLINK_HWID := 0x10430002
 endef
+TARGET_DEVICES += tl-wr1043nd-v2
 
 define Device/tl-wr1043nd-v3
   $(Device/tl-wr1043nd-v2)
   DEVICE_TITLE := TP-LINK TL-WR1043N/ND v3
   TPLINK_HWID := 0x10430003
 endef
+TARGET_DEVICES += tl-wr1043nd-v3
 
 define Device/tl-wr1043nd-v4
   $(Device/tplink)
@@ -726,6 +776,7 @@ define Device/tl-wr1043nd-v4
   IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
 endef
+TARGET_DEVICES += tl-wr1043nd-v4
 
 define Device/tl-wr2543-v1
   $(Device/tplink-8mlzma)
@@ -737,7 +788,7 @@ define Device/tl-wr2543-v1
   IMAGE/sysupgrade.bin := append-rootfs | mktplinkfw sysupgrade -v 3.13.99
   IMAGE/factory.bin := append-rootfs | mktplinkfw factory -v 3.13.99
 endef
-TARGET_DEVICES += tl-wr1043nd-v1 tl-wr1043nd-v2 tl-wr1043nd-v3 tl-wr1043nd-v4 tl-wr1043n-v5 tl-wr2543-v1
+TARGET_DEVICES += tl-wr2543-v1
 
 define Device/tl-wr703n-v1
   $(Device/tplink-4mlzma)
@@ -748,6 +799,7 @@ define Device/tl-wr703n-v1
   TPLINK_HWID := 0x07030101
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-wr703n-v1
 
 define Device/tl-wr710n-v1
   $(Device/tplink-8mlzma)
@@ -759,6 +811,7 @@ define Device/tl-wr710n-v1
   CONSOLE := ttyATH0,115200
   IMAGE/factory.bin := append-rootfs | mktplinkfw factory -C US
 endef
+TARGET_DEVICES += tl-wr710n-v1
 
 define Device/tl-wr710n-v2
   $(Device/tplink-4mlzma)
@@ -769,6 +822,7 @@ define Device/tl-wr710n-v2
   TPLINK_HWID := 0x07100002
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-wr710n-v2
 
 define Device/tl-wr710n-v2.1
   $(Device/tl-wr710n-v1)
@@ -776,6 +830,7 @@ define Device/tl-wr710n-v2.1
   TPLINK_HWID := 0x07100002
   TPLINK_HWREV := 0x00000002
 endef
+TARGET_DEVICES += tl-wr710n-v2.1
 
 define Device/tl-wr720n-v3
   $(Device/tplink-4mlzma)
@@ -786,13 +841,14 @@ define Device/tl-wr720n-v3
   TPLINK_HWID := 0x07200103
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-wr720n-v3
 
 define Device/tl-wr720n-v4
   $(Device/tl-wr720n-v3)
   DEVICE_TITLE := TP-LINK TL-WR720N v4
   TPLINK_HWID := 0x07200104
 endef
-TARGET_DEVICES += tl-wr703n-v1 tl-wr710n-v1 tl-wr710n-v2 tl-wr710n-v2.1 tl-wr720n-v3 tl-wr720n-v4
+TARGET_DEVICES += tl-wr720n-v4
 
 define Device/tl-wr740n-v1
   $(Device/tplink-4m)
@@ -801,12 +857,14 @@ define Device/tl-wr740n-v1
   DEVICE_PROFILE := TLWR740
   TPLINK_HWID := 0x07400001
 endef
+TARGET_DEVICES += tl-wr740n-v1
 
 define Device/tl-wr740n-v3
   $(Device/tl-wr740n-v1)
   DEVICE_TITLE := TP-LINK TL-WR740N/ND v3
   TPLINK_HWID := 0x07400003
 endef
+TARGET_DEVICES += tl-wr740n-v3
 
 define Device/tl-wr740n-v4
   $(Device/tplink-4mlzma)
@@ -816,12 +874,14 @@ define Device/tl-wr740n-v4
   TPLINK_HWID := 0x07400004
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-wr740n-v4
 
 define Device/tl-wr740n-v5
   $(Device/tl-wr740n-v4)
   DEVICE_TITLE := TP-LINK TL-WR740N/ND v5
   TPLINK_HWID := 0x07400005
 endef
+TARGET_DEVICES += tl-wr740n-v5
 
 define Device/tl-wr740n-v6
   $(Device/tplink-4mlzma)
@@ -830,7 +890,7 @@ define Device/tl-wr740n-v6
   DEVICE_PROFILE := TLWR740
   TPLINK_HWID := 0x07400006
 endef
-TARGET_DEVICES += tl-wr740n-v1 tl-wr740n-v3 tl-wr740n-v4 tl-wr740n-v5 tl-wr740n-v6
+TARGET_DEVICES += tl-wr740n-v6
 
 define Device/tl-wr741nd-v1
   $(Device/tplink-4m)
@@ -839,11 +899,13 @@ define Device/tl-wr741nd-v1
   DEVICE_PROFILE := TLWR741
   TPLINK_HWID := 0x07410001
 endef
+TARGET_DEVICES += tl-wr741nd-v1
 
 define Device/tl-wr741nd-v2
   $(Device/tl-wr741nd-v1)
   DEVICE_TITLE := TP-LINK TL-WR741N/ND v2
 endef
+TARGET_DEVICES += tl-wr741nd-v2
 
 define Device/tl-wr741nd-v4
   $(Device/tplink-4mlzma)
@@ -853,12 +915,14 @@ define Device/tl-wr741nd-v4
   TPLINK_HWID := 0x07410004
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += tl-wr741nd-v4
 
 define Device/tl-wr741nd-v5
   $(Device/tl-wr741nd-v4)
   DEVICE_TITLE := TP-LINK TL-WR741N/ND v5
   TPLINK_HWID := 0x07400005
 endef
+TARGET_DEVICES += tl-wr741nd-v5
 
 define Device/tl-wr743nd-v1
   $(Device/tplink-4m)
@@ -867,6 +931,7 @@ define Device/tl-wr743nd-v1
   DEVICE_PROFILE := TLWR743
   TPLINK_HWID := 0x07430001
 endef
+TARGET_DEVICES += tl-wr743nd-v1
 
 define Device/tl-wr743nd-v2
   $(Device/tl-wr741nd-v4)
@@ -874,7 +939,7 @@ define Device/tl-wr743nd-v2
   DEVICE_PROFILE := TLWR743
   TPLINK_HWID := 0x07430002
 endef
-TARGET_DEVICES += tl-wr741nd-v1 tl-wr741nd-v2 tl-wr741nd-v4 tl-wr741nd-v5 tl-wr743nd-v1 tl-wr743nd-v2
+TARGET_DEVICES += tl-wr743nd-v2
 
 define Device/tl-wr802n-v1
   $(Device/tplink-4mlzma)
@@ -884,6 +949,7 @@ define Device/tl-wr802n-v1
   TPLINK_HWID := 0x08020001
   TPLINK_HWREV := 1
 endef
+TARGET_DEVICES += tl-wr802n-v1
 
 define Device/tl-wr802n-v2
   $(Device/tplink-4mlzma)
@@ -896,6 +962,7 @@ define Device/tl-wr802n-v2
   IMAGE/factory-us.bin := append-rootfs | mktplinkfw factory -C US
   IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
 endef
+TARGET_DEVICES += tl-wr802n-v2
 
 define Device/tl-wr810n-v1
   $(Device/tplink-8mlzma)
@@ -905,6 +972,7 @@ define Device/tl-wr810n-v1
   DEVICE_PROFILE := TLWR810
   TPLINK_HWID := 0x08100001
 endef
+TARGET_DEVICES += tl-wr810n-v1
 
 define Device/tl-wr810n-v2
   $(Device/tplink-8mlzma)
@@ -913,6 +981,7 @@ define Device/tl-wr810n-v2
   DEVICE_PROFILE := TLWR810
   TPLINK_HWID := 0x08100002
 endef
+TARGET_DEVICES += tl-wr810n-v2
 
 define Device/tl-wr840n-v2
   $(Device/tplink-4mlzma)
@@ -923,6 +992,7 @@ define Device/tl-wr840n-v2
   IMAGES += factory-eu.bin
   IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
 endef
+TARGET_DEVICES += tl-wr840n-v2
 
 define Device/tl-wr840n-v3
   $(Device/tl-wr840n-v2)
@@ -930,7 +1000,7 @@ define Device/tl-wr840n-v3
   BOARDNAME := TL-WR840N-v3
   TPLINK_HWID := 0x08400003
 endef
-TARGET_DEVICES += tl-wr802n-v1 tl-wr802n-v2 tl-wr810n-v1 tl-wr810n-v2 tl-wr840n-v2 tl-wr840n-v3
+TARGET_DEVICES += tl-wr840n-v3
 
 define Device/tl-wr841-v1.5
   $(Device/tplink-4m)
@@ -940,6 +1010,7 @@ define Device/tl-wr841-v1.5
   TPLINK_HWID := 0x08410002
   TPLINK_HWREV := 2
 endef
+TARGET_DEVICES += tl-wr841-v1.5
 
 define Device/tl-wr841-v3
   $(Device/tplink-4m)
@@ -949,6 +1020,7 @@ define Device/tl-wr841-v3
   TPLINK_HWID := 0x08410003
   TPLINK_HWREV := 3
 endef
+TARGET_DEVICES += tl-wr841-v3
 
 define Device/tl-wr841-v5
   $(Device/tplink-4m)
@@ -957,6 +1029,7 @@ define Device/tl-wr841-v5
   DEVICE_PROFILE := TLWR841
   TPLINK_HWID := 0x08410005
 endef
+TARGET_DEVICES += tl-wr841-v5
 
 define Device/tl-wr841-v7
   $(Device/tplink-4m)
@@ -965,6 +1038,7 @@ define Device/tl-wr841-v7
   DEVICE_PROFILE := TLWR841
   TPLINK_HWID := 0x08410007
 endef
+TARGET_DEVICES += tl-wr841-v7
 
 define Device/tl-wr841-v8
   $(Device/tplink-4mlzma)
@@ -973,6 +1047,7 @@ define Device/tl-wr841-v8
   DEVICE_PROFILE := TLWR841
   TPLINK_HWID := 0x08410008
 endef
+TARGET_DEVICES += tl-wr841-v8
 
 define Device/tl-wr841-v9
   $(Device/tplink-4mlzma)
@@ -981,12 +1056,14 @@ define Device/tl-wr841-v9
   DEVICE_PROFILE := TLWR841
   TPLINK_HWID := 0x08410009
 endef
+TARGET_DEVICES += tl-wr841-v9
 
 define Device/tl-wr841-v10
   $(Device/tl-wr841-v9)
   DEVICE_TITLE := TP-LINK TL-WR841N/ND v10
   TPLINK_HWID := 0x08410010
 endef
+TARGET_DEVICES += tl-wr841-v10
 
 define Device/tl-wr841-v11
   $(Device/tplink-4mlzma)
@@ -998,13 +1075,14 @@ define Device/tl-wr841-v11
   IMAGE/factory-us.bin := append-rootfs | mktplinkfw factory -C US
   IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
 endef
+TARGET_DEVICES += tl-wr841-v11
 
 define Device/tl-wr841-v12
   $(Device/tl-wr841-v11)
   DEVICE_TITLE := TP-LINK TL-WR841N/ND v12
   TPLINK_HWID := 0x08410012
 endef
-TARGET_DEVICES += tl-wr841-v1.5 tl-wr841-v3 tl-wr841-v5 tl-wr841-v7 tl-wr841-v8 tl-wr841-v9 tl-wr841-v10 tl-wr841-v11 tl-wr841-v12
+TARGET_DEVICES += tl-wr841-v12
 
 define Device/tl-wr842n-v1
   $(Device/tplink-8m)
@@ -1014,6 +1092,7 @@ define Device/tl-wr842n-v1
   DEVICE_PROFILE := TLWR842
   TPLINK_HWID := 0x08420001
 endef
+TARGET_DEVICES += tl-wr842n-v1
 
 define Device/tl-wr842n-v2
   $(Device/tplink-8mlzma)
@@ -1023,6 +1102,7 @@ define Device/tl-wr842n-v2
   DEVICE_PROFILE := TLWR842
   TPLINK_HWID := 0x8420002
 endef
+TARGET_DEVICES += tl-wr842n-v2
 
 define Device/tl-wr842n-v3
   $(Device/tplink-16mlzma)
@@ -1032,6 +1112,7 @@ define Device/tl-wr842n-v3
   DEVICE_PROFILE := TLWR842
   TPLINK_HWID := 0x08420003
 endef
+TARGET_DEVICES += tl-wr842n-v3
 
 define Device/tl-wr843nd-v1
   $(Device/tplink-4mlzma)
@@ -1040,6 +1121,7 @@ define Device/tl-wr843nd-v1
   DEVICE_PROFILE := TLWR843
   TPLINK_HWID := 0x08430001
 endef
+TARGET_DEVICES += tl-wr843nd-v1
 
 define Device/tl-wr847n-v8
   $(Device/tplink-4mlzma)
@@ -1048,7 +1130,7 @@ define Device/tl-wr847n-v8
   DEVICE_PROFILE := TLWR841
   TPLINK_HWID := 0x08470008
 endef
-TARGET_DEVICES += tl-wr842n-v1 tl-wr842n-v2 tl-wr842n-v3 tl-wr843nd-v1 tl-wr847n-v8
+TARGET_DEVICES += tl-wr847n-v8
 
 define Device/tl-wr902ac-v1
   DEVICE_TITLE := TP-LINK TL-WR902AC v1
@@ -1081,6 +1163,7 @@ define Device/tl-wr940n-v4
   IMAGE/factory-us.bin := append-rootfs | mktplinkfw factory -C US
   IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
 endef
+TARGET_DEVICES += tl-wr940n-v4
 
 define Device/tl-wr941nd-v2
   $(Device/tplink-4m)
@@ -1090,11 +1173,13 @@ define Device/tl-wr941nd-v2
   TPLINK_HWID := 0x09410002
   TPLINK_HWREV := 2
 endef
+TARGET_DEVICES += tl-wr941nd-v2
 
 define Device/tl-wr941nd-v3
   $(Device/tl-wr941nd-v2)
   DEVICE_TITLE := TP-LINK TL-WR941N/ND v3
 endef
+TARGET_DEVICES += tl-wr941nd-v3
 
 define Device/tl-wr941nd-v4
   $(Device/tplink-4m)
@@ -1103,6 +1188,7 @@ define Device/tl-wr941nd-v4
   DEVICE_PROFILE := TLWR941
   TPLINK_HWID := 0x09410004
 endef
+TARGET_DEVICES += tl-wr941nd-v4
 
 define Device/tl-wr941nd-v5
   $(Device/tplink-4mlzma)
@@ -1111,6 +1197,7 @@ define Device/tl-wr941nd-v5
   DEVICE_PROFILE := TLWR941
   TPLINK_HWID := 0x09410005
 endef
+TARGET_DEVICES += tl-wr941nd-v5
 
 define Device/tl-wr941nd-v6
   $(Device/tplink-4mlzma)
@@ -1119,6 +1206,7 @@ define Device/tl-wr941nd-v6
   DEVICE_PROFILE := TLWR941
   TPLINK_HWID := 0x09410006
 endef
+TARGET_DEVICES += tl-wr941nd-v6
 
 # Chinese version (unlike European) is similar to the TL-WDR3500
 define Device/tl-wr941nd-v6-cn
@@ -1128,6 +1216,7 @@ define Device/tl-wr941nd-v6-cn
   DEVICE_PROFILE := TLWR941
   TPLINK_HWID := 0x09410006
 endef
+TARGET_DEVICES += tl-wr941nd-v6-cn
 
 define Device/tl-wr942n-v1
   DEVICE_TITLE := TP-LINK TL-WR942N v1
@@ -1144,4 +1233,4 @@ define Device/tl-wr942n-v1
   MTDPARTS := spi0.0:128k(u-boot)ro,14464k(firmware),64k(product-info)ro,64k(partition-table)ro,256k(oem-config)ro,1344k(oem-vars)ro,64k(ART)ro
   SUPPORTED_DEVICES := tl-wr942n-v1
 endef
-TARGET_DEVICES += tl-wr940n-v4 tl-wr941nd-v2 tl-wr941nd-v3 tl-wr941nd-v4 tl-wr941nd-v5 tl-wr941nd-v6 tl-wr941nd-v6-cn tl-wr942n-v1
+TARGET_DEVICES += tl-wr942n-v1

--- a/target/linux/ar71xx/image/ubnt.mk
+++ b/target/linux/ar71xx/image/ubnt.mk
@@ -71,31 +71,35 @@ define Device/rw2458n
   DEVICE_TITLE := Ubiquiti RW2458N
   BOARDNAME := RW2458N
 endef
+TARGET_DEVICES += rw2458n
 
 define Device/ubnt-airrouter
   $(Device/ubnt-xm)
   DEVICE_TITLE := Ubiquiti AirRouter
   BOARDNAME := UBNT-AR
 endef
+TARGET_DEVICES += ubnt-airrouter
 
 define Device/ubnt-bullet-m
   $(Device/ubnt-xm)
   DEVICE_TITLE := Ubiquiti Bullet-M
   BOARDNAME := UBNT-BM
 endef
+TARGET_DEVICES += ubnt-bullet-m
 
 define Device/ubnt-rocket-m
   $(Device/ubnt-xm)
   DEVICE_TITLE := Ubiquiti Rocket-M
   BOARDNAME := UBNT-RM
 endef
+TARGET_DEVICES += ubnt-rocket-m
 
 define Device/ubnt-nano-m
   $(Device/ubnt-xm)
   DEVICE_TITLE := Ubiquiti Nano-M
   BOARDNAME := UBNT-NM
 endef
-TARGET_DEVICES += rw2458n ubnt-airrouter ubnt-bullet-m ubnt-rocket-m ubnt-nano-m
+TARGET_DEVICES += ubnt-nano-m
 
 define Device/ubnt-unifi
   $(Device/ubnt-bz)
@@ -103,6 +107,7 @@ define Device/ubnt-unifi
   BOARDNAME := UBNT-UF
   DEVICE_PROFILE += UBNTUNIFI
 endef
+TARGET_DEVICES += ubnt-unifi
 
 define Device/ubnt-unifiac
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
@@ -120,11 +125,13 @@ define Device/ubnt-unifiac-lite
   DEVICE_PROFILE += UBNTUNIFIACLITE
   BOARDNAME := UBNT-UF-AC-LITE
 endef
+TARGET_DEVICES += ubnt-unifiac-lite
 
 define Device/ubnt-unifiac-mesh
   $(Device/ubnt-unifiac-lite)
   DEVICE_TITLE := Ubiquiti UniFi AC-Mesh
 endef
+TARGET_DEVICES += ubnt-unifiac-mesh
 
 define Device/ubnt-unifiac-pro
   $(Device/ubnt-unifiac)
@@ -133,6 +140,7 @@ define Device/ubnt-unifiac-pro
   DEVICE_PROFILE += UBNTUNIFIACPRO
   BOARDNAME := UBNT-UF-AC-PRO
 endef
+TARGET_DEVICES += ubnt-unifiac-pro
 
 define Device/ubnt-unifi-outdoor
   $(Device/ubnt-bz)
@@ -140,25 +148,28 @@ define Device/ubnt-unifi-outdoor
   BOARDNAME := UBNT-U20
   DEVICE_PROFILE += UBNTUNIFIOUTDOOR
 endef
-TARGET_DEVICES += ubnt-unifi ubnt-unifiac-lite ubnt-unifiac-mesh ubnt-unifiac-pro ubnt-unifi-outdoor
+TARGET_DEVICES += ubnt-unifi-outdoor
 
 define Device/ubnt-nano-m-xw
   $(Device/ubnt-xw)
   DEVICE_TITLE := Ubiquiti Nano M XW
   BOARDNAME := UBNT-NM-XW
 endef
+TARGET_DEVICES += ubnt-nano-m-xw
 
 define Device/ubnt-loco-m-xw
   $(Device/ubnt-xw)
   DEVICE_TITLE := Ubiquiti Loco XW
   BOARDNAME := UBNT-LOCO-XW
 endef
+TARGET_DEVICES += ubnt-loco-m-xw
 
 define Device/ubnt-rocket-m-xw
   $(Device/ubnt-xw)
   DEVICE_TITLE := Ubiquiti Rocket M XW
   BOARDNAME := UBNT-RM-XW
 endef
+TARGET_DEVICES += ubnt-rocket-m-xw
 
 define Device/ubnt-rocket-m-ti
   $(Device/ubnt-xw)
@@ -166,7 +177,7 @@ define Device/ubnt-rocket-m-ti
   BOARDNAME := UBNT-RM-TI
   UBNT_TYPE := TI
 endef
-TARGET_DEVICES += ubnt-nano-m-xw ubnt-loco-m-xw ubnt-rocket-m-xw ubnt-rocket-m-ti
+TARGET_DEVICES += ubnt-rocket-m-ti
 
 define Device/ubnt-air-gateway
   $(Device/ubnt-xm)
@@ -176,6 +187,7 @@ define Device/ubnt-air-gateway
   UBNT_CHIP := ar933x
   CONSOLE := ttyATH0,115200
 endef
+TARGET_DEVICES += ubnt-air-gateway
 
 define Device/ubnt-air-gateway-pro
   $(Device/ubnt-xm)
@@ -184,6 +196,7 @@ define Device/ubnt-air-gateway-pro
   UBNT_TYPE := AirGWP
   UBNT_CHIP := ar934x
 endef
+TARGET_DEVICES += ubnt-air-gateway-pro
 
 define Device/ubdev01
   $(Device/ubnt-xm)
@@ -192,7 +205,7 @@ define Device/ubdev01
   BOARDNAME := UBNT-UF
   UBNT_BOARD := UBDEV01
 endef
-TARGET_DEVICES += ubnt-air-gateway ubnt-air-gateway-pro ubdev01
+TARGET_DEVICES += ubdev01
 
 define Device/ubnt-routerstation
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2
@@ -213,6 +226,7 @@ define Device/ubnt-rs
   UBNT_TYPE := RSx
   UBNT_CHIP := ar7100
 endef
+TARGET_DEVICES += ubnt-rs
 
 define Device/ubnt-rspro
   $(Device/ubnt-routerstation)
@@ -223,6 +237,7 @@ define Device/ubnt-rspro
   UBNT_TYPE := RSPRO
   UBNT_CHIP := ar7100pro
 endef
+TARGET_DEVICES += ubnt-rspro
 
 define Device/ubnt-ls-sr71
   $(Device/ubnt-routerstation)
@@ -232,7 +247,7 @@ define Device/ubnt-ls-sr71
   UBNT_TYPE := LS-SR71
   UBNT_CHIP := ar7100
 endef
-TARGET_DEVICES += ubnt-rs ubnt-rspro ubnt-ls-sr71
+TARGET_DEVICES += ubnt-ls-sr71
 
 define Device/ubnt-uap-pro
   DEVICE_TITLE := Ubiquiti UAP Pro

--- a/target/linux/brcm47xx/image/Makefile
+++ b/target/linux/brcm47xx/image/Makefile
@@ -519,7 +519,16 @@ define Device/usrobotics-usr5461
 endef
 TARGET_DEVICES += usrobotics-usr5461
 
-TARGET_DEVICES += standard standard-noloader-gz
+define Device/legacy-standard
+  $(Device/standard)
+endef
+TARGET_DEVICES += legacy-standard
+
+define Device/legacy-standard-noloader-gz
+  $(Device/standard-noloader-gz)
+endef
+TARGET_DEVICES += legacy-standard-noloader-gz
+
 endif
 
 #################################################
@@ -964,7 +973,16 @@ define Device/netgear-wnr3500-v2-vc
 endef
 #  TARGET_DEVICES += netgear-wnr3500-v2-vc
 
-TARGET_DEVICES += standard standard-noloader-nodictionarylzma
+define Device/mips74k-standard
+  $(Device/standard)
+endef
+TARGET_DEVICES += mips74k-standard
+
+define Device/mips74k-standard-noloader-nodictionarylzma
+  $(Device/standard-noloader-nodictionarylzma)
+endef
+TARGET_DEVICES += mips74k-standard-noloader-nodictionarylzma
+
 endif
 
 #################################################

--- a/target/linux/imx6/image/Makefile
+++ b/target/linux/imx6/image/Makefile
@@ -104,6 +104,7 @@ define Device/ventana
   BLOCKSIZE := 128k
   MKUBIFS_OPTS := -m $$(PAGESIZE) -e 124KiB
 endef
+TARGET_DEVICES += ventana
 
 define Device/ventana-large
   $(Device/ventana)
@@ -114,14 +115,12 @@ define Device/ventana-large
   BLOCKSIZE := 256k
   MKUBIFS_OPTS := -m $$(PAGESIZE) -e 248KiB
 endef
+TARGET_DEVICES += ventana-large
 
 define Device/wandboard
   DEVICE_TITLE := Wandboard Dual
   DEVICE_DTS := imx6dl-wandboard
 endef
-
-TARGET_DEVICES += \
-	ventana ventana-large \
-	wandboard
+TARGET_DEVICES += wandboard
 
 $(eval $(call BuildImage))

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -109,6 +109,7 @@ define Device/AP148
 	DEVICE_TITLE := Qualcomm AP148
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
+TARGET_DEVICES += AP148
 
 define Device/AP148-legacy
 	$(call Device/LegacyImage)
@@ -120,6 +121,7 @@ define Device/AP148-legacy
 	DEVICE_TITLE := Qualcomm AP148 (legacy)
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
+TARGET_DEVICES += AP148-legacy
 
 define Device/C2600
 	$(call Device/TpSafeImage)
@@ -131,6 +133,7 @@ define Device/C2600
 	DEVICE_TITLE := TP-Link Archer C2600
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
+TARGET_DEVICES += C2600
 
 define Device/D7800
 	$(call Device/DniImage)
@@ -144,6 +147,7 @@ define Device/D7800
 	DEVICE_TITLE := Netgear Nighthawk X4 D7800
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
+TARGET_DEVICES += D7800
 
 define Device/DB149
 	$(call Device/FitImage)
@@ -153,6 +157,7 @@ define Device/DB149
 	DEVICE_TITLE := Qualcomm DB149
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
+TARGET_DEVICES += DB149
 
 define Device/EA8500
 	$(call Device/LegacyImage)
@@ -170,6 +175,7 @@ define Device/EA8500
 	DEVICE_TITLE := Linksys EA8500
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0
 endef
+TARGET_DEVICES += EA8500
 
 define Device/FRITZ4040
 	$(call Device/FitImageLzma)
@@ -184,6 +190,7 @@ define Device/FRITZ4040
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
 	DEVICE_PACKAGES := kmod-usb-phy-qcom-ipq4019 ipq-wifi-fritz4040 fritz-tffs fritz-caldata u-boot-fritz4040
 endef
+TARGET_DEVICES += FRITZ4040
 
 define Device/R7500
 	$(call Device/DniImage)
@@ -197,6 +204,7 @@ define Device/R7500
 	DEVICE_TITLE := Netgear Nighthawk X4 R7500
 	DEVICE_PACKAGES := ath10k-firmware-qca988x
 endef
+TARGET_DEVICES += R7500
 
 define Device/R7500v2
 	$(call Device/DniImage)
@@ -210,6 +218,7 @@ define Device/R7500v2
 	DEVICE_TITLE := Netgear Nighthawk X4 R7500v2
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0 ath10k-firmware-qca988x
 endef
+TARGET_DEVICES += R7500v2
 
 define Device/R7800
 	$(call Device/DniImage)
@@ -223,6 +232,7 @@ define Device/R7800
 	DEVICE_TITLE := Netgear Nighthawk X4S R7800
 	DEVICE_PACKAGES := ath10k-firmware-qca9984
 endef
+TARGET_DEVICES += R7800
 
 define Device/NBG6817
 	DEVICE_DTS := qcom-ipq8065-nbg6817
@@ -233,6 +243,7 @@ define Device/NBG6817
 	DEVICE_PACKAGES := ath10k-firmware-qca9984 e2fsprogs kmod-fs-ext4 losetup
 	$(call Device/ZyXELImage)
 endef
+TARGET_DEVICES += NBG6817
 
 define Device/VR2600v
 	PROFILES += $$(DEVICE_NAME)
@@ -250,6 +261,7 @@ define Device/VR2600v
 	IMAGES := sysupgrade.bin
 	IMAGE/sysupgrade.bin := pad-extra 512 | append-kernel | pad-to $$$${KERNEL_SIZE} | append-rootfs | pad-rootfs | append-metadata
 endef
+TARGET_DEVICES += VR2600v
 
 define Device/AP-DK01.1-C1
 	PROFILES += $$(DEVICE_NAME)
@@ -266,6 +278,7 @@ define Device/AP-DK01.1-C1
 	IMAGE/sysupgrade.bin := append-kernel | pad-to $$$${KERNEL_SIZE} | append-rootfs | pad-rootfs | append-metadata
 	DEVICE_PACKAGES := ath10k-firmware-qca4019
 endef
+TARGET_DEVICES += AP-DK01.1-C1
 
 define Device/AP-DK04.1-C1
 	$(call Device/FitImage)
@@ -279,8 +292,6 @@ define Device/AP-DK04.1-C1
 	BOARD_NAME := ap-dk04.1-c1
 	DEVICE_TITLE := QCA AP-DK04.1-C1
 endef
-
-TARGET_DEVICES += AP148 AP148-legacy C2600 D7800 DB149 EA8500 FRITZ4040 R7500 \
-		  R7500v2 R7800 NBG6817 VR2600v AP-DK01.1-C1 AP-DK04.1-C1
+TARGET_DEVICES += AP-DK04.1-C1
 
 $(eval $(call BuildImage))

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -11,7 +11,6 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
 KERNEL_LOADADDR:=0x8000
-TARGET_DEVICES = linksys-audi linksys-viper dockstar goflexnet goflexhome iconnect pogo_e02 ib62x0 nsa310b nsa325 on100
 
 UBI_OPTS := -m 2048 -p 128KiB -s 512
 UBIFS_OPTS := -m 2048 -e 126KiB -c 4096
@@ -39,18 +38,21 @@ define Device/dockstar
   IMAGE/factory.bin := append-ubi
   KERNEL_IN_UBI := 1
 endef
+TARGET_DEVICES += dockstar
 
 define Device/goflexnet
 $(Device/dockstar)
   DEVICE_TITLE := Seagate GoFlexNet
   DEVICE_DTS := kirkwood-goflexnet
 endef
+TARGET_DEVICES += goflexnet
 
 define Device/goflexhome
 $(Device/dockstar)
   DEVICE_TITLE := Seagate GoFlexHome
   DEVICE_DTS := kirkwood-goflexhome
 endef
+TARGET_DEVICES += goflexhome
 
 define Device/linksys-audi
   DEVICE_TITLE := Linksys EA3500 (Audi)
@@ -62,6 +64,7 @@ define Device/linksys-audi
   UBINIZE_OPTS := -E 5
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
 endef
+TARGET_DEVICES += linksys-audi
 
 define Device/linksys-viper
   DEVICE_TITLE := Linksys E4200v2 / EA4500 (Viper)
@@ -73,12 +76,14 @@ define Device/linksys-viper
   UBINIZE_OPTS := -E 5
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
 endef
+TARGET_DEVICES += linksys-viper
 
 define Device/iconnect
 $(Device/dockstar)
   DEVICE_TITLE := Iomega Iconnect
   DEVICE_DTS := kirkwood-iconnect
 endef
+TARGET_DEVICES += iconnect
 
 define Device/nsa310b
 $(Device/dockstar)
@@ -86,6 +91,7 @@ $(Device/dockstar)
   DEVICE_DTS := kirkwood-nsa310b
   DEVICE_PACKAGES := kmod-r8169 kmod-gpio-button-hotplug kmod-hwmon-lm85
 endef
+TARGET_DEVICES += nsa310b
 
 define Device/nsa325
 $(Device/dockstar)
@@ -93,6 +99,7 @@ $(Device/dockstar)
   DEVICE_DTS := kirkwood-nsa325
   DEVICE_PACKAGES := kmod-gpio-button-hotplug kmod-rtc-pcf8563 kmod-usb3
 endef
+TARGET_DEVICES += nsa325
 
 define Device/on100
   DEVICE_TITLE := Cisco Systems ON100
@@ -104,17 +111,20 @@ define Device/on100
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
   UBINIZE_OPTS := -E 5
 endef
+TARGET_DEVICES += on100
 
 define Device/pogo_e02
 $(Device/dockstar)
   DEVICE_TITLE := Cloud Engines Pogoplug E02
   DEVICE_DTS := kirkwood-pogo_e02
 endef
+TARGET_DEVICES += pogo_e02
 
 define Device/ib62x0
 $(Device/dockstar)
   DEVICE_TITLE := RaidSonic ICY BOX IB-NAS62x0
   DEVICE_DTS := kirkwood-ib62x0
 endef
+TARGET_DEVICES += ib62x0
 
 $(eval $(call BuildImage))

--- a/target/linux/lantiq/image/tp-link.mk
+++ b/target/linux/lantiq/image/tp-link.mk
@@ -21,6 +21,7 @@ define Device/TDW8970
   DEVICE_TITLE := TP-LINK TD-W8970
   DEVICE_PACKAGES:= kmod-ath9k wpad-mini kmod-usb-dwc2 kmod-usb-ledtrig-usbport
 endef
+TARGET_DEVICES += TDW8970
 
 define Device/TDW8980
   $(Device/lantiqTpLink)
@@ -32,6 +33,7 @@ define Device/TDW8980
   DEVICE_TITLE := TP-LINK TD-W8980
   DEVICE_PACKAGES:= kmod-ath9k kmod-owl-loader wpad-mini kmod-usb-dwc2 kmod-usb-ledtrig-usbport
 endef
+TARGET_DEVICES += TDW8980
 
 define Device/VR200v
   $(Device/lantiqTpLink)
@@ -44,5 +46,5 @@ define Device/VR200v
   DEVICE_TITLE := TP-LINK Archer VR200v
   DEVICE_PACKAGES:= kmod-usb-dwc2 kmod-usb-ledtrig-usbport
 endef
-TARGET_DEVICES += TDW8970 TDW8980 VR200v
+TARGET_DEVICES += VR200v
 

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -163,11 +163,25 @@ define Device/marvell-nand
   DEVICE_TITLE := Marvell Armada $(1)
 endef
 
-Device/armada-370-db = $(call Device/marvell-nand,370 DB (DB-88F6710-BP-DDR3))
-Device/armada-370-rd = $(call Device/marvell-nand,370 RD (RD-88F6710-A1))
-Device/armada-xp-db = $(call Device/marvell-nand,XP DB (DB-78460-BP))
-Device/armada-xp-gp = $(call Device/marvell-nand,XP GP (DB-MV784MP-GP))
-TARGET_DEVICES += armada-370-db armada-370-rd armada-xp-db armada-xp-gp
+define Device/armada-370-db
+	$(call Device/marvell-nand,370 DB (DB-88F6710-BP-DDR3))
+endef
+TARGET_DEVICES += armada-370-db
+
+define Device/armada-370-rd
+	$(call Device/marvell-nand,370 RD (RD-88F6710-A1))
+endef
+TARGET_DEVICES += armada-370-rd
+
+define Device/armada-xp-db
+	$(call Device/marvell-nand,XP DB (DB-78460-BP))
+endef
+TARGET_DEVICES += armada-xp-db
+
+define Device/armada-xp-gp
+	$(call Device/marvell-nand,XP GP (DB-MV784MP-GP))
+endef
+TARGET_DEVICES += armada-xp-gp
 
 define Device/armada-388-rd
   DEVICE_TITLE := Marvell Armada 388 RD (RD-88F6820-AP)

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -64,6 +64,7 @@ define Device/omega2
   DEVICE_TITLE := Onion Omega2
   DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools
 endef
+TARGET_DEVICES += omega2
 
 define Device/omega2p
   DTS := OMEGA2P
@@ -71,7 +72,7 @@ define Device/omega2p
   DEVICE_TITLE := Onion Omega2+
   DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools kmod-sdhci-mt7620
 endef
-TARGET_DEVICES += omega2 omega2p
+TARGET_DEVICES += omega2p
 
 define Device/pbr-d1
   DTS := PBR-D1
@@ -98,6 +99,7 @@ define Device/tl-wr840n-v4
   IMAGE/sysupgrade.bin := tplink-v2-image -s -e | append-metadata | \
 	check-size $$$$(IMAGE_SIZE)
 endef
+TARGET_DEVICES += tl-wr840n-v4
 
 define Device/tl-wr840n-v5
   DTS := TL-WR840NV5
@@ -113,6 +115,7 @@ define Device/tl-wr840n-v5
   IMAGE/sysupgrade.bin := tplink-v2-image -s -e | append-metadata | \
 	check-size $$$$(IMAGE_SIZE)
 endef
+TARGET_DEVICES += tl-wr840n-v5
 
 define Device/tl-wr841n-v13
   $(Device/tl-wr840n-v4)
@@ -122,7 +125,7 @@ define Device/tl-wr841n-v13
   TPLINK_HWREV := 0x268
   TPLINK_HWREVADD := 0x13
 endef
-TARGET_DEVICES += tl-wr840n-v4 tl-wr840n-v5 tl-wr841n-v13
+TARGET_DEVICES += tl-wr841n-v13
 
 define Device/u7628-01-128M-16M
   DTS := U7628-01-128M-16M
@@ -139,6 +142,7 @@ define Device/vocore2
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
     kmod-sdhci-mt7620
 endef
+TARGET_DEVICES += vocore2
 
 define Device/vocore2lite
   DTS := VOCORE2LITE
@@ -147,7 +151,7 @@ define Device/vocore2lite
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
     kmod-sdhci-mt7620
 endef
-TARGET_DEVICES += vocore2 vocore2lite
+TARGET_DEVICES += vocore2lite
 
 define Device/wcr-1166ds
   DTS := WCR-1166DS
@@ -186,6 +190,7 @@ define Device/wrtnode2p
   DEVICE_TITLE := WRTnode 2P
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
 endef
+TARGET_DEVICES += wrtnode2p
 
 define Device/wrtnode2r
   DTS := WRTNODE2R
@@ -193,4 +198,4 @@ define Device/wrtnode2r
   DEVICE_TITLE := WRTnode 2R
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
 endef
-TARGET_DEVICES += wrtnode2p wrtnode2r
+TARGET_DEVICES += wrtnode2r


### PR DESCRIPTION
I've encountered conflicts several times when rebasing a developing branch (ipq806x) against master.

This will avoid some conflicts when doing a git rebase or merge,
specially when adding support to a a new device.