### PR TITLE
ar71xx: TL-WR1043N(D) v2+ add support for VLAN IDs up to 4096

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/ar8216.h
+++ b/target/linux/generic/files/drivers/net/phy/ar8216.h
@@ -29,7 +29,7 @@
 #define AR8316_NUM_VLANS	4096
 
 /* size of the vlan table */
-#define AR8X16_MAX_VLANS	128
+#define AR8X16_MAX_VLANS	4096
 #define AR8X16_PROBE_RETRIES	10
 #define AR8X16_MAX_PORTS	8
 


### PR DESCRIPTION
This patch solves this [old problem](https://dev.openwrt.org/ticket/22316) in TPLINK 1043ND v2+.

It permits to assign VLAN ids > 128.

Signed-off-by: Felipe Zipitría <fzipi@fing.edu.uy>
