### PR TITLE
ramips:Correct switch and LED configuration for Lenovo newifi-y1

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -453,8 +453,7 @@ y1)
 	set_usb_led "$boardname:blue:usb"
 	ucidef_set_led_netdev "wifi" "WIFI" "$boardname:blue:wifi" "wlan1"
 	ucidef_set_led_netdev "wifi5g" "WIFI5G" "$boardname:blue:wifi5g" "wlan0"
-	ucidef_set_led_netdev "lan" "LAN" "$boardname:blue:lan" "eth0.1" "tx rx"
-	ucidef_set_led_netdev "wan" "WAN" "$boardname:blue:internet" "eth0.2" "tx rx"
+	ucidef_set_led_switch "lan" "LAN" "$boardname:blue:lan" "switch0" "0x03"
 	;;
 y1s)
 	set_usb_led "$boardname:blue:usb"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -111,7 +111,6 @@ ramips_setup_interfaces()
 	wndr3700v5|\
 	wt1520-4M|\
 	wt1520-8M|\
-	y1|\
 	youku-yk1|\
 	zbt-ape522ii|\
 	zbt-we1326|\
@@ -347,6 +346,10 @@ ramips_setup_interfaces()
 	wizfi630a)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "0:wan" "6@eth0"
+		;;
+	y1)
+		ucidef_add_switch "switch0" \
+			"0:lan:2" "1:lan:1" "4:wan" "6@eth0"
 		;;
 	*)
 		RT3X5X=`cat /proc/cpuinfo | egrep "(RT3.5|RT5350)"`


### PR DESCRIPTION
There are 3 ethernet ports on Y1(LAN1 on port1, LAN2 on port0 and WAN on port4).
Use a standalone switch configuration to match this and use switch trigger so that LAN LED could indicate the connetction status for both lan ports correctly.

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
