### PR TITLE
ar71xx: fix MAC of 5GHz WiFi on Archer C58/C59/C60

### DIFF
--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -145,6 +145,7 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 12064
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -1)
 		;;
 	esac
 	;;


### PR DESCRIPTION
This assigns the 5GHz interface a MAC-address based on the devices primary MAC. 

Previously the MAC-address was not connected with the primary MAC.