### PR TITLE
kernel: Remove AutoLoad for legacy usb gadget modules

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -131,7 +131,6 @@ define KernelPackage/usb-gadget-ehci-debug
 	CONFIG_USB_G_DBGP_PRINTK=n
   DEPENDS:=+kmod-usb-gadget +kmod-usb-lib-composite +kmod-usb-gadget-serial
   FILES:=$(LINUX_DIR)/drivers/usb/gadget/legacy/g_dbgp.ko
-  AUTOLOAD:=$(call AutoLoad,52,g_dbgp)
   $(call AddDepends/usb)
 endef
 
@@ -154,7 +153,7 @@ define KernelPackage/usb-gadget-eth
 	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_ecm_subset.ko \
 	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_rndis.ko \
 	$(LINUX_DIR)/drivers/usb/gadget/legacy/g_ether.ko
-  AUTOLOAD:=$(call AutoLoad,52,usb_f_ecm g_ether)
+  AUTOLOAD:=$(call AutoLoad,52,usb_f_ecm)
   $(call AddDepends/usb)
 endef
 
@@ -175,7 +174,7 @@ define KernelPackage/usb-gadget-serial
 	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_obex.ko \
 	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_serial.ko \
 	$(LINUX_DIR)/drivers/usb/gadget/legacy/g_serial.ko
-  AUTOLOAD:=$(call AutoLoad,52,usb_f_acm g_serial)
+  AUTOLOAD:=$(call AutoLoad,52,usb_f_acm)
   $(call AddDepends/usb)
 endef
 
@@ -192,7 +191,7 @@ define KernelPackage/usb-gadget-mass-storage
   FILES:= \
 	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_mass_storage.ko \
 	$(LINUX_DIR)/drivers/usb/gadget/legacy/g_mass_storage.ko
-  AUTOLOAD:=$(call AutoLoad,52,usb_f_mass_storage g_mass_storage)
+  AUTOLOAD:=$(call AutoLoad,52,usb_f_mass_storage)
   $(call AddDepends/usb)
 endef
 


### PR DESCRIPTION
These modules usually require some special arguments to customize the emulated device and they should be loaded manually by users and add AutoLoad for them could be useless for some modules (e.g. g_mass_storage). I have to remove all those modules if I want to use one of them or use configfs to create a custom gadget device.

BTW I got kernel panic when I try to remove g_mass_storage after removing g_ether.(I think it's because mass storage failed to start without arguments.)
```
[   10.401804] g_ether gadget: Ethernet Gadget, version: Memorial Day 2008
[   10.408268] g_ether gadget: g_ether ready
[   10.461127] udc-core: couldn't find an available UDC - added [g_mass_storage] to list of pending drivers
[   10.504875] udc-core: couldn't find an available UDC - added [g_serial] to list of pending drivers
......
root@OpenWrt:/# rmmod g_ether
[   88.390518] Mass Storage Function, version: 2009/09/11
[   88.394389] LUN: removable file: (no medium)
[   88.398611] no file given for LUN0
[   88.401889] g_mass_storage ci_hdrc: failed to start g_mass_storage: -22
root@OpenWrt:/# rmmod g_mass_storage
[  104.151945] CPU 0 Unable to handle kernel paging request at virtual address 00000104, epc == 830aee30, ra == 830aee0c
[  104.161234] Oops[#1]:
[  104.163369] CPU: 0 PID: 1353 Comm: rmmod Not tainted 4.9.91 #0
[  104.169178] task: 83a3f390 task.stack: 831ba000
[  104.173686] $ 0   : 00000000 00000001 00000200 00000100
[  104.178893] $ 4   : 830afc68 831bbede 8321571a 0000003b
[  104.184101] $ 8   : 0000000e 8006f68c 800c7d80 7faf7eb4
[  104.189311] $12   : 7faf7ff8 00400cf8 00000000 00000000
[  104.194518] $16   : 830afba4 83215528 830b0000 831bbed0
[  104.199726] $20   : 77282000 77282000 77282000 00000000
[  104.204935] $24   : 00001021 771f0e20                  
[  104.210144] $28   : 831ba000 831bbea0 00000000 830aee0c
[  104.215353] Hi    : 00000000
[  104.218218] Lo    : 00000034
[  104.221119] epc   : 830aee30 0x830aee30 [udc_core@830ae000+0x1df0]
[  104.227264] ra    : 830aee0c 0x830aee0c [udc_core@830ae000+0x1df0]
[  104.233408] Status: 1000dc03	KERNEL EXL IE 
[  104.237578] Cause : 0080000c (ExcCode 03)
[  104.241567] BadVA : 00000104
[  104.244434] PrId  : 00019374 (MIPS 24Kc)
[  104.248337] Modules linked in: ath9k ath9k_common pppoe ppp_async ath9k_hw ath pppox ppp_generic nf_conntrack_ipv6 mac80211 iptable_nat ipt_REJECT ipt_MASQUERADE cfg80211 xt_time xt_tcpudp xt_state xt_nat xt_multiport xt_mark xt_mac xt_limit xt_conntrack xt_comment xt_TCPMSS xt_REDIRECT xt_LOG slhc nf_reject_ipv4 nf_nat_redirect nf_nat_masquerade_ipv4 nf_conntrack_ipv4 nf_nat_ipv4 nf_nat nf_log_ipv4 nf_defrag_ipv6 nf_defrag_ipv4 nf_conntrack_rtcache nf_conntrack iptable_mangle iptable_filter ip_tables crc_ccitt compat g_serial usb_f_acm u_serial g_mass_storage(-) usb_f_mass_storage usb_f_rndis usb_f_ecm u_ether libcomposite xt_set ip_set_list_set ip_set_hash_netiface ip_set_hash_netport ip_set_hash_netnet ip_set_hash_net ip_set_hash_netportnet ip_set_hash_mac ip_set_hash_ipportnet ip_set_hash_ipportip ip_set_hash_ipport ip_set_hash_ipmark ip_set_hash_ip ip_set_bitmap_port ip_set_bitmap_ipmac ip_set_bitmap_ip ip_set nfnetlink ip6t_REJECT nf_reject_ipv6 nf_log_ipv6 nf_log_common ip6table_mangle ip6table_filter ip6_tables x_tables configfs ehci_platform ci_hdrc extcon_core ehci_hcd gpio_button_hotplug phy_generic udc_core usbcore nls_base usb_common [last unloaded: g_ether]
Process rmmod (pid: 1353, threadinfo=831ba000, task=83a3f390, tls=7728ddc0)
[  104.358667] Stack : 0000000e 80400000 803f0000 831bbed0 83215700 80400000 803f0000 800c7f34
[  104.367001]         00000010 8352b6e8 8381c8d0 80115c00 675f6d61 73735f73 746f7261 67650000
[  104.375334]         00000000 00000000 83a3f390 804640b0 00000000 83a3f390 804640b0 00000000
[  104.383668]         83a3f390 8009642c 00000000 79a67cd6 771e0660 00000002 0000003a 00001021
[  104.392002]         00000000 8006f2ec 00000012 00000000 7ffebdf0 00000000 00400cf8 00000000
[  104.400333]         ...
[  104.402764] Call Trace:[  104.405051] [<800c7f34>] 0x800c7f34
[  104.408501] [<80115c00>] 0x80115c00
[  104.411974] [<8009642c>] 0x8009642c
[  104.415445] [<8006f2ec>] 0x8006f2ec
[  104.418919] [<801c80f8>] 0x801c80f8
[  104.422388] [<800ffa80>] 0x800ffa80
[  104.425863] 
[  104.427329] Code: 00000000  8e22006c  8e230068 <ac620004> ac430000  24020100  ae220068  24020200  1000000b 
[  104.437052] 
[  104.438585] ---[ end trace f535e1bc444d3e77 ]---
[  104.446262] Kernel panic - not syncing: Fatal exception
[  104.451462] Rebooting in 3 seconds..
```

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>