### PR TITLE
patch is required for rb951g rev3 boards

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rb95x.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rb95x.c
@@ -266,6 +266,7 @@ static void __init rb951g_setup(void)
 		return;
 
 	ath79_setup_ar934x_eth_cfg(AR934X_ETH_CFG_RGMII_GMAC0 |
+				   AR934X_ETH_CFG_RXD_DELAY |
 				   AR934X_ETH_CFG_SW_ONLY_MODE);
 
 	ath79_register_mdio(0, 0x0);
@@ -276,7 +277,7 @@ static void __init rb951g_setup(void)
 	ath79_init_mac(ath79_eth0_data.mac_addr, ath79_mac_base, 0);
 	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;
 	ath79_eth0_data.phy_mask = BIT(0);
-
+	ath79_eth0_pll_data.pll_1000 = 0x6f000000;
 	ath79_register_eth(0);
 
 	rb95x_wlan_init();


### PR DESCRIPTION
There has been a number of discussions on the RB951G-2HnD and the ToH page lists that the ethernet patch is required for rev3 boards (but doesn't specifically say it breaks v1/2 boards).
https://openwrt.org/toh/mikrotik/rb951g_2hnd
And using 6f rather than 3e to improve performance.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
