### PR TITLE
hostapd: make cli treat UNKNOWN COMMAND as failing

### DIFF
--- a/package/network/services/hostapd/patches/381-hostapd_cli_UNKNOWN-COMMAND.patch
+++ b/package/network/services/hostapd/patches/381-hostapd_cli_UNKNOWN-COMMAND.patch
@@ -1,0 +1,13 @@
+--- a/hostapd/hostapd_cli.c
++++ b/hostapd/hostapd_cli.c
+@@ -743,7 +743,7 @@ static int wpa_ctrl_command_sta(struct wpa_ctrl *ctrl, const char *cmd,
+ 	}
+ 
+ 	buf[len] = '\0';
+-	if (memcmp(buf, "FAIL", 4) == 0)
++	if (memcmp(buf, "FAIL", 4) == 0 || memcmp(buf, "UNKNOWN COMMAND", 15) == 0)
+ 		return -1;
+ 	if (print)
+ 		printf("%s", buf);
+-- 
+2.11.0


### PR DESCRIPTION
Avoid infinite loop at 100% CPU when running hostapd_cli
if CONFIG_CTRL_IFACE_MIB is not defined.

  _newselect(4, [3], NULL, NULL, ...)
  recvfrom(3, "UNKNOWN COMMAND\n", 4095, 0, NULL, NULL) = 16
  sendto(3, "STA-NEXT UNKNOWN COMMAND", 24, 0, NULL, 0) = 24

Signed-off-by: Denton Gentry <denny@geekhold.com>
