### PR TITLE
rt2x00: enable MFP regardless of hw crypt

### DIFF
--- a/package/kernel/mac80211/patches/90-rt2x00_enable_mfp.patch
+++ b/package/kernel/mac80211/patches/90-rt2x00_enable_mfp.patch
@@ -1,0 +1,14 @@
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -9171,9 +9171,8 @@ static int rt2800_probe_hw_mode(struct r
+ 	if (!rt2x00_is_usb(rt2x00dev))
+ 		ieee80211_hw_set(rt2x00dev->hw, HOST_BROADCAST_PS_BUFFERING);
+ 
+-	/* Set MFP if HW crypto is disabled. */
+-	if (rt2800_hwcrypt_disabled(rt2x00dev))
+-		ieee80211_hw_set(rt2x00dev->hw, MFP_CAPABLE);
++	/* Set MFP */
++	ieee80211_hw_set(rt2x00dev->hw, MFP_CAPABLE);
+ 
+ 	SET_IEEE80211_DEV(rt2x00dev->hw, rt2x00dev->dev);
+ 	SET_IEEE80211_PERM_ADDR(rt2x00dev->hw,


### PR DESCRIPTION
Disabling hw crypt degraded performance so enable MFP for either case.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>
