### PR TITLE
hostapd: add support for radius_client_addr

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -172,6 +172,7 @@ hostapd_common_add_bss_config() {
 
 	config_add_string nasid
 	config_add_string ownip
+	config_add_string radius_client_addr
 	config_add_string iapp_interface
 	config_add_string eap_type ca_cert client_cert identity anonymous_identity auth priv_key priv_key_pwd
 	config_add_string ieee80211w_mgmt_cipher
@@ -305,7 +306,7 @@ hostapd_set_bss_options() {
 			json_get_vars \
 				auth_server auth_secret auth_port \
 				dae_client dae_secret dae_port \
-				ownip \
+				ownip radius_client_addr \
 				eap_reauth_period
 
 			# radius can provide VLAN ID for clients
@@ -332,6 +333,7 @@ hostapd_set_bss_options() {
 			}
 
 			[ -n "$ownip" ] && append bss_conf "own_ip_addr=$ownip" "$N"
+			[ -n "$radius_client_addr" ] && append bss_conf "radius_client_addr=$radius_client_addr" "$N"
 			append bss_conf "eapol_key_index_workaround=1" "$N"
 			append bss_conf "ieee8021x=1" "$N"
 


### PR DESCRIPTION
Add support for hostapd's radius_client_addr in order to
force hostapd to send RADIUS packets from the correct source
interface rather than letting linux select the most appropriate.

I intentionally didn't use the "ownip" config parameter as this
sets the NAS-IP-Address. Some admins may (or may not)
enter something else there.

Signed-off-by: Stephan Brunner <s.brunner@stephan-brunner.net>