### PR TITLE
ar71xx: Add support for MikroTik RB921GS-5HPacD-r2 devices

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -97,6 +97,7 @@ ar71xx_setup_interfaces()
 	rb-911g-5hpnd|\
 	rb-912uag-2hpnd|\
 	rb-912uag-5hpnd|\
+	rb-921gs-5hpacd-r2|\
 	rb-lhg-5nd|\
 	rb-mapl-2nd|\
 	rb-sxt2n|\

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -132,6 +132,7 @@ case "$FIRMWARE" in
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
 	rb-911g-5hpacd|\
+	rb-921gs-5hpacd-r2|\
 	rb-962uigs-5hact2hnt)
 		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
 		;;

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -944,6 +944,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD 912UAG-5HPnD")
 		name="rb-912uag-5hpnd"
 		;;
+	*"RouterBOARD 921GS-5HPacD r2")
+		name="rb-921gs-5hpacd-r2"
+		;;
 	*"RouterBOARD 941-2nD")
 		name="rb-941-2nd"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -512,6 +512,7 @@ platform_check_image() {
 	rb-911g-5hpacd|\
 	rb-912uag-2hpnd|\
 	rb-912uag-5hpnd|\
+	rb-921gs-5hpacd-r2|\
 	rb-951g-2hnd|\
 	rb-951ui-2hnd|\
 	rb-2011l|\
@@ -697,6 +698,7 @@ platform_pre_upgrade() {
 	rb-911g-5hpnd|\
 	rb-912uag-2hpnd|\
 	rb-912uag-5hpnd|\
+	rb-921gs-5hpacd-r2|\
 	rb-951g-2hnd|\
 	rb-951ui-2hnd|\
 	rb-2011il|\

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rb922.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rb922.c
@@ -195,7 +195,9 @@ static int rb922gs_nand_scan_fixup(struct mtd_info *mtd)
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
 	struct nand_chip *chip = mtd->priv;
-#endif
+#else
+	struct nand_chip *chip = mtd_to_nand(mtd);
+#endif /* < 4.6.0 */
 
 	if (mtd->writesize == 512) {
 		/*
@@ -208,6 +210,8 @@ static int rb922gs_nand_scan_fixup(struct mtd_info *mtd)
 		mtd_set_ooblayout(mtd, &rb922gs_nand_ecclayout_ops);
 #endif
 	}
+
+	chip->options = NAND_NO_SUBPAGE_WRITE;
 
 	return 0;
 }

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rb922.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rb922.c
@@ -276,9 +276,16 @@ static void __init rb922gs_setup(void)
 	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
 	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;
 	ath79_eth0_data.phy_mask = BIT(RB922_PHY_ADDR);
-	ath79_eth0_pll_data.pll_10 = 0x81001313;
-	ath79_eth0_pll_data.pll_100 = 0x81000101;
-	ath79_eth0_pll_data.pll_1000 = 0x8f000000;
+	if (strcmp(info->board_name, "921GS-5HPacD r2") == 0) {
+		ath79_eth0_pll_data.pll_10 = 0xa0001313;
+		ath79_eth0_pll_data.pll_100 = 0xa0000101;
+		ath79_eth0_pll_data.pll_1000 = 0x8f000000;
+	}
+	else {
+		ath79_eth0_pll_data.pll_10 = 0x81001313;
+		ath79_eth0_pll_data.pll_100 = 0x81000101;
+		ath79_eth0_pll_data.pll_1000 = 0x8f000000;
+	}
 
 	ath79_register_eth(0);
 

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rb922.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rb922.c
@@ -256,7 +256,7 @@ static void __init rb922gs_setup(void)
 	if (!info)
 		return;
 
-	scnprintf(buf, sizeof(buf), "Mikrotik RouterBOARD %s",
+	scnprintf(buf, sizeof(buf), "MikroTik RouterBOARD %s",
 		  (info->board_name) ? info->board_name : "");
 	mips_set_machine_name(buf);
 

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -24,6 +24,15 @@ define Device/nand-large
 endef
 TARGET_DEVICES += nand-large
 
+define Device/nand-large-ac
+  $(Device/mikrotik)
+  DEVICE_TITLE := MikroTik RouterBoard (>= 128 MB NAND, 802.11ac)
+  DEVICE_PACKAGES += kmod-ath10k ath10k-firmware-qca988x
+  KERNEL := kernel-bin | kernel2minor -s 2048 -e -c
+  SUPPORTED_DEVICES := rb-921gs-5hpacd-r2
+endef
+TARGET_DEVICES += nand-large-ac
+
 define Device/rb-nor-flash-16M
   DEVICE_TITLE := MikroTik RouterBoard (16 MB SPI NOR)
   DEVICE_PACKAGES := rbcfg rssileds -nand-utils kmod-ledtrig-gpio


### PR DESCRIPTION
This pull request contains a few commits to add support for the MikroTik RouterBOARD 921GS-5HPacD r2 wireless router.

- 1505d5786f2c33a74284bfbff10a16122f677c08: add a new profile to the ar71xx/mikrotik subtarget called "nand-large-ac"
Since the RB921GS-5HPacD r2 has an ath10k radio and the "nand-large" profile only ships the ath9k driver, it may make sense to add a new profile for devices with a large nand (>= 128 MB) which have an 802.11ac radio (QCA9880 or QCA9882 according to Mikrotik's web page).

- 1515f7abff05079e56ea9cde9ebb4ea8bb489c64: fix the rb922gs_nand_scan_fixup() function
This piece of code was applied to the RB95x devices and was also needed for the RB92x ones

- bc7b3b9c43bae17c3b35cbb9dbf6b7b8962e52a1: fix a typo in mach-rb922.c

- 29fd0a10beac666bbf3484f46d5c003d3200ada4: add support for MikroTik RouterBOARD 921GS-5HPacD r2 (mANTBox 15s)
Well, this actually adds support for the device.
