### PR TITLE
lantiq: remove DSL_ChipSetHWVersion from status information

### DIFF
--- a/target/linux/lantiq/base-files/lib/functions/lantiq_dsl.sh
+++ b/target/linux/lantiq/base-files/lib/functions/lantiq_dsl.sh
@@ -166,20 +166,18 @@ data_rates() {
 chipset() {
 	local vig
 	local cs
-	local csv
 
 	vig=$(dsl_cmd vig)
 	cs=$(dsl_val "$vig" DSL_ChipSetType)
-	csv=$(dsl_val "$vig" DSL_ChipSetHWVersion)
 	csfw=$(dsl_val "$vig" DSL_ChipSetFWVersion)
 	csapi=$(dsl_val "$vig" DSL_DriverVersionApi)
 
 	if [ "$action" = "lucistat" ]; then
-		echo "dsl.chipset=\"${cs} ${csv}\""
+		echo "dsl.chipset=\"${cs}\""
 		echo "dsl.firmware_version=\"${csfw}\""
 		echo "dsl.api_version=\"${csapi}\""
 	else
-		echo "Chipset:                                  ${cs} ${csv}"
+		echo "Chipset:                                  ${cs}"
 		echo "Firmware Version:                         ${csfw}"
 		echo "API Version:                              ${csapi}"
 	fi


### PR DESCRIPTION
The value DSL_ChipSetHWVersion is fetched from the dsl frontend
via the dsl_control service, but not really provided by the dsl
frontend firmware and for now always "UNKNOWN".

The lantiq support told us that this information wouldn't be
provided in the foreseeable future, so let's remove this
useless "UNKNOWN" information.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
