### PR TITLE
kernel: uas

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -894,7 +894,7 @@ define KernelPackage/usb-storage-uas
   DEPENDS:=+kmod-usb-storage
   KCONFIG:=CONFIG_USB_UAS
   FILES:=$(LINUX_DIR)/drivers/usb/storage/uas.ko
-  AUTOLOAD:=$(call AutoProbe,uas)
+  AUTOLOAD:=$(call AutoProbe,uas,1)
 endef
 
 define KernelPackage/usb-storage-uas/description


### PR DESCRIPTION
Add the uas module to the modules loaded on boot.
This is necessary to be able to use uas storage for extroot.

