### PR TITLE
mvebu: cortexa53: set correct CPU_SUBTYPE

### DIFF
--- a/target/linux/mvebu/cortexa53/target.mk
+++ b/target/linux/mvebu/cortexa53/target.mk
@@ -10,6 +10,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=aarch64
 BOARDNAME:=Marvell Armada 3700LP (ARM64)
 CPU_TYPE:=cortex-a53
+CPU_SUBTYPE:=neon-vfpv4
 FEATURES+=ext4
 
 KERNELNAME:=Image dtbs


### PR DESCRIPTION
Compile & run tested on espressobin (mvebu/cortexa53)

Description:
Some packages like 'node' will not compile if CPU_SUBTYPE is not set. This will set correct FPU settings for this CPU so that node and other packages can compile.

Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>