### PR TITLE
package/base-files: add -m option to append/check metadata on backup create/restore

### DIFF
--- a/package/base-files/files/lib/upgrade/fwtool.sh
+++ b/package/base-files/files/lib/upgrade/fwtool.sh
@@ -41,3 +41,77 @@ fwtool_check_image() {
 
 	return 1
 }
+
+fwtool_append_meta_config() {
+	[ $# -gt 1 ] && return 1
+
+	. /usr/share/libubox/jshn.sh
+	. /etc/openwrt_release
+
+	local sha256_file board
+
+	sha256_file=$(sha256sum "$1")
+	sha256_file="${sha256_file%% *}"
+
+	if [ -f "/tmp/sysinfo/board_name" ]; then
+		board="$(cat /tmp/sysinfo/board_name)"
+	else
+		board="unknown"
+	fi
+
+	json_init
+	json_add_object "version"
+	json_add_string "dist" "$DISTRIB_ID"
+	json_add_string "version" "$DISTRIB_RELEASE"
+	json_add_string "revision" "$DISTRIB_REVISION"
+	json_close_object
+	json_add_object "device"
+	json_add_string "target" "${DISTRIB_TARGET%%/*}"
+	json_add_string "subtarget" "${DISTRIB_TARGET##*/}"
+	json_add_string "board" "$board"
+	json_add_string "hostname" "$(hostname)"
+	json_close_object
+	json_add_object "checksum"
+	json_add_string "sha256sum" "$sha256_file"
+	json_close_object
+	json_dump | fwtool -I - "$1"
+
+	return 0
+}
+
+fwtool_check_meta_config() {
+	[ $# -gt 1 ] && return 1
+
+	. /usr/share/libubox/jshn.sh
+	. /etc/openwrt_release
+
+	local meta board_info sha256_file
+	local sha256sum board
+
+	meta=$(fwtool -t -i - "$1" 2>/dev/null)
+	[ -z "$meta" ] && return 2
+
+	sha256_file=$(sha256sum "$1")
+	sha256_file="${sha256_file%% *}"
+
+	echo "$meta" | fwtool -I - "$1"
+
+	if [ -f "/tmp/sysinfo/board_name" ]; then
+		board_info="$(cat /tmp/sysinfo/board_name)"
+	else
+		board_info="unknown"
+	fi
+
+	json_load "$meta"
+	json_select checksum
+	json_get_var sha256sum sha256sum
+	json_select ..
+	json_select device
+	json_get_var board board
+	json_select ..
+
+	[ "$sha256sum" != "$sha256_file" ] && return 3
+	[ "$board" != "$board_info" ] && return 4
+
+	return 0
+}

--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -18,6 +18,7 @@ export NEED_IMAGE=
 export HELP=0
 export FORCE=0
 export TEST=0
+export META_DATA=0
 
 # parse options
 while [ -n "$1" ]; do
@@ -28,6 +29,7 @@ while [ -n "$1" ]; do
 		-n) export SAVE_CONFIG=0;;
 		-c) export SAVE_OVERLAY=1;;
 		-p) export SAVE_PARTITIONS=0;;
+		-m) export META_DATA=1;;
 		-b|--create-backup) export CONF_BACKUP="$2" NEED_IMAGE=1; shift;;
 		-r|--restore-backup) export CONF_RESTORE="$2" NEED_IMAGE=1; shift;;
 		-l|--list-backup) export CONF_BACKUP_LIST=1; break;;
@@ -70,6 +72,8 @@ upgrade-option:
 	-h | --help  display this help
 
 backup-command:
+	-m           append/check meta information only applicable if file is
+	             not read/write from/to stdin/stdout '-'.
 	-b | --create-backup <file>
 	             create .tar.gz of files specified in sysupgrade.conf
 	             then exit. Does not flash an image. If file is '-',
@@ -149,6 +153,8 @@ do_save_conffiles() {
 	[ "$VERBOSE" -gt 1 ] && TAR_V="v" || TAR_V=""
 	tar c${TAR_V}zf "$conf_tar" -T "$CONFFILES" 2>/dev/null
 
+	[ "$META_DATA" -gt 0 ] && fwtool_append_meta_config "$conf_tar"
+
 	rm -f "$CONFFILES"
 }
 
@@ -169,6 +175,30 @@ if [ -n "$CONF_RESTORE" ]; then
 		echo "Backup archive '$CONF_RESTORE' not found."
 		exit 1
 	fi
+
+	[ "$META_DATA" -gt 0 ] && {
+		fwtool_check_meta_config "$CONF_RESTORE"
+		case "$?" in
+			0)
+				;;
+			2)
+				echo "Meta data not found"
+				exit 2
+				;;
+			3)
+				echo "Checksum does not match"
+				exit 3
+				;;
+			4)
+				echo "Board name does not match"
+				exit 4
+				;;
+			*)
+				echo "Unknown error"
+				exit 5
+				;;
+		esac
+	}
 
 	[ "$VERBOSE" -gt 1 ] && TAR_V="v" || TAR_V=""
 	tar -C / -x${TAR_V}zf "$CONF_RESTORE"


### PR DESCRIPTION
* create-backup:

If option -m is given then the metadata are appended on backup creation.
The following information are appended to the metadata set.

dist -> from the file "/etc/openwrt_release"
version -> from the file "/etc/openwrt_release"
revision -> from the file "/etc/openwrt_release"
target -> from the file "/etc/openwrt_release"
subtarget -> from the file "/etc/openwrt_release"
board -> from the file "/tmp/sysinfo/board_name"
hostname -> of the system
sha256sum -> checksum from backup file without metadata

* restore-backup:

If option -m is given then the metadata are checked on backup restore.
The following information are checked in the metadata set against the
runnig system.

verify checksum from metadata against backup.tar.gz file with out metadata
check board_name from metadata against /tmp/sysinfo/board_name
