### PR TITLE
kernel: I2C better driver for MT7621/MT7628

### DIFF
--- a/target/linux/ramips/patches-4.14/0045-i2c-add-mt7621-driver.patch
+++ b/target/linux/ramips/patches-4.14/0045-i2c-add-mt7621-driver.patch
@@ -37,12 +37,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-$(CONFIG_I2C_RK3X)		+= i2c-rk3x.o
 --- /dev/null
 +++ b/drivers/i2c/busses/i2c-mt7621.c
-@@ -0,0 +1,433 @@
+@@ -0,0 +1,406 @@
 +/*
 + * drivers/i2c/busses/i2c-mt7621.c
 + *
 + * Copyright (C) 2013 Steven Liu <steven_liu@mediatek.com>
 + * Copyright (C) 2016 Michael Lee <igvtee@gmail.com>
++ * Copyright (C) 2018 Jan Breuer <jan.breuer@jaybee.cz>
 + *
 + * Improve driver for i2cdetect from i2c-tools to detect i2c devices on the bus.
 + * (C) 2014 Sittisak <sittisaks@hotmail.com>
@@ -73,70 +74,39 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#include <linux/err.h>
 +#include <linux/clk.h>
 +
-+#define REG_SM0CFG0		0x08
-+#define REG_SM0DOUT		0x10
-+#define REG_SM0DIN		0x14
-+#define REG_SM0ST		0x18
-+#define REG_SM0AUTO		0x1C
-+#define REG_SM0CFG1		0x20
-+#define REG_SM0CFG2		0x28
-+#define REG_SM0CTL0		0x40
-+#define REG_SM0CTL1		0x44
-+#define REG_SM0D0		0x50
-+#define REG_SM0D1		0x54
-+#define REG_PINTEN		0x5C
-+#define REG_PINTST		0x60
-+#define REG_PINTCL		0x64
++#define REG_SM0CFG2_REG		0x28
++#define REG_SM0CTL0_REG		0x40
++#define REG_SM0CTL1_REG		0x44
++#define REG_SM0D0_REG		0x50
++#define REG_SM0D1_REG		0x54
++#define REG_PINTEN_REG		0x5C
++#define REG_PINTST_REG		0x60
++#define REG_PINTCL_REG		0x64
 +
-+/* REG_SM0CFG0 */
-+#define I2C_DEVADDR_MASK	0x7f
++/* REG_SM0CFG2_REG */
++#define SM0CFG2_IS_AUTOMODE	BIT(0)
 +
-+/* REG_SM0ST */
-+#define I2C_DATARDY		BIT(2)
-+#define I2C_SDOEMPTY		BIT(1)
-+#define I2C_BUSY		BIT(0)
++/* REG_SM0CTL0_REG */
++#define SM0CTL0_ODRAIN		BIT(31)
++#define SM0CTL0_CLK_DIV_MASK	(0x7FF << 16)
++#define SM0CTL0_CLK_DIV_MAX	0x7ff
++#define SM0CTL0_CS_STATUS       BIT(4)
++#define SM0CTL0_SCL_STATE       BIT(3)
++#define SM0CTL0_SDA_STATE       BIT(2)
++#define SM0CTL0_EN              BIT(1)
++#define SM0CTL0_SCL_STRETCH     BIT(0)
 +
-+/* REG_SM0AUTO */
-+#define READ_CMD		BIT(0)
-+
-+/* REG_SM0CFG1 */
-+#define BYTECNT_MAX		64
-+#define SET_BYTECNT(x)		(x - 1)
-+
-+/* REG_SM0CFG2 */
-+#define AUTOMODE_EN		BIT(0)
-+
-+/* REG_SM0CTL0 */
-+#define ODRAIN_HIGH_SM0		BIT(31)
-+#define VSYNC_SHIFT		28
-+#define VSYNC_MASK		0x3
-+#define VSYNC_PULSE		(0x1 << VSYNC_SHIFT)
-+#define VSYNC_RISING		(0x2 << VSYNC_SHIFT)
-+#define CLK_DIV_SHIFT		16
-+#define CLK_DIV_MASK		0xfff
-+#define DEG_CNT_SHIFT		8
-+#define DEG_CNT_MASK		0xff
-+#define WAIT_HIGH		BIT(6)
-+#define DEG_EN			BIT(5)
-+#define CS_STATUA		BIT(4)
-+#define SCL_STATUS		BIT(3)
-+#define SDA_STATUS		BIT(2)
-+#define SM0_EN			BIT(1)
-+#define SCL_STRECH		BIT(0)
-+
-+/* REG_SM0CTL1 */
-+#define ACK_SHIFT		16
-+#define ACK_MASK		0xff
-+#define PGLEN_SHIFT		8
-+#define PGLEN_MASK		0x7
-+#define SM0_MODE_SHIFT		4
-+#define SM0_MODE_MASK		0x7
-+#define SM0_MODE_START		0x1
-+#define SM0_MODE_WRITE		0x2
-+#define SM0_MODE_STOP		0x3
-+#define SM0_MODE_READ_NACK	0x4
-+#define SM0_MODE_READ_ACK	0x5
-+#define SM0_TRI_BUSY		BIT(0)
++/* REG_SM0CTL1_REG */
++#define SM0CTL1_ACK_MASK	(0xFF << 16)
++#define SM0CTL1_PGLEN_MASK	(0x7 << 8)
++#define SM0CTL1_PGLEN(x)	(((x - 1) << 8) & SM0CTL1_PGLEN_MASK)
++#define SM0CTL1_READ		(5 << 4)
++#define SM0CTL1_READ_LAST	(4 << 4)
++#define SM0CTL1_STOP		(3 << 4)
++#define SM0CTL1_WRITE		(2 << 4)
++#define SM0CTL1_START		(1 << 4)
++#define SM0CTL1_MODE_MASK	(0x7 << 4)
++#define SM0CTL1_TRI		BIT(0)
 +
 +/* timeout waiting for I2C devices to respond (clock streching) */
 +#define TIMEOUT_MS              1000
@@ -165,12 +135,21 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static int poll_down_timeout(void __iomem *addr, u32 mask)
 +{
 +	unsigned long timeout = jiffies + msecs_to_jiffies(TIMEOUT_MS);
++	int current_delay = 1;
 +
 +	do {
 +		if (!(readl_relaxed(addr) & mask))
 +			return 0;
 +
-+		usleep_range(DELAY_INTERVAL_US, DELAY_INTERVAL_US + 50);
++		if (current_delay > 0 && current_delay < 10) {
++			udelay(current_delay);
++		} else if (current_delay >= 10) {
++			usleep_range(current_delay, current_delay + 50);
++		}
++		current_delay *= current_delay;
++		if (current_delay > DELAY_INTERVAL_US) {
++			current_delay = DELAY_INTERVAL_US;
++		}
 +	} while (time_before(jiffies, timeout));
 +
 +	return (readl_relaxed(addr) & mask) ? -EAGAIN : 0;
@@ -180,94 +159,74 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +{
 +	int ret;
 +
-+	ret = poll_down_timeout(i2c->base + REG_SM0ST, I2C_BUSY);
++	ret = poll_down_timeout(i2c->base + REG_SM0CTL1_REG, SM0CTL1_TRI);
 +	if (ret < 0)
 +		dev_dbg(i2c->dev, "idle err(%d)\n", ret);
 +
 +	return ret;
 +}
 +
-+static int poll_up_timeout(void __iomem *addr, u32 mask)
-+{
-+	unsigned long timeout = jiffies + msecs_to_jiffies(TIMEOUT_MS);
-+	u32 status;
-+
-+	do {
-+		status = readl_relaxed(addr);
-+		if (status & mask)
-+			return 0;
-+		usleep_range(DELAY_INTERVAL_US, DELAY_INTERVAL_US + 50);
-+	} while (time_before(jiffies, timeout));
-+
-+	return -ETIMEDOUT;
-+}
-+
-+static int mtk_i2c_wait_rx_done(struct mtk_i2c *i2c)
-+{
-+	int ret;
-+
-+	ret = poll_up_timeout(i2c->base + REG_SM0ST, I2C_DATARDY);
-+	if (ret < 0)
-+		dev_dbg(i2c->dev, "rx err(%d)\n", ret);
-+
-+	return ret;
-+}
-+
-+static int mtk_i2c_wait_tx_done(struct mtk_i2c *i2c)
-+{
-+	int ret;
-+
-+	ret = poll_up_timeout(i2c->base + REG_SM0ST, I2C_SDOEMPTY);
-+	if (ret < 0)
-+		dev_dbg(i2c->dev, "tx err(%d)\n", ret);
-+
-+	return ret;
-+}
-+
 +static void mtk_i2c_reset(struct mtk_i2c *i2c)
 +{
-+	u32 reg;
 +	device_reset(i2c->adap.dev.parent);
 +	barrier();
-+
-+	/* ctrl0 */
-+	reg = ODRAIN_HIGH_SM0 | VSYNC_PULSE | (i2c->clk_div << CLK_DIV_SHIFT) |
-+		WAIT_HIGH | SM0_EN;
-+	mtk_i2c_w32(i2c, reg, REG_SM0CTL0);
-+
-+	/* auto mode */
-+	mtk_i2c_w32(i2c, AUTOMODE_EN, REG_SM0CFG2);
++	mtk_i2c_w32(i2c,
++		   SM0CTL0_ODRAIN
++		   | ((i2c->clk_div << 16) & SM0CTL0_CLK_DIV_MASK)
++		   | SM0CTL0_EN
++		   | SM0CTL0_SCL_STRETCH, REG_SM0CTL0_REG);
++	mtk_i2c_w32(i2c, 0, REG_SM0CFG2_REG);
 +}
 +
 +static void mtk_i2c_dump_reg(struct mtk_i2c *i2c)
 +{
-+	dev_dbg(i2c->dev, "cfg0 %08x, dout %08x, din %08x, " \
-+			"status %08x, auto %08x, cfg1 %08x, " \
-+			"cfg2 %08x, ctl0 %08x, ctl1 %08x\n",
-+			mtk_i2c_r32(i2c, REG_SM0CFG0),
-+			mtk_i2c_r32(i2c, REG_SM0DOUT),
-+			mtk_i2c_r32(i2c, REG_SM0DIN),
-+			mtk_i2c_r32(i2c, REG_SM0ST),
-+			mtk_i2c_r32(i2c, REG_SM0AUTO),
-+			mtk_i2c_r32(i2c, REG_SM0CFG1),
-+			mtk_i2c_r32(i2c, REG_SM0CFG2),
-+			mtk_i2c_r32(i2c, REG_SM0CTL0),
-+			mtk_i2c_r32(i2c, REG_SM0CTL1));
++	dev_dbg(i2c->dev, "SM0CFG2 %08x, SM0CTL0 %08x, SM0CTL1 %08x, " \
++			"SM0D0 %08x, SM0D1 %08x\n",
++			mtk_i2c_r32(i2c, REG_SM0CFG2_REG),
++			mtk_i2c_r32(i2c, REG_SM0CTL0_REG),
++			mtk_i2c_r32(i2c, REG_SM0CTL1_REG),
++			mtk_i2c_r32(i2c, REG_SM0D0_REG),
++			mtk_i2c_r32(i2c, REG_SM0D1_REG));
 +}
 +
++static int mtk_i2c_check_ack(struct mtk_i2c *i2c, u32 expected)
++{
++	u32 ack = readl_relaxed(i2c->base + REG_SM0CTL1_REG);
++	u32 ack_expected = (expected << 16) & SM0CTL1_ACK_MASK;
++	return ((ack & ack_expected) == ack_expected) ? 0 : -ENXIO;
++}
++
++static int mtk_i2c_master_start(struct mtk_i2c *i2c)
++{
++	mtk_i2c_w32(i2c, SM0CTL1_START | SM0CTL1_TRI, REG_SM0CTL1_REG);
++	return mtk_i2c_wait_idle(i2c);
++}
++
++static int mtk_i2c_master_stop(struct mtk_i2c *i2c)
++{
++	mtk_i2c_w32(i2c, SM0CTL1_STOP | SM0CTL1_TRI, REG_SM0CTL1_REG);
++	return mtk_i2c_wait_idle(i2c);
++}
++
++static int mtk_i2c_master_cmd(struct mtk_i2c *i2c, u32 cmd, int page_len)
++{
++	mtk_i2c_w32(i2c, cmd | SM0CTL1_TRI | SM0CTL1_PGLEN(page_len), REG_SM0CTL1_REG);
++	return mtk_i2c_wait_idle(i2c);
++}
 +static int mtk_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
 +		int num)
 +{
 +	struct mtk_i2c *i2c;
 +	struct i2c_msg *pmsg;
-+	int i, j, ret;
++	u16 addr;
++	int i, j, ret, len, page_len;
 +	u32 cmd;
++	u32 data[2];
 +
 +	i2c = i2c_get_adapdata(adap);
 +
 +	for (i = 0; i < num; i++) {
 +		pmsg = &msgs[i];
-+		cmd = 0;
 +
 +		dev_dbg(i2c->dev, "addr: 0x%x, len: %d, flags: 0x%x\n",
 +				pmsg->addr, pmsg->len, pmsg->flags);
@@ -276,61 +235,79 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		if ((ret = mtk_i2c_wait_idle(i2c)))
 +			goto err_timeout;
 +
++		/* start sequence */
++		if ((ret = mtk_i2c_master_start(i2c)))
++			goto err_timeout;
++
++		/* write address */
 +		if (pmsg->flags & I2C_M_TEN) {
-+			dev_dbg(i2c->dev, "10 bits addr not supported\n");
-+			return -EINVAL;
++			/* 10 bits address */
++			addr = 0xf0 | ((pmsg->addr >> 7) & 0x06);
++			addr |= (pmsg->addr & 0xff) << 8;
++			if (pmsg->flags & I2C_M_RD)
++				addr |= 1;
++			mtk_i2c_w32(i2c, addr, REG_SM0D0_REG);
++			if ((ret = mtk_i2c_master_cmd(i2c, SM0CTL1_WRITE, 2)))
++				goto err_timeout;
 +		} else {
 +			/* 7 bits address */
-+			mtk_i2c_w32(i2c, pmsg->addr & I2C_DEVADDR_MASK,
-+					REG_SM0CFG0);
++			addr = pmsg->addr << 1;
++			if (pmsg->flags & I2C_M_RD)
++				addr |= 1;
++			mtk_i2c_w32(i2c, addr, REG_SM0D0_REG);
++			if ((ret = mtk_i2c_master_cmd(i2c, SM0CTL1_WRITE, 1)))
++				goto err_timeout;
 +		}
 +
-+		/* buffer length */
-+		if (pmsg->len == 0) {
-+			dev_dbg(i2c->dev, "length is 0\n");
-+			return -EINVAL;
-+		} else
-+			mtk_i2c_w32(i2c, SET_BYTECNT(pmsg->len),
-+					REG_SM0CFG1);
++		/* check address ACK */
++		if (!(pmsg->flags & I2C_M_IGNORE_NAK)) {
++			if ((ret = mtk_i2c_check_ack(i2c, BIT(0))))
++				goto err_ack;
++		}
 +
++		/* transfer data */
 +		j = 0;
-+		if (pmsg->flags & I2C_M_RD) {
-+			cmd |= READ_CMD;
-+			/* start transfer */
-+			barrier();
-+			mtk_i2c_w32(i2c, cmd, REG_SM0AUTO);
-+			do {
-+				/* wait */
-+				if ((ret = mtk_i2c_wait_rx_done(i2c)))
-+					goto err_timeout;
-+				/* read data */
-+				if (pmsg->len)
-+					pmsg->buf[j] = mtk_i2c_r32(i2c,
-+							REG_SM0DIN);
-+				j++;
-+			} while (j < pmsg->len);
-+		} else {
-+			do {
-+				/* write data */
-+				if (pmsg->len)
-+					mtk_i2c_w32(i2c, pmsg->buf[j],
-+							REG_SM0DOUT);
-+				/* start transfer */
-+				if (j == 0) {
-+					barrier();
-+					mtk_i2c_w32(i2c, cmd, REG_SM0AUTO);
++		for (len = pmsg->len; len > 0; len -= 8) {
++			page_len = (len >= 8) ? 8 : len;
++
++			if (pmsg->flags & I2C_M_RD) {
++				cmd = (len > 8) ? SM0CTL1_READ : SM0CTL1_READ_LAST;
++			} else {
++				memcpy(data, &pmsg->buf[j], page_len);
++				mtk_i2c_w32(i2c, data[0], REG_SM0D0_REG);
++				mtk_i2c_w32(i2c, data[1], REG_SM0D1_REG);
++				cmd = SM0CTL1_WRITE;
++			}
++
++			if ((ret = mtk_i2c_master_cmd(i2c, cmd, page_len)))
++				goto err_timeout;
++
++			if (pmsg->flags & I2C_M_RD) {
++				data[0] = mtk_i2c_r32(i2c, REG_SM0D0_REG);
++				data[1] = mtk_i2c_r32(i2c, REG_SM0D1_REG);
++				memcpy(&pmsg->buf[j], data, page_len);
++			} else {
++				if (!(pmsg->flags & I2C_M_IGNORE_NAK)) {
++					if ((ret = mtk_i2c_check_ack(i2c, (1 << page_len) - 1)))
++						goto err_ack;
 +				}
-+				/* wait */
-+				if ((ret = mtk_i2c_wait_tx_done(i2c)))
-+					goto err_timeout;
-+				j++;
-+			} while (j < pmsg->len);
++			}
++			j += 8;
 +		}
 +	}
++
++	if ((ret = mtk_i2c_master_stop(i2c)))
++		goto err_timeout;
++
 +	/* the return value is number of executed messages */
 +	ret = i;
 +
 +	return ret;
++
++err_ack:
++	if ((ret = mtk_i2c_master_stop(i2c)))
++		goto err_timeout;
++	return -ENXIO;
 +
 +err_timeout:
 +	mtk_i2c_dump_reg(i2c);
@@ -355,16 +332,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +MODULE_DEVICE_TABLE(of, i2c_mtk_dt_ids);
 +
-+static struct i2c_adapter_quirks mtk_i2c_quirks = {
-+        .max_write_len = BYTECNT_MAX,
-+        .max_read_len = BYTECNT_MAX,
-+};
-+
 +static void mtk_i2c_init(struct mtk_i2c *i2c)
 +{
-+	i2c->clk_div = clk_get_rate(i2c->clk) / i2c->cur_clk;
-+	if (i2c->clk_div > CLK_DIV_MASK)
-+		i2c->clk_div = CLK_DIV_MASK;
++	i2c->clk_div = clk_get_rate(i2c->clk) / i2c->cur_clk - 1;
++	if (i2c->clk_div < 99)
++		i2c->clk_div = 99;
++	if (i2c->clk_div > SM0CTL0_CLK_DIV_MAX)
++		i2c->clk_div = SM0CTL0_CLK_DIV_MAX;
 +
 +	mtk_i2c_reset(i2c);
 +}
@@ -416,7 +390,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	i2c_set_adapdata(adap, i2c);
 +	adap->dev.of_node = pdev->dev.of_node;
 +	strlcpy(adap->name, dev_name(&pdev->dev), sizeof(adap->name));
-+	adap->quirks = &mtk_i2c_quirks;
 +
 +	platform_set_drvdata(pdev, i2c);
 +
@@ -429,7 +402,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		return ret;
 +	}
 +
-+	dev_info(&pdev->dev, "clock %uKHz, re-start not support\n",
++	dev_info(&pdev->dev, "clock %u kHz\n",
 +			i2c->cur_clk/1000);
 +
 +	return ret;

--- a/target/linux/ramips/patches-4.9/0045-i2c-add-mt7621-driver.patch
+++ b/target/linux/ramips/patches-4.9/0045-i2c-add-mt7621-driver.patch
@@ -37,12 +37,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-$(CONFIG_I2C_RK3X)		+= i2c-rk3x.o
 --- /dev/null
 +++ b/drivers/i2c/busses/i2c-mt7621.c
-@@ -0,0 +1,433 @@
+@@ -0,0 +1,406 @@
 +/*
 + * drivers/i2c/busses/i2c-mt7621.c
 + *
 + * Copyright (C) 2013 Steven Liu <steven_liu@mediatek.com>
 + * Copyright (C) 2016 Michael Lee <igvtee@gmail.com>
++ * Copyright (C) 2018 Jan Breuer <jan.breuer@jaybee.cz>
 + *
 + * Improve driver for i2cdetect from i2c-tools to detect i2c devices on the bus.
 + * (C) 2014 Sittisak <sittisaks@hotmail.com>
@@ -73,70 +74,39 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#include <linux/err.h>
 +#include <linux/clk.h>
 +
-+#define REG_SM0CFG0		0x08
-+#define REG_SM0DOUT		0x10
-+#define REG_SM0DIN		0x14
-+#define REG_SM0ST		0x18
-+#define REG_SM0AUTO		0x1C
-+#define REG_SM0CFG1		0x20
-+#define REG_SM0CFG2		0x28
-+#define REG_SM0CTL0		0x40
-+#define REG_SM0CTL1		0x44
-+#define REG_SM0D0		0x50
-+#define REG_SM0D1		0x54
-+#define REG_PINTEN		0x5C
-+#define REG_PINTST		0x60
-+#define REG_PINTCL		0x64
++#define REG_SM0CFG2_REG		0x28
++#define REG_SM0CTL0_REG		0x40
++#define REG_SM0CTL1_REG		0x44
++#define REG_SM0D0_REG		0x50
++#define REG_SM0D1_REG		0x54
++#define REG_PINTEN_REG		0x5C
++#define REG_PINTST_REG		0x60
++#define REG_PINTCL_REG		0x64
 +
-+/* REG_SM0CFG0 */
-+#define I2C_DEVADDR_MASK	0x7f
++/* REG_SM0CFG2_REG */
++#define SM0CFG2_IS_AUTOMODE	BIT(0)
 +
-+/* REG_SM0ST */
-+#define I2C_DATARDY		BIT(2)
-+#define I2C_SDOEMPTY		BIT(1)
-+#define I2C_BUSY		BIT(0)
++/* REG_SM0CTL0_REG */
++#define SM0CTL0_ODRAIN		BIT(31)
++#define SM0CTL0_CLK_DIV_MASK	(0x7FF << 16)
++#define SM0CTL0_CLK_DIV_MAX	0x7ff
++#define SM0CTL0_CS_STATUS       BIT(4)
++#define SM0CTL0_SCL_STATE       BIT(3)
++#define SM0CTL0_SDA_STATE       BIT(2)
++#define SM0CTL0_EN              BIT(1)
++#define SM0CTL0_SCL_STRETCH     BIT(0)
 +
-+/* REG_SM0AUTO */
-+#define READ_CMD		BIT(0)
-+
-+/* REG_SM0CFG1 */
-+#define BYTECNT_MAX		64
-+#define SET_BYTECNT(x)		(x - 1)
-+
-+/* REG_SM0CFG2 */
-+#define AUTOMODE_EN		BIT(0)
-+
-+/* REG_SM0CTL0 */
-+#define ODRAIN_HIGH_SM0		BIT(31)
-+#define VSYNC_SHIFT		28
-+#define VSYNC_MASK		0x3
-+#define VSYNC_PULSE		(0x1 << VSYNC_SHIFT)
-+#define VSYNC_RISING		(0x2 << VSYNC_SHIFT)
-+#define CLK_DIV_SHIFT		16
-+#define CLK_DIV_MASK		0xfff
-+#define DEG_CNT_SHIFT		8
-+#define DEG_CNT_MASK		0xff
-+#define WAIT_HIGH		BIT(6)
-+#define DEG_EN			BIT(5)
-+#define CS_STATUA		BIT(4)
-+#define SCL_STATUS		BIT(3)
-+#define SDA_STATUS		BIT(2)
-+#define SM0_EN			BIT(1)
-+#define SCL_STRECH		BIT(0)
-+
-+/* REG_SM0CTL1 */
-+#define ACK_SHIFT		16
-+#define ACK_MASK		0xff
-+#define PGLEN_SHIFT		8
-+#define PGLEN_MASK		0x7
-+#define SM0_MODE_SHIFT		4
-+#define SM0_MODE_MASK		0x7
-+#define SM0_MODE_START		0x1
-+#define SM0_MODE_WRITE		0x2
-+#define SM0_MODE_STOP		0x3
-+#define SM0_MODE_READ_NACK	0x4
-+#define SM0_MODE_READ_ACK	0x5
-+#define SM0_TRI_BUSY		BIT(0)
++/* REG_SM0CTL1_REG */
++#define SM0CTL1_ACK_MASK	(0xFF << 16)
++#define SM0CTL1_PGLEN_MASK	(0x7 << 8)
++#define SM0CTL1_PGLEN(x)	(((x - 1) << 8) & SM0CTL1_PGLEN_MASK)
++#define SM0CTL1_READ		(5 << 4)
++#define SM0CTL1_READ_LAST	(4 << 4)
++#define SM0CTL1_STOP		(3 << 4)
++#define SM0CTL1_WRITE		(2 << 4)
++#define SM0CTL1_START		(1 << 4)
++#define SM0CTL1_MODE_MASK	(0x7 << 4)
++#define SM0CTL1_TRI		BIT(0)
 +
 +/* timeout waiting for I2C devices to respond (clock streching) */
 +#define TIMEOUT_MS              1000
@@ -165,12 +135,21 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static int poll_down_timeout(void __iomem *addr, u32 mask)
 +{
 +	unsigned long timeout = jiffies + msecs_to_jiffies(TIMEOUT_MS);
++	int current_delay = 1;
 +
 +	do {
 +		if (!(readl_relaxed(addr) & mask))
 +			return 0;
 +
-+		usleep_range(DELAY_INTERVAL_US, DELAY_INTERVAL_US + 50);
++		if (current_delay > 0 && current_delay < 10) {
++			udelay(current_delay);
++		} else if (current_delay >= 10) {
++			usleep_range(current_delay, current_delay + 50);
++		}
++		current_delay *= current_delay;
++		if (current_delay > DELAY_INTERVAL_US) {
++			current_delay = DELAY_INTERVAL_US;
++		}
 +	} while (time_before(jiffies, timeout));
 +
 +	return (readl_relaxed(addr) & mask) ? -EAGAIN : 0;
@@ -180,94 +159,74 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +{
 +	int ret;
 +
-+	ret = poll_down_timeout(i2c->base + REG_SM0ST, I2C_BUSY);
++	ret = poll_down_timeout(i2c->base + REG_SM0CTL1_REG, SM0CTL1_TRI);
 +	if (ret < 0)
 +		dev_dbg(i2c->dev, "idle err(%d)\n", ret);
 +
 +	return ret;
 +}
 +
-+static int poll_up_timeout(void __iomem *addr, u32 mask)
-+{
-+	unsigned long timeout = jiffies + msecs_to_jiffies(TIMEOUT_MS);
-+	u32 status;
-+
-+	do {
-+		status = readl_relaxed(addr);
-+		if (status & mask)
-+			return 0;
-+		usleep_range(DELAY_INTERVAL_US, DELAY_INTERVAL_US + 50);
-+	} while (time_before(jiffies, timeout));
-+
-+	return -ETIMEDOUT;
-+}
-+
-+static int mtk_i2c_wait_rx_done(struct mtk_i2c *i2c)
-+{
-+	int ret;
-+
-+	ret = poll_up_timeout(i2c->base + REG_SM0ST, I2C_DATARDY);
-+	if (ret < 0)
-+		dev_dbg(i2c->dev, "rx err(%d)\n", ret);
-+
-+	return ret;
-+}
-+
-+static int mtk_i2c_wait_tx_done(struct mtk_i2c *i2c)
-+{
-+	int ret;
-+
-+	ret = poll_up_timeout(i2c->base + REG_SM0ST, I2C_SDOEMPTY);
-+	if (ret < 0)
-+		dev_dbg(i2c->dev, "tx err(%d)\n", ret);
-+
-+	return ret;
-+}
-+
 +static void mtk_i2c_reset(struct mtk_i2c *i2c)
 +{
-+	u32 reg;
 +	device_reset(i2c->adap.dev.parent);
 +	barrier();
-+
-+	/* ctrl0 */
-+	reg = ODRAIN_HIGH_SM0 | VSYNC_PULSE | (i2c->clk_div << CLK_DIV_SHIFT) |
-+		WAIT_HIGH | SM0_EN;
-+	mtk_i2c_w32(i2c, reg, REG_SM0CTL0);
-+
-+	/* auto mode */
-+	mtk_i2c_w32(i2c, AUTOMODE_EN, REG_SM0CFG2);
++	mtk_i2c_w32(i2c,
++		   SM0CTL0_ODRAIN
++		   | ((i2c->clk_div << 16) & SM0CTL0_CLK_DIV_MASK)
++		   | SM0CTL0_EN
++		   | SM0CTL0_SCL_STRETCH, REG_SM0CTL0_REG);
++	mtk_i2c_w32(i2c, 0, REG_SM0CFG2_REG);
 +}
 +
 +static void mtk_i2c_dump_reg(struct mtk_i2c *i2c)
 +{
-+	dev_dbg(i2c->dev, "cfg0 %08x, dout %08x, din %08x, " \
-+			"status %08x, auto %08x, cfg1 %08x, " \
-+			"cfg2 %08x, ctl0 %08x, ctl1 %08x\n",
-+			mtk_i2c_r32(i2c, REG_SM0CFG0),
-+			mtk_i2c_r32(i2c, REG_SM0DOUT),
-+			mtk_i2c_r32(i2c, REG_SM0DIN),
-+			mtk_i2c_r32(i2c, REG_SM0ST),
-+			mtk_i2c_r32(i2c, REG_SM0AUTO),
-+			mtk_i2c_r32(i2c, REG_SM0CFG1),
-+			mtk_i2c_r32(i2c, REG_SM0CFG2),
-+			mtk_i2c_r32(i2c, REG_SM0CTL0),
-+			mtk_i2c_r32(i2c, REG_SM0CTL1));
++	dev_dbg(i2c->dev, "SM0CFG2 %08x, SM0CTL0 %08x, SM0CTL1 %08x, " \
++			"SM0D0 %08x, SM0D1 %08x\n",
++			mtk_i2c_r32(i2c, REG_SM0CFG2_REG),
++			mtk_i2c_r32(i2c, REG_SM0CTL0_REG),
++			mtk_i2c_r32(i2c, REG_SM0CTL1_REG),
++			mtk_i2c_r32(i2c, REG_SM0D0_REG),
++			mtk_i2c_r32(i2c, REG_SM0D1_REG));
 +}
 +
++static int mtk_i2c_check_ack(struct mtk_i2c *i2c, u32 expected)
++{
++	u32 ack = readl_relaxed(i2c->base + REG_SM0CTL1_REG);
++	u32 ack_expected = (expected << 16) & SM0CTL1_ACK_MASK;
++	return ((ack & ack_expected) == ack_expected) ? 0 : -ENXIO;
++}
++
++static int mtk_i2c_master_start(struct mtk_i2c *i2c)
++{
++	mtk_i2c_w32(i2c, SM0CTL1_START | SM0CTL1_TRI, REG_SM0CTL1_REG);
++	return mtk_i2c_wait_idle(i2c);
++}
++
++static int mtk_i2c_master_stop(struct mtk_i2c *i2c)
++{
++	mtk_i2c_w32(i2c, SM0CTL1_STOP | SM0CTL1_TRI, REG_SM0CTL1_REG);
++	return mtk_i2c_wait_idle(i2c);
++}
++
++static int mtk_i2c_master_cmd(struct mtk_i2c *i2c, u32 cmd, int page_len)
++{
++	mtk_i2c_w32(i2c, cmd | SM0CTL1_TRI | SM0CTL1_PGLEN(page_len), REG_SM0CTL1_REG);
++	return mtk_i2c_wait_idle(i2c);
++}
 +static int mtk_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
 +		int num)
 +{
 +	struct mtk_i2c *i2c;
 +	struct i2c_msg *pmsg;
-+	int i, j, ret;
++	u16 addr;
++	int i, j, ret, len, page_len;
 +	u32 cmd;
++	u32 data[2];
 +
 +	i2c = i2c_get_adapdata(adap);
 +
 +	for (i = 0; i < num; i++) {
 +		pmsg = &msgs[i];
-+		cmd = 0;
 +
 +		dev_dbg(i2c->dev, "addr: 0x%x, len: %d, flags: 0x%x\n",
 +				pmsg->addr, pmsg->len, pmsg->flags);
@@ -276,61 +235,79 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		if ((ret = mtk_i2c_wait_idle(i2c)))
 +			goto err_timeout;
 +
++		/* start sequence */
++		if ((ret = mtk_i2c_master_start(i2c)))
++			goto err_timeout;
++
++		/* write address */
 +		if (pmsg->flags & I2C_M_TEN) {
-+			dev_dbg(i2c->dev, "10 bits addr not supported\n");
-+			return -EINVAL;
++			/* 10 bits address */
++			addr = 0xf0 | ((pmsg->addr >> 7) & 0x06);
++			addr |= (pmsg->addr & 0xff) << 8;
++			if (pmsg->flags & I2C_M_RD)
++				addr |= 1;
++			mtk_i2c_w32(i2c, addr, REG_SM0D0_REG);
++			if ((ret = mtk_i2c_master_cmd(i2c, SM0CTL1_WRITE, 2)))
++				goto err_timeout;
 +		} else {
 +			/* 7 bits address */
-+			mtk_i2c_w32(i2c, pmsg->addr & I2C_DEVADDR_MASK,
-+					REG_SM0CFG0);
++			addr = pmsg->addr << 1;
++			if (pmsg->flags & I2C_M_RD)
++				addr |= 1;
++			mtk_i2c_w32(i2c, addr, REG_SM0D0_REG);
++			if ((ret = mtk_i2c_master_cmd(i2c, SM0CTL1_WRITE, 1)))
++				goto err_timeout;
 +		}
 +
-+		/* buffer length */
-+		if (pmsg->len == 0) {
-+			dev_dbg(i2c->dev, "length is 0\n");
-+			return -EINVAL;
-+		} else
-+			mtk_i2c_w32(i2c, SET_BYTECNT(pmsg->len),
-+					REG_SM0CFG1);
++		/* check address ACK */
++		if (!(pmsg->flags & I2C_M_IGNORE_NAK)) {
++			if ((ret = mtk_i2c_check_ack(i2c, BIT(0))))
++				goto err_ack;
++		}
 +
++		/* transfer data */
 +		j = 0;
-+		if (pmsg->flags & I2C_M_RD) {
-+			cmd |= READ_CMD;
-+			/* start transfer */
-+			barrier();
-+			mtk_i2c_w32(i2c, cmd, REG_SM0AUTO);
-+			do {
-+				/* wait */
-+				if ((ret = mtk_i2c_wait_rx_done(i2c)))
-+					goto err_timeout;
-+				/* read data */
-+				if (pmsg->len)
-+					pmsg->buf[j] = mtk_i2c_r32(i2c,
-+							REG_SM0DIN);
-+				j++;
-+			} while (j < pmsg->len);
-+		} else {
-+			do {
-+				/* write data */
-+				if (pmsg->len)
-+					mtk_i2c_w32(i2c, pmsg->buf[j],
-+							REG_SM0DOUT);
-+				/* start transfer */
-+				if (j == 0) {
-+					barrier();
-+					mtk_i2c_w32(i2c, cmd, REG_SM0AUTO);
++		for (len = pmsg->len; len > 0; len -= 8) {
++			page_len = (len >= 8) ? 8 : len;
++
++			if (pmsg->flags & I2C_M_RD) {
++				cmd = (len > 8) ? SM0CTL1_READ : SM0CTL1_READ_LAST;
++			} else {
++				memcpy(data, &pmsg->buf[j], page_len);
++				mtk_i2c_w32(i2c, data[0], REG_SM0D0_REG);
++				mtk_i2c_w32(i2c, data[1], REG_SM0D1_REG);
++				cmd = SM0CTL1_WRITE;
++			}
++
++			if ((ret = mtk_i2c_master_cmd(i2c, cmd, page_len)))
++				goto err_timeout;
++
++			if (pmsg->flags & I2C_M_RD) {
++				data[0] = mtk_i2c_r32(i2c, REG_SM0D0_REG);
++				data[1] = mtk_i2c_r32(i2c, REG_SM0D1_REG);
++				memcpy(&pmsg->buf[j], data, page_len);
++			} else {
++				if (!(pmsg->flags & I2C_M_IGNORE_NAK)) {
++					if ((ret = mtk_i2c_check_ack(i2c, (1 << page_len) - 1)))
++						goto err_ack;
 +				}
-+				/* wait */
-+				if ((ret = mtk_i2c_wait_tx_done(i2c)))
-+					goto err_timeout;
-+				j++;
-+			} while (j < pmsg->len);
++			}
++			j += 8;
 +		}
 +	}
++
++	if ((ret = mtk_i2c_master_stop(i2c)))
++		goto err_timeout;
++
 +	/* the return value is number of executed messages */
 +	ret = i;
 +
 +	return ret;
++
++err_ack:
++	if ((ret = mtk_i2c_master_stop(i2c)))
++		goto err_timeout;
++	return -ENXIO;
 +
 +err_timeout:
 +	mtk_i2c_dump_reg(i2c);
@@ -355,16 +332,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +MODULE_DEVICE_TABLE(of, i2c_mtk_dt_ids);
 +
-+static struct i2c_adapter_quirks mtk_i2c_quirks = {
-+        .max_write_len = BYTECNT_MAX,
-+        .max_read_len = BYTECNT_MAX,
-+};
-+
 +static void mtk_i2c_init(struct mtk_i2c *i2c)
 +{
-+	i2c->clk_div = clk_get_rate(i2c->clk) / i2c->cur_clk;
-+	if (i2c->clk_div > CLK_DIV_MASK)
-+		i2c->clk_div = CLK_DIV_MASK;
++	i2c->clk_div = clk_get_rate(i2c->clk) / i2c->cur_clk - 1;
++	if (i2c->clk_div < 99)
++		i2c->clk_div = 99;
++	if (i2c->clk_div > SM0CTL0_CLK_DIV_MAX)
++		i2c->clk_div = SM0CTL0_CLK_DIV_MAX;
 +
 +	mtk_i2c_reset(i2c);
 +}
@@ -416,7 +390,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	i2c_set_adapdata(adap, i2c);
 +	adap->dev.of_node = pdev->dev.of_node;
 +	strlcpy(adap->name, dev_name(&pdev->dev), sizeof(adap->name));
-+	adap->quirks = &mtk_i2c_quirks;
 +
 +	platform_set_drvdata(pdev, i2c);
 +
@@ -429,7 +402,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		return ret;
 +	}
 +
-+	dev_info(&pdev->dev, "clock %uKHz, re-start not support\n",
++	dev_info(&pdev->dev, "clock %u kHz\n",
 +			i2c->cur_clk/1000);
 +
 +	return ret;


### PR DESCRIPTION
New supported features
 - unlimited message length
 - clock stretching
 - ACK handling (i2c-detect now works)
 - repeated start sequence

Signed-off-by: Jan Breuer <jan.breuer@jaybee.cz>
