### PR TITLE
dnsmasq: reload configuration by signal

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.78
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1044,7 +1044,7 @@ dnsmasq_stop()
 
 service_triggers()
 {
-	procd_add_reload_trigger "dhcp"
+	procd_add_reload_trigger "dhcp" "system"
 	procd_add_raw_trigger "interface.*" 2000 /etc/init.d/dnsmasq reload
 }
 

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1084,7 +1084,7 @@ start_service() {
 
 reload_service() {
 	rc_procd start_service "$@"
-	return 0
+	procd_send_signal dnsmasq "$@"
 }
 
 stop_service() {


### PR DESCRIPTION
- If the system name was changed then the "dnsmasq" must be restarted to rewrite his config with the new hostname. Adding "/etc/config/system" to the reload trigger will trigger "dnsmasq" on "/etc/config/system" change.

- To apply the new configuration "dnsmasq" must get restarted with start/stop to rewrite the configuration and then also restart a new instance to serve the new configuration. If reload_service was triggered then only sending a signal to dnsmasq to reload his config for the running service is enough. No new instance is required to serve the new configuration.

I have added this functionality one year ago, but this introduce errors on service reload and was reverted.
ADD:
https://github.com/TDT-AG/source/commit/854459a2f923376e0e509ebc0fb8ff90e9f13c02#diff-f65b4391dc02a776f873f8e933742458
REVERT:
https://github.com/TDT-AG/source/commit/93227e4d3fb81332f1dcb6eaa158ddf914ca67a6#diff-f65b4391dc02a776f873f8e933742458