### PR TITLE
ramips: add support for TP-Link Archer C20 v4

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -87,12 +87,6 @@ c108)
 	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"
 	ucidef_set_led_netdev "modem" "modem" "$boardname:green:modem" "wwan0"
 	;;
-c20)
-	ucidef_set_led_switch "lan" "lan" "$boardname:blue:lan" "switch0" "0x1e"
-	ucidef_set_led_switch "wan" "wan" "$boardname:blue:wan" "switch0" "0x01"
-	set_usb_led "$boardname:blue:usb"
-	ucidef_set_led_netdev "wlan2g" "wlan2g" "$boardname:blue:wlan2g" "wlan0"
-	;;
 c20i)
 	ucidef_set_led_switch "lan" "lan" "$boardname:blue:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:blue:wan" "switch0" "0x01"
@@ -383,6 +377,12 @@ tl-wr841n-v13)
 	ucidef_set_led_switch "lan3" "lan3" "$boardname:green:lan3" "switch0" "0x8"
 	ucidef_set_led_switch "lan4" "lan4" "$boardname:green:lan4" "switch0" "0x10"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
+	;;
+tplink,c20-v1)
+	ucidef_set_led_switch "lan" "lan" "$boardname:blue:lan" "switch0" "0x1e"
+	ucidef_set_led_switch "wan" "wan" "$boardname:blue:wan" "switch0" "0x01"
+	set_usb_led "$boardname:blue:usb"
+	ucidef_set_led_netdev "wlan2g" "wlan2g" "$boardname:blue:wlan2g" "wlan0"
 	;;
 tplink,c20-v4)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -384,6 +384,11 @@ tl-wr841n-v13)
 	ucidef_set_led_switch "lan4" "lan4" "$boardname:green:lan4" "switch0" "0x10"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
 	;;
+tplink,c20-v4)
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
+	ucidef_set_led_netdev "wlan2g" "wlan2g" "$boardname:green:wlan2g" "wlan0"
+	;;
 tplink,tl-mr3420-v5)
 	set_usb_led "$boardname:green:usb"
 	set_wifi_led "$boardname:green:wlan"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -173,6 +173,7 @@ ramips_setup_interfaces()
 	mzk-wdpr|\
 	rb750gr3|\
 	rt-n14u|\
+	tplink,c20-v4|\
 	tplink,tl-mr3420-v5|\
 	tl-wr840n-v4|\
 	tl-wr840n-v5|\

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -191,8 +191,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
-	c20|\
-	c50)
+	c50|\
+	tplink,c20-v1)
 		ucidef_add_switch "switch0" \
 			"1:lan:3" "2:lan:4" "3:lan:1" "4:lan:2" "0:wan" "6@eth0"
 		;;

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -123,7 +123,6 @@ get_status_led() {
 	w502u)
 		status_led="$boardname:blue:wps"
 		;;
-	c20|\
 	d240|\
 	dap-1350|\
 	na930|\
@@ -135,6 +134,7 @@ get_status_led() {
 	rt-n14u|\
 	rt-n15|\
 	rt-n56u|\
+	tplink,c20-v1|\
 	wl-330n|\
 	wl-330n3g|\
 	wli-tx4-ag300n|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -37,6 +37,7 @@ get_status_led() {
 	nbg-419n2|\
 	pwh2004|\
 	r6220|\
+	tplink,c20-v4|\
 	tplink,tl-mr3420-v5|\
 	tl-wr840n-v4|\
 	tl-wr840n-v5|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -85,9 +85,6 @@ ramips_board_detect() {
 	*"C108")
 		name="c108"
 		;;
-	*"C20")
-		name="c20"
-		;;
 	*"C20i")
 		name="c20i"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -236,10 +236,10 @@ platform_check_image() {
 		}
 		return 0
 		;;
-	c20|\
 	c20i|\
 	c50|\
 	mr200|\
+	tplink,c20-v1|\
 	tplink,c20-v4|\
 	tplink,tl-mr3420-v5|\
 	tl-wr840n-v4|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -240,6 +240,7 @@ platform_check_image() {
 	c20i|\
 	c50|\
 	mr200|\
+	tplink,c20-v4|\
 	tplink,tl-mr3420-v5|\
 	tl-wr840n-v4|\
 	tl-wr840n-v5|\

--- a/target/linux/ramips/dts/ArcherC20v1.dts
+++ b/target/linux/ramips/dts/ArcherC20v1.dts
@@ -6,8 +6,8 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	compatible = "tplink,c20", "ralink,mt7620a-soc";
-	model = "TP-Link Archer C20";
+	compatible = "tplink,c20-v1", "ralink,mt7620a-soc";
+	model = "TP-Link Archer C20 v1";
 
 	chosen {
 		bootargs = "console=ttyS0,115200";
@@ -17,43 +17,43 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "c20:blue:lan";
+			label = "c20-v1:blue:lan";
 			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		};
 
 		power {
-			label = "c20:blue:power";
+			label = "c20-v1:blue:power";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			default-state = "keep";
 		};
 
 		usb {
-			label = "c20:blue:usb";
+			label = "c20-v1:blue:usb";
 			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
-			label = "c20:blue:wan";
+			label = "c20-v1:blue:wan";
 			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 		};
 
 		wan_orange {
-			label = "c20:orange:wan";
+			label = "c20-v1:orange:wan";
 			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		wlan5g {
-			label = "c20:blue:wlan5g";
+			label = "c20-v1:blue:wlan5g";
 			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan2g {
-			label = "c20:blue:wlan2g";
+			label = "c20-v1:blue:wlan2g";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
-			label = "c20:blue:wps";
+			label = "c20-v1:blue:wps";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 	};
@@ -74,7 +74,8 @@
 			label = "rfkill";
 			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
-		};	};
+		};
+	};
 };
 
 &gpio1 {
@@ -178,7 +179,7 @@
 		mt76@0,0 {
 			reg = <0x0000 0 0 0 0>;
 			device_type = "pci";
-			mediatek,mtd-eeprom = <&radio 32768>;
+			mediatek,mtd-eeprom = <&radio 0x8000>;
 			ieee80211-freq-limit = <5000000 6000000>;
 			mtd-mac-address = <&rom 0xf100>;
 			mtd-mac-address-increment = <(-1)>;

--- a/target/linux/ramips/dts/ArcherC20v4.dts
+++ b/target/linux/ramips/dts/ArcherC20v4.dts
@@ -1,0 +1,170 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "tplink,c20-v4", "mediatek,mt7628an-soc";
+	model = "TP-Link Archer C20 v4";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "c20-v4:green:lan";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
+		power {
+			label = "c20-v4:green:power";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "c20-v4:green:wan";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "c20-v4:orange:wan";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+		
+		wlan5g {
+			label = "c20-v4:green:wlan5g";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "c20-v4:green:wlan2g";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "c20-v4:green:wps";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x20000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "firmware";
+			reg = <0x20000 0x7a0000>;
+		};
+
+		partition@7c0000 {
+			label = "config";
+			reg = <0x7c0000 0x10000>;
+			read-only;
+		};
+
+		rom: partition@7d0000 {
+			label = "rom";
+			reg = <0x7d0000 0x10000>;
+			read-only;
+		};
+
+		partition@7e0000 {
+			label = "romfile";
+			reg = <0x7e0000 0x10000>;
+			read-only;
+		};
+
+		radio: partition@7f0000 {
+			label = "radio";
+			reg = <0x7f0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&wmac {
+	status = "okay";
+	mediatek,mtd-eeprom = <&radio 0x0>;
+	mtd-mac-address = <&rom 0xf100>;
+	mtd-mac-address-increment = <(-2)>;
+};
+
+&ethernet {
+	mtd-mac-address = <&rom 0xf100>;
+	mediatek,portmap = "wllll";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2s", "refclk", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie-bridge {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&radio 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+			mtd-mac-address = <&rom 0xf100>;
+			mtd-mac-address-increment = <(-1)>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -36,20 +36,6 @@ define Device/Archer
   IMAGE/sysupgrade.bin := tplink-v2-image -s -e | append-metadata
 endef
 
-define Device/ArcherC20
-  $(Device/Archer)
-  DTS := ArcherC20
-  SUPPORTED_DEVICES := c20
-  TPLINK_FLASHLAYOUT := 8Mmtk
-  TPLINK_HWID := 0xc2000001
-  TPLINK_HWREV := 0x44
-  TPLINK_HWREVADD := 0x1
-  IMAGES += factory.bin
-  DEVICE_TITLE := TP-Link ArcherC20
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
-endef
-TARGET_DEVICES += ArcherC20
-
 define Device/ArcherC20i
   $(Device/Archer)
   DTS := ArcherC20i
@@ -423,6 +409,20 @@ define Device/tiny-ac
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += tiny-ac
+
+define Device/tplink_c20-v1
+  $(Device/Archer)
+  DTS := ArcherC20v1
+  SUPPORTED_DEVICES := c20v1
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0xc2000001
+  TPLINK_HWREV := 0x44
+  TPLINK_HWREVADD := 0x1
+  IMAGES += factory.bin
+  DEVICE_TITLE := TP-Link ArcherC20 v1
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += tplink_c20-v1
 
 define Device/vonets_var11n-300
   DTS := VAR11N-300

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -139,6 +139,19 @@ define Device/tl-wr841n-v13
 endef
 TARGET_DEVICES += tl-wr841n-v13
 
+define Device/tplink_c20-v4
+  $(Device/tplink)
+  DTS := ArcherC20v4
+  IMAGE_SIZE := 7808k
+  DEVICE_TITLE := TP-Link ArcherC20 v4
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0xc200004
+  TPLINK_HWREV := 0x1
+  TPLINK_HWREVADD := 0x4
+  TPLINK_HVERSION := 3
+endef
+TARGET_DEVICES += tplink_c20-v4
+
 define Device/tplink_tl-mr3420-v5
   $(Device/tplink)
   DTS := TL-MR3420V5


### PR DESCRIPTION
TP-Link Archer C20 v4 is a router with 5-port FE switch and
non-detachable antennas. It's based on MediaTek MT7628N+MT7610EN.

Specification:
- MediaTek MT7628N/N (580 Mhz)
- 64 MB of RAM
- 8 MB of FLASH
- 2T2R 2.4 GHz and 1T1R 5 GHz
- 5x 10/100 Mbps Ethernet
- 3x external, non-detachable antennas
- UART (J1) header on PCB (115200 8n1)
- 7x LED (GPIO-controlled*), 2x button, power input switch

* WAN LED in this devices is a dual-color, dual-leads type which isn't
  (fully) supported by gpio-leds driver. This type of LED requires both
  GPIOs state change at the same time to select color or turn it off.
  For now, we support/use only the green part of the LED.
* MT7610EN ac chip isn't not supported by LEDE. Therefore 5Ghz won't
  work.

Flash instruction:

The only way to flash LEDE image in ArcherC20v4 is to use
tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.0.66/24 and tftp server.
2. Rename "openwrt-ramips-mt7628-ArcherC20v4-squashfs-tftp-recovery.bin"
   to "tp_recovery.bin" and place it in tftp server directory.
3. Connect PC with one of LAN ports, press the reset button, power up
   the router and keep button pressed for around 6-7 seconds, until
   device starts downloading the file.
4. Router will download file from server, write it to flash and reboot.

Signed-off-by: Maxim Anisimov <maxim.anisimov.ua@gmail.com>
[LEDE_Bootlog.txt](https://github.com/lede-project/source/files/1614151/LEDE_Bootlog.txt)