### PR TITLE
odhcp6c: authdata option config + patch

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -26,6 +26,7 @@ proto_dhcpv6_init_config() {
 	proto_config_add_string 'ifaceid:ip6addr'
 	proto_config_add_string "userclass"
 	proto_config_add_string "vendorclass"
+	proto_config_add_string sendopts
 	proto_config_add_boolean delegate
 	proto_config_add_int "soltimeout"
 	proto_config_add_boolean fakeroutes
@@ -38,8 +39,8 @@ proto_dhcpv6_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local reqaddress reqprefix clientid reqopts noslaaconly forceprefix extendprefix norelease ip6prefix iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass delegate zone_dslite zone_map zone_464xlat zone soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff
-	json_get_vars reqaddress reqprefix clientid reqopts noslaaconly forceprefix extendprefix norelease ip6prefix iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass delegate zone_dslite zone_map zone_464xlat zone soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff
+	local reqaddress reqprefix clientid reqopts noslaaconly forceprefix extendprefix norelease ip6prefix iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass sendopts delegate zone_dslite zone_map zone_464xlat zone soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff
+	json_get_vars reqaddress reqprefix clientid reqopts noslaaconly forceprefix extendprefix norelease ip6prefix iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass sendopts delegate zone_dslite zone_map zone_464xlat zone soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff
 
 
 	# Configure
@@ -69,6 +70,10 @@ proto_dhcpv6_setup() {
 
 	for opt in $reqopts; do
 		append opts "-r$opt"
+	done
+
+	for opt in $sendopts; do
+		append opts "-x$opt"
 	done
 
 	append opts "-t${soltimeout:-120}"

--- a/package/network/ipv6/odhcp6c/patches/001-sendopts-option.patch
+++ b/package/network/ipv6/odhcp6c/patches/001-sendopts-option.patch
@@ -1,0 +1,95 @@
+commit ab6e985b8b10e52e79c2a840a8cdec90a5f292b4
+Author: Frank Andrieu <fandrieu@gmail.com>
+Date:   Tue Jan 2 11:59:52 2018 +0100
+
+    odhcp6c: Add -x option to set any DHCP option
+
+diff --git a/src/dhcpv6.c b/src/dhcpv6.c
+index 9dce577..e82a4d8 100644
+--- a/src/dhcpv6.c
++++ b/src/dhcpv6.c
+@@ -225,6 +225,7 @@ enum {
+ 	IOV_VENDOR_CLASS,
+ 	IOV_USER_CLASS_HDR,
+ 	IOV_USER_CLASS,
++	IOV_CUSTOM_OPTS,
+ 	IOV_RECONF_ACCEPT,
+ 	IOV_FQDN,
+ 	IOV_HDR_IA_NA,
+@@ -427,9 +428,10 @@ static void dhcpv6_send(enum dhcpv6_msg type, uint8_t trid[3], uint32_t ecs)
+ 	uint16_t oro_refresh = htons(DHCPV6_OPT_INFO_REFRESH);
+ 
+ 	// Build vendor-class option
+-	size_t vendor_class_len, user_class_len;
++	size_t vendor_class_len, user_class_len, custom_opts_len;
+ 	struct dhcpv6_vendorclass *vendor_class = odhcp6c_get_state(STATE_VENDORCLASS, &vendor_class_len);
+ 	void *user_class = odhcp6c_get_state(STATE_USERCLASS, &user_class_len);
++	void *custom_opts = odhcp6c_get_state(STATE_CUSTOMOPTS, &custom_opts_len);
+ 
+ 	struct {
+ 		uint16_t type;
+@@ -469,6 +471,7 @@ static void dhcpv6_send(enum dhcpv6_msg type, uint8_t trid[3], uint32_t ecs)
+ 		[IOV_VENDOR_CLASS] = {vendor_class, vendor_class_len},
+ 		[IOV_USER_CLASS_HDR] = {&user_class_hdr, user_class_len ? sizeof(user_class_hdr) : 0},
+ 		[IOV_USER_CLASS] = {user_class, user_class_len},
++		[IOV_CUSTOM_OPTS] = {custom_opts, custom_opts_len},
+ 		[IOV_RECONF_ACCEPT] = {&reconf_accept, sizeof(reconf_accept)},
+ 		[IOV_FQDN] = {&fqdn, fqdn_len},
+ 		[IOV_HDR_IA_NA] = {&hdr_ia_na, sizeof(hdr_ia_na)},
+diff --git a/src/odhcp6c.c b/src/odhcp6c.c
+index 666af5c..eef7bc7 100644
+--- a/src/odhcp6c.c
++++ b/src/odhcp6c.c
+@@ -83,7 +83,7 @@ int main(_unused int argc, char* const argv[])
+ 	unsigned int ra_options = RA_RDNSS_DEFAULT_LIFETIME;
+ 	unsigned int ra_holdoff_interval = RA_MIN_ADV_INTERVAL;
+ 
+-	while ((c = getopt(argc, argv, "S::N:V:P:FB:c:i:r:Ru:s:kt:m:Lhedp:fav")) != -1) {
++	while ((c = getopt(argc, argv, "S::N:V:P:FB:c:i:r:Ru:x:s:kt:m:Lhedp:fav")) != -1) {
+ 		switch (c) {
+ 		case 'S':
+ 			allow_slaac_only = (optarg) ? atoi(optarg) : -1;
+@@ -182,6 +182,23 @@ int main(_unused int argc, char* const argv[])
+ 			odhcp6c_add_state(STATE_USERCLASS, optarg, strlen(optarg));
+ 			break;
+ 
++		case 'x':
++			help = true;
++			optpos = strchr(optarg, ':');
++			if (optpos) {
++				l = script_unhexlify(buf, sizeof(buf), optpos+1);
++				opttype = strtoul(optarg, &optpos, 0);
++				if (l && opttype > 0 && opttype < 255) {
++					help = false;
++					opttype = htons(opttype);
++					odhcp6c_add_state(STATE_CUSTOMOPTS, &opttype, 2);
++					optlen = htons(l);
++					odhcp6c_add_state(STATE_CUSTOMOPTS, &optlen, 2);
++					odhcp6c_add_state(STATE_CUSTOMOPTS, buf, l);
++				}
++			}
++			break;
++
+ 		case 's':
+ 			script = optarg;
+ 			break;
+@@ -447,6 +464,7 @@ static int usage(void)
+ 	"	-F		Force IPv6-Prefix\n"
+ 	"	-V <class>	Set vendor-class option (base-16 encoded)\n"
+ 	"	-u <user-class> Set user-class option string\n"
++	"	-x <opt>:<val>	Set option opt to val (integer + base-16 encoded)\n"
+ 	"	-c <clientid>	Override client-ID (base-16 encoded 16-bit type + value)\n"
+ 	"	-i <iface-id>	Use a custom interface identifier for RA handling\n"
+ 	"	-r <options>	Options to be requested (comma-separated)\n"
+diff --git a/src/odhcp6c.h b/src/odhcp6c.h
+index 1d9bd3e..52c1549 100644
+--- a/src/odhcp6c.h
++++ b/src/odhcp6c.h
+@@ -261,6 +261,7 @@ enum odhcp6c_state {
+ 	STATE_AFTR_NAME,
+ 	STATE_VENDORCLASS,
+ 	STATE_USERCLASS,
++	STATE_CUSTOMOPTS,
+ 	STATE_CER,
+ 	STATE_S46_MAPT,
+ 	STATE_S46_MAPE,


### PR DESCRIPTION
Allows to set DHCPv6 option 11 "Authenfication" with hex data.

Adds "authdata" uci config for dhcpv6, passed as option -A to odhcp6c.
Includes a patch implementing this option in odhcp6c.

The french ISP orange.fr requires this options to be present, I guess this new uci config may be helpful to others.
A typical configuration would look like :
```
config interface 'wan6'
	option ifname '@wan'
	option proto 'dhcpv6'
	option reqaddress 'none'
	option vendorclass '0000040e0005736167656d'
	option userclass 'FSVDSL_livebox.Internet.softathome.Livebox4'
	option authdata '00000000000000000000006674692Fxxxxxxxxxxxxxx'
```
