### PR TITLE
ramips: add support for TP-Link TL-MR3420 v5

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -361,11 +361,18 @@ tiny-ac)
 	set_wifi_led "$board:orange:wifi"
 	set_usb_led "$board:green:usb"
 	;;
+tl-mr3420-v5|\
 tl-wr840n-v4)
 	set_wifi_led "$board:green:wlan"
 	ucidef_set_led_switch "lan" "lan" "$board:green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$board:green:wan" "switch0" "0x01"
-	;;
+
+	case "$board" in
+	tl-mr3420-v5)
+		set_usb_led "$board:green:usb"
+		;;
+	esac
+;;
 tl-wr841n-v13)
 	set_wifi_led "$board:green:wlan"
 	ucidef_set_led_switch "lan1" "lan1" "$board:green:lan1" "switch0" "0x2"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -173,6 +173,7 @@ ramips_setup_interfaces()
 	mzk-wdpr|\
 	rb750gr3|\
 	rt-n14u|\
+	tl-mr3420-v5|\
 	tl-wr840n-v4|\
 	tl-wr840n-v5|\
 	tl-wr841n-v13|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -36,6 +36,7 @@ get_status_led() {
 	nbg-419n2|\
 	pwh2004|\
 	r6220|\
+	tl-mr3420-v5|\
 	tl-wr840n-v4|\
 	tl-wr840n-v5|\
 	tl-wr841n-v13|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -502,6 +502,9 @@ ramips_board_detect() {
 	*"Timecloud")
 		name="timecloud"
 		;;
+	*"TL-MR3420 v5")
+		name="tl-mr3420-v5"
+		;;
 	*"TL-WR840N v4")
 		name="tl-wr840n-v4"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -239,6 +239,7 @@ platform_check_image() {
 	c20i|\
 	c50|\
 	mr200|\
+	tl-mr3420-v5|\
 	tl-wr840n-v4|\
 	tl-wr840n-v5|\
 	tl-wr841n-v13)

--- a/target/linux/ramips/dts/TL-MR3420V5.dts
+++ b/target/linux/ramips/dts/TL-MR3420V5.dts
@@ -1,0 +1,86 @@
+/dts-v1/;
+
+#include "TL-WR84XN.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-mr3420-v5", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-MR3420 v5";
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "tl-mr3420-v5:green:lan";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		power {
+			label = "tl-mr3420-v5:green:power";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "tl-mr3420-v5:green:usb";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "tl-mr3420-v5:green:wan";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "tl-mr3420-v5:amber:wan";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tl-mr3420-v5:green:wlan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tl-mr3420-v5:green:wps";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "p0led_an", "p2led_an", "perst", "refclk", "wdt", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -82,6 +82,18 @@ define Device/pbr-d1
 endef
 TARGET_DEVICES += pbr-d1
 
+define Device/tl-mr3420-v5
+  $(Device/tl-wr840n-v4)
+  DTS := TL-MR3420V5
+  SUPPORTED_DEVICES := tl-mr3420-v5
+  DEVICE_TITLE := TP-Link TL-MR3420 v5
+  TPLINK_HWID := 0x34200005
+  TPLINK_HWREV := 0x5
+  TPLINK_HWREVADD := 0x5
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += tl-mr3420-v5
+
 define Device/tl-wr840n-v4
   DTS := TL-WR840NV4
   IMAGE_SIZE := 7808k


### PR DESCRIPTION
TP-Link TL-MR3420 v5 are simple N300 router with
5-port FE switch and non-detachable antennas.
Its very similar to TP-Link TL-WR841N V13.

Specification:

- MT7628N/N (580 MHz)
- 64 MB of RAM (DDR2)
- 8 MB of FLASH
- 2T2R 2.4 GHz
- 5x 10/100 Mbps Ethernet
- 2x external, non-detachable antennas
- USB 2.0 Port
- UART (J1) header on PCB (115200 8n1)
- 8x LED, 2x button, power input switch

Flash instruction:

The only way to flash LEDE image in mr3420v5 is to use
tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.0.225/24 and tftp server.
2. Rename "lede-ramips-mt7628-tl-mr3420-v5-squashfs-tftp-recovery.bin"
   to "tp_recovery.bin" and place it in tftp server directory.
3. Connect PC with one of LAN ports, press the reset button, power up
   the router and keep button pressed for around 6-7 seconds, until
   device starts downloading the file.
4. Router will download file from server, write it to flash and reboot.
