### PR TITLE
ar71xx: Fix LAN leds for archer-c7-v4

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -60,13 +60,18 @@ sc450)
 	;;
 archer-c25-v1|\
 archer-c7-v4)
+	local pm_base;
+	case "$board" in
+		archer-c7-v4) pm_base=2 ;;
+		*) pm_base=1 ;;
+	esac
 	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
-	ucidef_set_led_switch "lan1" "LAN1" "$board:green:lan1" "switch0" "0x10"
-	ucidef_set_led_switch "lan2" "LAN2" "$board:green:lan2" "switch0" "0x08"
-	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan3" "switch0" "0x04"
-	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "0x02"
+	ucidef_set_led_switch "lan1" "LAN1" "$board:green:lan1" "switch0" "$((pm_base<<4))"
+	ucidef_set_led_switch "lan2" "LAN2" "$board:green:lan2" "switch0" "$((pm_base<<3))"
+	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan3" "switch0" "$((pm_base<<2))"
+	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "$((pm_base<<1))"
 	case "$board" in
 		archer-c7-v4)
 			ucidef_set_led_usbdev "usb1" "USB1" "$board:green:usb1" "1-1"


### PR DESCRIPTION
The port_mask seems to be one (left)shift off on (my) Archer C7 v4
(european version): led lan4 would be controlled by the link on the
wan port, whereas led lan1 would never work, even though link appeared
on port 5 of the switch.

pm_base corresponds to the switch port number of the wan interface.

Product info:

vendor_name:TP-Link
vendor_url:www.tp-link.com
product_name:Archer C7
device_name:Archer C7
language:EU
product_ver:4.0.0
product_id:00070004
special_id:45550000
oem_id:890725E7A1D0EFADCF5D3B3B44822726
country:DE
hw_ver:00000001
soft_ver:1.0.0
ild 20170301 rel.75727

New port_mask values:

$ grep . /sys/class/leds/*lan*/port_mask
/sys/class/leds/archer-c7-v4:green:lan1/port_mask:0x20
/sys/class/leds/archer-c7-v4:green:lan2/port_mask:0x10
/sys/class/leds/archer-c7-v4:green:lan3/port_mask:0x8
/sys/class/leds/archer-c7-v4:green:lan4/port_mask:0x4

Signed-off-by: Tijs Van Buggenhout <tvbuggen@gmail.com>