### PR TITLE
[KERNEL-BUILD] Fix kernel compilation when CONFIG_STRIP_KERNEL_EXPORTS

### DIFF
--- a/include/kernel-build.mk
+++ b/include/kernel-build.mk
@@ -138,8 +138,9 @@ define BuildKernel
   $(LINUX_DIR)/.modules: $(STAMP_CONFIGURED) $(LINUX_DIR)/.config FORCE
 	$(Kernel/CompileModules)
 	touch $$@
+	$(if $(CONFIG_STRIP_KERNEL_EXPORTS),$($(KERNEL_BUILD_DIR)/symtab.h))
 
-  $(LINUX_DIR)/.image: $(STAMP_CONFIGURED) $(if $(CONFIG_STRIP_KERNEL_EXPORTS),$(KERNEL_BUILD_DIR)/symtab.h) FORCE
+  $(LINUX_DIR)/.image: $(STAMP_CONFIGURED)
 	$(Kernel/CompileImage)
 	$(Kernel/CollectDebug)
 	touch $$@


### PR DESCRIPTION
is enabled

When you enable CONFIG_STRIP_KERNEL_EXPORTS on PI3 at least the kernel
can't be compiled because 'vdso' complains about missing 'symtab.h'
which seems to be created later at the image installation.

Fix this by moving up when the file is generated (just after modules are
built)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
