### PR TITLE
ramips: add full support for newifi d2

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -304,6 +304,12 @@ pbr-m1)
 	ucidef_set_led_default "power" "power" "$board:blue:power" "1"
 	ucidef_set_led_default "sys" "sys" "$board:blue:sys" "1"
 	;;
+newifi-d2)
+	set_usb_led "$board:blue:usb"
+	ucidef_set_led_switch "internet" "internet" "$board:amber:internet" "switch0" "0x10"
+	ucidef_set_led_netdev "wlan2g" "WiFi 2.4GHz" "$board:blue:wlan2g" "wlan0"
+	ucidef_set_led_netdev "wlan5g" "WiFi 5GHz" "$board:blue:wlan5g" "wlan1"
+	;;
 psg1208)
 	set_wifi_led "$board:white:wlan2g"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -93,6 +93,7 @@ ramips_setup_interfaces()
 	mt7628|\
 	mzk-750dhp|\
 	mzk-w300nh2|\
+	newifi-d2|\
 	nixcore-x1-8M|\
 	nixcore-x1-16M|\
 	oy-0001|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -124,6 +124,7 @@ get_status_led() {
 	d240|\
 	dap-1350|\
 	na930|\
+	newifi-d2|\
 	pbr-m1|\
 	re350-v1|\
 	rt-ac51u|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -376,6 +376,9 @@ ramips_board_detect() {
 	*"Newifi-D1")
 		name="newifi-d1"
 		;;
+	*"Newifi-D2")
+		name="newifi-d2"
+		;;
 	*"NCS601W")
 		name="ncs601w"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -108,6 +108,7 @@ platform_check_image() {
 	nbg-419n|\
 	nbg-419n2|\
 	newifi-d1|\
+	newifi-d2|\
 	nixcore-x1-8M|\
 	nixcore-x1-16M|\
 	nw718|\

--- a/target/linux/ramips/dts/Newifi-D2.dts
+++ b/target/linux/ramips/dts/Newifi-D2.dts
@@ -1,0 +1,165 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "pandorabox,newifi-d2", "mediatek,mt7621-soc";
+	model = "Newifi-D2";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power-amber {
+			label = "newifi-d2:amber:power";
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+		};
+
+		power-blue {
+			label = "newifi-d2:blue:power";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		};
+		
+		internet-amber {
+			label = "newifi-d2:amber:internet";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+
+		internet-blue {
+			label = "newifi-d2:blue:internet";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "newifi-d2:blue:wlan2g";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "newifi-d2:blue:wlan5g";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "newifi-d2:blue:usb";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+		
+		wps {
+			label = "wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		power_usb3 {
+			gpio-export,name = "power_usb3";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdhci_pins>;
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfb0000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+		};
+	};
+
+	pcie1 {
+		mt76@1,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt", "rgmii2", "jtag", "uart3";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -142,6 +142,16 @@ define Device/newifi-d1
 endef
 TARGET_DEVICES += newifi-d1
 
+define Device/newifi-d2
+  DTS := Newifi-D2
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DEVICE_TITLE := Newifi D2
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-mt76x2 kmod-sdhci-mt7620 \
+	kmod-usb3 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += newifi-d2
+
 define Device/pbr-m1
   DTS := PBR-M1
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
# Overview

Previously Newifi D2 could only use PandoraBox M1's firmware. It works fine, but LED GPIO is different. As a result, a separated DTS file for this device should be implemented.

Signed-off-by: Jackson Ming Hu <huming2207@gmail.com>

# Installation method

the same as PBR-M1 and/or Newifi D1.

Simply upload the firmware to bootloader's web console (press and hold reset button when powering it up) at 192.168.1.1.

# Hardware spec

* CPU: MTK MT7621A
* RAM: 512MB
* ROM: 32MB SPI Flash
* WiFi: MT7612EN+MT7603EN
* Other features: USB 3.0, UART, Gigabit Ethernet

