### PR TITLE
iptables: allow IPTABLES_NFTABLES

### DIFF
--- a/package/network/utils/iptables/patches/600-shared-libext.patch
+++ b/package/network/utils/iptables/patches/600-shared-libext.patch
@@ -82,3 +82,24 @@
  endif
  xtables_multi_SOURCES += xshared.c
  xtables_multi_LDADD   += ../libxtables/libxtables.la -lm
+@@ -32,7 +35,9 @@ if ENABLE_NFTABLES
+ BUILT_SOURCES += xtables-config-parser.h
+ xtables_compat_multi_SOURCES  = xtables-compat-multi.c iptables-xml.c
+ xtables_compat_multi_CFLAGS   = ${AM_CFLAGS}
+-xtables_compat_multi_LDADD    = ../extensions/libext.a ../extensions/libext_ebt.a
++#xtables_compat_multi_LDADD    = ../extensions/libext.a ../extensions/libext_ebt.a
++xtables_compat_multi_LDADD    =
++xtables_compat_multi_LDFLAGS  = -L../extensions/ -liptext -liptext_ebt
+ if ENABLE_STATIC
+ xtables_compat_multi_CFLAGS  += -DALL_INCLUSIVE
+ endif
+@@ -45,7 +50,8 @@ xtables_compat_multi_SOURCES += xtables-
+ 				getethertype.c nft-bridge.c \
+ 				xtables-eb-standalone.c xtables-eb.c \
+ 				xtables-translate.c
+-xtables_compat_multi_LDADD   += ${libmnl_LIBS} ${libnftnl_LIBS} ${libnetfilter_conntrack_LIBS} ../extensions/libext4.a ../extensions/libext6.a ../extensions/libext_ebt.a ../extensions/libext_arpt.a
++xtables_compat_multi_LDADD   += ${libmnl_LIBS} ${libnftnl_LIBS} ${libnetfilter_conntrack_LIBS}
++xtables_compat_multi_LDFLAGS += -L../extensions/ -liptext4 -liptext6 -liptext_ebt -liptext_arpt
+ # yacc and lex generate dirty code
+ xtables_compat_multi-xtables-config-parser.o xtables_compat_multi-xtables-config-syntax.o: AM_CFLAGS += -Wno-missing-prototypes -Wno-missing-declarations -Wno-implicit-function-declaration -Wno-nested-externs -Wno-undef -Wno-redundant-decls
+ xtables_compat_multi_SOURCES += xshared.c


### PR DESCRIPTION
Enabling IPTABLES_NFTABLES resulted in an error during build:
*** No rule to make target '../extensions/libext.a',
needed by 'xtables-compat-multi'."
    
Comments from Alexander Lochmann and Fedor Konstantinov in FS#711
provided fixes for this build error, allowing iptables to compile.
https://bugs.lede-project.org/index.php?do=details&task_id=711.
    
This commit updates the Makefile.am xtables_compat_multi_LDFLAGS
and _LDADD, moving a number of linking responsibilities to LDFLAGS.