### PR TITLE
lantiq: fix Netgear DM200 dts compatible string

### DIFF
--- a/target/linux/lantiq/dts/DM200.dts
+++ b/target/linux/lantiq/dts/DM200.dts
@@ -5,7 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "netgear,dm200", "lantiq,xway", "lantiq,ar9";
+	compatible = "netgear,dm200", "lantiq,xway", "lantiq,vr9";
 	model = "Netgear DM200";
 
 	chosen {


### PR DESCRIPTION
This was broken in 7bab49fd ("lantiq: add compatible strings to dts files"), causing garbled serial output during boot, and likely other issues.

It looks like the same issue is present in P2601HNFX.dts, though i don't have that device to test it.

Thanks,

Tom