### PR TITLE
kernel: add mt7621 nand driver dma support

### DIFF
--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -431,6 +431,17 @@
 
 		clocks = <&nficlock>;
 		clock-names = "nfi_clk";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&nand_pins>;
+
+		resets = <&rstctrl 15>;
+		reset-names = "nfi";
+
+		interrupt-parent = <&gic>;
+		interrupt-names = "nfi", "ecc";
+		interrupts = <GIC_SHARED 14 IRQ_TYPE_LEVEL_HIGH
+			GIC_SHARED 15 IRQ_TYPE_LEVEL_HIGH>;
 	};
 
 	ethsys: syscon@1e000000 {

--- a/target/linux/ramips/patches-5.4/0302-mt7621-nand-add-dma-support.patch
+++ b/target/linux/ramips/patches-5.4/0302-mt7621-nand-add-dma-support.patch
@@ -1,0 +1,1347 @@
+--- a/drivers/mtd/nand/raw/mt7621_nand.c
++++ b/drivers/mtd/nand/raw/mt7621_nand.c
+@@ -6,20 +6,13 @@
+  *
+  * Author: Weijie Gao <weijie.gao@mediatek.com>
+  */
+-
+-#include <linux/io.h>
+ #include <linux/clk.h>
+-#include <linux/init.h>
+-#include <linux/errno.h>
+-#include <linux/sizes.h>
+ #include <linux/iopoll.h>
+-#include <linux/kernel.h>
+ #include <linux/module.h>
+-#include <linux/mtd/mtd.h>
+ #include <linux/mtd/rawnand.h>
+-#include <linux/mtd/partitions.h>
+ #include <linux/platform_device.h>
+-#include <asm/addrspace.h>
++#include <linux/reset.h>
++#include <linux/dma-mapping.h>
+ 
+ /* NFI core registers */
+ #define NFI_CNFG			0x000
+@@ -30,6 +23,7 @@
+ #define   CNFG_HW_ECC_EN		BIT(8)
+ #define   CNFG_BYTE_RW			BIT(6)
+ #define   CNFG_READ_MODE		BIT(1)
++#define   CNFG_DMA_MODE			BIT(0)
+ 
+ #define NFI_PAGEFMT			0x004
+ #define   PAGEFMT_FDM_ECC_S		12
+@@ -74,6 +68,10 @@
+ #define   ACCCON_RLT_DEF		15
+ #define   ACCCON_RLT_MIN		3
+ 
++#define NFI_INTR_EN			0x010
++#define NFI_INTR			0x014
++#define   INTR_AHB_DONE			BIT(6)
++
+ #define NFI_CMD				0x020
+ 
+ #define NFI_ADDRNOB			0x030
+@@ -103,6 +101,7 @@
+ #define   STA_NFI_FSM_S			16
+ #define   STA_NFI_FSM_M			GENMASK(19, 16)
+ #define     STA_FSM_CUSTOM_DATA		14
++#define   STA_READ_EMPTY		BIT(12)
+ #define   STA_BUSY			BIT(8)
+ #define   STA_ADDR			BIT(1)
+ #define   STA_CMD			BIT(0)
+@@ -113,10 +112,23 @@
+ #define   SEC_ADDR_S			0
+ #define   SEC_ADDR_M			GENMASK(9, 0)
+ 
++#define NFI_STRADDR			0x080
++
++#define NFI_BYTELEN			0x084
++#define   BYTELEN_S			12
++#define   BYTELEN_M			GENMASK(15, 12)
++
+ #define NFI_CSEL			0x090
+ #define   CSEL_S			0
+ #define   CSEL_M			GENMASK(1, 0)
+ 
++#define NFI_IOCON			0x094
++#define   IOCON_BRSTN_S			4
++#define   IOCON_BRSTN_M			GENMASK(7, 4)
++#define   IOCON_L2NW			BIT(2)
++#define   IOCON_L2NR			BIT(1)
++#define   IOCON_NLDPD			BIT(0)
++
+ #define NFI_FDM0L			0x0a0
+ #define NFI_FDML(n)			(0x0a0 + ((n) << 3))
+ 
+@@ -145,6 +157,11 @@
+ #define ECC_ENCIDLE			0x00c
+ #define   ENC_IDLE			BIT(0)
+ 
++#define ECC_ENCIRQEN			0x028
++#define   ENC_IRQEN			BIT(0)
++
++#define ECC_ENCIRQSTA			0x02c
++
+ #define ECC_DECCON			0x100
+ #define   DEC_EN			BIT(0)
+ 
+@@ -155,6 +172,7 @@
+ #define   DEC_CON_S			12
+ #define   DEC_CON_M			GENMASK(13, 12)
+ #define     DEC_CON_EL			2
++#define     DEC_CON_CORT		3
+ #define   DEC_MODE_S			4
+ #define   DEC_MODE_M			GENMASK(5, 4)
+ #define     DEC_MODE_NFI		1
+@@ -185,6 +203,11 @@
+ #define   DEC_EL_BYTE_POS_S		3
+ #define   DEC_EL_BIT_POS_M		GENMASK(3, 0)
+ 
++#define ECC_DECIRQEN			0x134
++#define   DEC_IRQEN			BIT(0)
++
++#define ECC_DECIRQSTA			0x138
++
+ #define ECC_FDMADDR			0x13c
+ 
+ /* ENCIDLE and DECIDLE */
+@@ -217,7 +240,12 @@ struct mt7621_nfc {
+ 	void __iomem *nfi_regs;
+ 	void __iomem *ecc_regs;
+ 
++	struct completion nfi_done;
++	struct completion ecc_done;
++
+ 	u32 spare_per_sector;
++	int pages_per_block;
++	u8 *block_buf;
+ };
+ 
+ static const u16 mt7621_nfi_page_size[] = { SZ_512, SZ_2K, SZ_4K };
+@@ -244,6 +272,11 @@ static inline void nfi_write16(struct mt
+ 	writew(val, nfc->nfi_regs + reg);
+ }
+ 
++static inline u16 ecc_read16(struct mt7621_nfc *nfc, u32 reg)
++{
++	return readw(nfc->ecc_regs + reg);
++}
++
+ static inline void ecc_write16(struct mt7621_nfc *nfc, u32 reg, u16 val)
+ {
+ 	writew(val, nfc->ecc_regs + reg);
+@@ -259,113 +292,59 @@ static inline void ecc_write32(struct mt
+ 	return writel(val, nfc->ecc_regs + reg);
+ }
+ 
+-static inline u8 *oob_fdm_ptr(struct nand_chip *nand, int sect)
+-{
+-	return nand->oob_poi + sect * NFI_FDM_SIZE;
+-}
+-
+-static inline u8 *oob_ecc_ptr(struct mt7621_nfc *nfc, int sect)
+-{
+-	struct nand_chip *nand = &nfc->nand;
+-
+-	return nand->oob_poi + nand->ecc.steps * NFI_FDM_SIZE +
+-		sect * (nfc->spare_per_sector - NFI_FDM_SIZE);
+-}
+-
+-static inline u8 *page_data_ptr(struct nand_chip *nand, const u8 *buf,
+-				int sect)
+-{
+-	return (u8 *)buf + sect * nand->ecc.size;
+-}
+-
+ static int mt7621_ecc_wait_idle(struct mt7621_nfc *nfc, u32 reg)
+ {
+ 	struct device *dev = nfc->dev;
+-	u32 val;
++	u16 val;
+ 	int ret;
+ 
+ 	ret = readw_poll_timeout_atomic(nfc->ecc_regs + reg, val,
+ 					val & ECC_IDLE, 10,
+ 					ECC_ENGINE_TIMEOUT);
+-	if (ret) {
++	if (ret)
+ 		dev_warn(dev, "ECC engine timed out entering idle mode\n");
+-		return -EIO;
+-	}
+-
+-	return 0;
+-}
+-
+-static int mt7621_ecc_decoder_wait_done(struct mt7621_nfc *nfc, u32 sect)
+-{
+-	struct device *dev = nfc->dev;
+-	u32 val;
+-	int ret;
+ 
+-	ret = readw_poll_timeout_atomic(nfc->ecc_regs + ECC_DECDONE, val,
+-					val & (1 << sect), 10,
+-					ECC_ENGINE_TIMEOUT);
+-
+-	if (ret) {
+-		dev_warn(dev, "ECC decoder for sector %d timed out\n",
+-			 sect);
+-		return -ETIMEDOUT;
+-	}
+-
+-	return 0;
++	return ret;
+ }
+ 
+ static void mt7621_ecc_encoder_op(struct mt7621_nfc *nfc, bool enable)
+ {
+ 	mt7621_ecc_wait_idle(nfc, ECC_ENCIDLE);
+ 	ecc_write16(nfc, ECC_ENCCON, enable ? ENC_EN : 0);
++	if (!enable)
++		ecc_read16(nfc, ECC_ENCIRQSTA);
+ }
+ 
+ static void mt7621_ecc_decoder_op(struct mt7621_nfc *nfc, bool enable)
+ {
+ 	mt7621_ecc_wait_idle(nfc, ECC_DECIDLE);
+ 	ecc_write16(nfc, ECC_DECCON, enable ? DEC_EN : 0);
++	if (!enable)
++		ecc_read16(nfc, ECC_DECIRQSTA);
+ }
+ 
+-static int mt7621_ecc_correct_check(struct mt7621_nfc *nfc, u8 *sector_buf,
+-				   u8 *fdm_buf, u32 sect)
++static int mt7621_ecc_status(struct mt7621_nfc *nfc, struct mtd_info *mtd)
+ {
+ 	struct nand_chip *nand = &nfc->nand;
+-	u32 decnum, num_error_bits, fdm_end_bits;
+-	u32 error_locations, error_bit_loc;
+-	u32 error_byte_pos, error_bit_pos;
++	u32 decnum, num_error_bits;
+ 	int bitflips = 0;
+ 	u32 i;
+ 
+ 	decnum = ecc_read32(nfc, ECC_DECENUM);
+-	num_error_bits = (decnum >> (sect << ERRNUM_S)) & ERRNUM_M;
+-	fdm_end_bits = (nand->ecc.size + NFI_FDM_SIZE) << 3;
+-
+-	if (!num_error_bits)
++	if (!decnum)
+ 		return 0;
+ 
+-	if (num_error_bits == ERRNUM_M)
+-		return -1;
+-
+-	for (i = 0; i < num_error_bits; i++) {
+-		error_locations = ecc_read32(nfc, ECC_DECEL(i / 2));
+-		error_bit_loc = (error_locations >> ((i % 2) * DEC_EL_ODD_S)) &
+-				DEC_EL_M;
+-		error_byte_pos = error_bit_loc >> DEC_EL_BYTE_POS_S;
+-		error_bit_pos = error_bit_loc & DEC_EL_BIT_POS_M;
+-
+-		if (error_bit_loc < (nand->ecc.size << 3)) {
+-			if (sector_buf) {
+-				sector_buf[error_byte_pos] ^=
+-					(1 << error_bit_pos);
+-			}
+-		} else if (error_bit_loc < fdm_end_bits) {
+-			if (fdm_buf) {
+-				fdm_buf[error_byte_pos - nand->ecc.size] ^=
+-					(1 << error_bit_pos);
+-			}
++	for (i = 0; i < nand->ecc.steps; i++) {
++		num_error_bits = (decnum >> (i << ERRNUM_S)) & ERRNUM_M;
++		if (!num_error_bits)
++			continue;
++		else if (num_error_bits == ERRNUM_M) {
++			dev_dbg(nfc->dev, "decode sector %d error\n", i);
++			mtd->ecc_stats.failed++;
++		} else {
++			mtd->ecc_stats.corrected += num_error_bits;
++			bitflips = max_t(int, bitflips, num_error_bits);
+ 		}
+-
+-		bitflips++;
+ 	}
+ 
+ 	return bitflips;
+@@ -382,17 +361,15 @@ static int mt7621_nfc_wait_write_complet
+ 		((val & SEC_CNTR_M) >> SEC_CNTR_S) >= nand->ecc.steps, 10,
+ 		NFI_CORE_TIMEOUT);
+ 
+-	if (ret) {
++	if (ret)
+ 		dev_warn(dev, "NFI core write operation timed out\n");
+-		return -ETIMEDOUT;
+-	}
+ 
+ 	return ret;
+ }
+ 
+ static void mt7621_nfc_hw_reset(struct mt7621_nfc *nfc)
+ {
+-	u32 val;
++	u16 val;
+ 	int ret;
+ 
+ 	/* reset all registers and force the NFI master to terminate */
+@@ -416,6 +393,8 @@ static inline void mt7621_nfc_hw_init(st
+ {
+ 	u32 acccon;
+ 
++	device_reset(nfc->dev);
++
+ 	/*
+ 	 * CNRNB: nand ready/busy register
+ 	 * -------------------------------
+@@ -432,6 +411,14 @@ static inline void mt7621_nfc_hw_init(st
+ 			   ACCCON_RLT_DEF);
+ 
+ 	nfi_write32(nfc, NFI_ACCCON, acccon);
++
++	/* enable/clean interrupt */
++	nfi_write16(nfc, NFI_INTR_EN, INTR_AHB_DONE);
++	nfi_read16(nfc, NFI_INTR);
++
++	/* data bus pull down when no use */
++	nfi_write16(nfc, NFI_IOCON, (4 << IOCON_BRSTN_S) | IOCON_L2NW |
++		    IOCON_L2NR | IOCON_NLDPD);
+ }
+ 
+ static int mt7621_nfc_send_command(struct mt7621_nfc *nfc, u8 command)
+@@ -479,19 +466,16 @@ static int mt7621_nfc_send_address(struc
+ {
+ 	int ret;
+ 
+-	while (naddrs) {
+-		ret = mt7621_nfc_send_address_byte(nfc, *addr);
++	while (naddrs--) {
++		ret = mt7621_nfc_send_address_byte(nfc, *addr++);
+ 		if (ret)
+ 			return ret;
+-
+-		addr++;
+-		naddrs--;
+ 	}
+ 
+ 	return 0;
+ }
+ 
+-static void mt7621_nfc_wait_pio_ready(struct mt7621_nfc *nfc)
++static int mt7621_nfc_wait_pio_ready(struct mt7621_nfc *nfc)
+ {
+ 	struct device *dev = nfc->dev;
+ 	int ret;
+@@ -500,8 +484,10 @@ static void mt7621_nfc_wait_pio_ready(st
+ 	ret = readw_poll_timeout_atomic(nfc->nfi_regs + NFI_PIO_DIRDY, val,
+ 					val & PIO_DIRDY, 10,
+ 					NFI_CORE_TIMEOUT);
+-	if (ret < 0)
++	if (ret)
+ 		dev_err(dev, "NFI core PIO mode not ready\n");
++
++	return ret;
+ }
+ 
+ static u32 mt7621_nfc_pio_read(struct mt7621_nfc *nfc, bool br)
+@@ -534,11 +520,8 @@ static u32 mt7621_nfc_pio_read(struct mt
+ 
+ static void mt7621_nfc_read_data(struct mt7621_nfc *nfc, u8 *buf, u32 len)
+ {
+-	while (((uintptr_t)buf & 3) && len) {
+-		*buf = mt7621_nfc_pio_read(nfc, true);
+-		buf++;
+-		len--;
+-	}
++	while (!IS_ALIGNED((unsigned long)buf, 3) && len--)
++		*buf++ = mt7621_nfc_pio_read(nfc, true);
+ 
+ 	while (len >= 4) {
+ 		*(u32 *)buf = mt7621_nfc_pio_read(nfc, false);
+@@ -546,24 +529,8 @@ static void mt7621_nfc_read_data(struct
+ 		len -= 4;
+ 	}
+ 
+-	while (len) {
+-		*buf = mt7621_nfc_pio_read(nfc, true);
+-		buf++;
+-		len--;
+-	}
+-}
+-
+-static void mt7621_nfc_read_data_discard(struct mt7621_nfc *nfc, u32 len)
+-{
+-	while (len >= 4) {
+-		mt7621_nfc_pio_read(nfc, false);
+-		len -= 4;
+-	}
+-
+-	while (len) {
+-		mt7621_nfc_pio_read(nfc, true);
+-		len--;
+-	}
++	while (len--)
++		*buf++ = mt7621_nfc_pio_read(nfc, true);
+ }
+ 
+ static void mt7621_nfc_pio_write(struct mt7621_nfc *nfc, u32 val, bool bw)
+@@ -589,11 +556,8 @@ static void mt7621_nfc_pio_write(struct
+ static void mt7621_nfc_write_data(struct mt7621_nfc *nfc, const u8 *buf,
+ 				  u32 len)
+ {
+-	while (((uintptr_t)buf & 3) && len) {
+-		mt7621_nfc_pio_write(nfc, *buf, true);
+-		buf++;
+-		len--;
+-	}
++	while (!IS_ALIGNED((unsigned long)buf, 3) && len--)
++		mt7621_nfc_pio_write(nfc, *buf++, true);
+ 
+ 	while (len >= 4) {
+ 		mt7621_nfc_pio_write(nfc, *(const u32 *)buf, false);
+@@ -601,24 +565,8 @@ static void mt7621_nfc_write_data(struct
+ 		len -= 4;
+ 	}
+ 
+-	while (len) {
+-		mt7621_nfc_pio_write(nfc, *buf, true);
+-		buf++;
+-		len--;
+-	}
+-}
+-
+-static void mt7621_nfc_write_data_empty(struct mt7621_nfc *nfc, u32 len)
+-{
+-	while (len >= 4) {
+-		mt7621_nfc_pio_write(nfc, 0xffffffff, false);
+-		len -= 4;
+-	}
+-
+-	while (len) {
+-		mt7621_nfc_pio_write(nfc, 0xff, true);
+-		len--;
+-	}
++	while (len--)
++		mt7621_nfc_pio_write(nfc, *buf++, true);
+ }
+ 
+ static int mt7621_nfc_dev_ready(struct mt7621_nfc *nfc,
+@@ -669,12 +617,15 @@ static int mt7621_nfc_exec_op(struct nan
+ 	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
+ 	int i, ret;
+ 
++	/* Only CS0 available */
++	if (op->cs == 0)
++		nfi_write16(nfc, NFI_CSEL, 0);
++	else
++		nfi_write16(nfc, NFI_CSEL, 1);
++
+ 	if (check_only)
+ 		return 0;
+ 
+-	/* Only CS0 available */
+-	nfi_write16(nfc, NFI_CSEL, 0);
+-
+ 	for (i = 0; i < op->ninstrs; i++) {
+ 		ret = mt7621_nfc_exec_instr(nand, &op->instrs[i]);
+ 		if (ret)
+@@ -759,7 +710,8 @@ static int mt7621_nfc_setup_data_interfa
+ 
+ 	acccon = ACCTIMING(tpoecs, tprecs, tc2r, tw2r, twh, twst, trlt);
+ 
+-	dev_info(nfc->dev, "Using programmed access timing: %08x\n", acccon);
++	dev_info_once(nfc->dev, "Using programmed access timing: %08x\n",
++		      acccon);
+ 
+ 	nfi_write32(nfc, NFI_ACCCON, acccon);
+ 
+@@ -789,6 +741,7 @@ static int mt7621_nfc_calc_ecc_strength(
+ 	}
+ 
+ 	nand->ecc.strength = mt7621_ecc_strength[i];
++	nand->ecc.prepad = NFI_FDM_SIZE;
+ 	nand->ecc.bytes =
+ 		DIV_ROUND_UP(nand->ecc.strength * ECC_PARITY_BITS, 8);
+ 
+@@ -820,6 +773,7 @@ static int mt7621_nfc_set_spare_per_sect
+ 	}
+ 
+ 	nfc->spare_per_sector = mt7621_nfi_spare_size[i];
++	nand->ecc.postpad = mt7621_nfi_spare_size[i] - size;
+ 
+ 	return i;
+ }
+@@ -858,7 +812,7 @@ static int mt7621_nfc_ecc_init(struct mt
+ 			    nand->ecc.strength * ECC_PARITY_BITS;
+ 	ecc_deccfg = ecc_cap | (DEC_MODE_NFI << DEC_MODE_S) |
+ 		     (decode_block_size << DEC_CS_S) |
+-		     (DEC_CON_EL << DEC_CON_S) | DEC_EMPTY_EN;
++		     (DEC_CON_CORT << DEC_CON_S) | DEC_EMPTY_EN;
+ 
+ 	mt7621_ecc_encoder_op(nfc, false);
+ 	ecc_write32(nfc, ECC_ENCCNFG, ecc_enccfg);
+@@ -866,6 +820,10 @@ static int mt7621_nfc_ecc_init(struct mt
+ 	mt7621_ecc_decoder_op(nfc, false);
+ 	ecc_write32(nfc, ECC_DECCNFG, ecc_deccfg);
+ 
++	/* enable interrupt */
++	ecc_write16(nfc, ECC_DECIRQEN, DEC_IRQEN);
++	ecc_write16(nfc, ECC_ENCIRQEN, ENC_IRQEN);
++
+ 	return 0;
+ }
+ 
+@@ -903,6 +861,7 @@ static int mt7621_nfc_set_page_format(st
+ static int mt7621_nfc_attach_chip(struct nand_chip *nand)
+ {
+ 	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
++	struct mtd_info *mtd = nand_to_mtd(nand);
+ 	int ret;
+ 
+ 	if (nand->options & NAND_BUSWIDTH_16) {
+@@ -910,11 +869,26 @@ static int mt7621_nfc_attach_chip(struct
+ 		return -EINVAL;
+ 	}
+ 
++	if (nand->bbt_options & NAND_BBT_USE_FLASH)
++		nand->bbt_options |= NAND_BBT_NO_OOB;
++
+ 	ret = mt7621_nfc_ecc_init(nfc);
+ 	if (ret)
+ 		return ret;
+ 
+-	return mt7621_nfc_set_page_format(nfc);
++	ret = mt7621_nfc_set_page_format(nfc);
++	if (ret)
++		return ret;
++
++	nfc->pages_per_block = 0x1 << (nand->phys_erase_shift -
++				       nand->page_shift);
++	nfc->block_buf = devm_kmalloc_array(nfc->dev, nfc->pages_per_block,
++					    mtd->writesize + mtd->oobsize,
++					    GFP_KERNEL);
++	if (!nfc->block_buf)
++		return -ENOMEM;
++
++	return 0;
+ }
+ 
+ static const struct nand_controller_ops mt7621_nfc_controller_ops = {
+@@ -927,12 +901,23 @@ static int mt7621_nfc_ooblayout_free(str
+ 				     struct mtd_oob_region *oob_region)
+ {
+ 	struct nand_chip *nand = mtd_to_nand(mtd);
++	int chunk = nand->ecc.prepad + nand->ecc.bytes + nand->ecc.postpad;
+ 
+-	if (section >= nand->ecc.steps)
++	if (section > nand->ecc.steps)
+ 		return -ERANGE;
+ 
+-	oob_region->length = NFI_FDM_SIZE - 1;
+-	oob_region->offset = section * NFI_FDM_SIZE + 1;
++	oob_region->length = nand->ecc.prepad;
++	oob_region->offset = section * chunk;
++
++	if (section == 0) {
++		oob_region->length -= 1;
++		oob_region->offset = 1;
++	} else if (section == nand->ecc.steps) {
++		chunk = mtd->oobsize - (nand->ecc.steps * chunk);
++		if (!chunk)
++			return -ERANGE;
++		oob_region->length = chunk;
++	}
+ 
+ 	return 0;
+ }
+@@ -941,12 +926,13 @@ static int mt7621_nfc_ooblayout_ecc(stru
+ 				    struct mtd_oob_region *oob_region)
+ {
+ 	struct nand_chip *nand = mtd_to_nand(mtd);
++	int chunk = nand->ecc.prepad + nand->ecc.bytes + nand->ecc.postpad;
+ 
+-	if (section)
++	if (section >= nand->ecc.steps)
+ 		return -ERANGE;
+ 
+-	oob_region->offset = NFI_FDM_SIZE * nand->ecc.steps;
+-	oob_region->length = mtd->oobsize - oob_region->offset;
++	oob_region->offset = section * chunk + nand->ecc.prepad;
++	oob_region->length = nand->ecc.bytes + nand->ecc.postpad;
+ 
+ 	return 0;
+ }
+@@ -956,213 +942,453 @@ static const struct mtd_ooblayout_ops mt
+ 	.ecc = mt7621_nfc_ooblayout_ecc,
+ };
+ 
+-static void mt7621_nfc_write_fdm(struct mt7621_nfc *nfc)
++static void mt7621_nfc_write_fdm(struct mt7621_nfc *nfc, const uint8_t *oob)
+ {
+ 	struct nand_chip *nand = &nfc->nand;
+-	u32 vall, valm;
+-	u8 *oobptr;
+-	int i, j;
++	uint32_t fdm[2];
++	int i;
+ 
++	fdm[0] = fdm[1] = 0xffffffff;
+ 	for (i = 0; i < nand->ecc.steps; i++) {
+-		vall = 0;
+-		valm = 0;
+-		oobptr = oob_fdm_ptr(nand, i);
+-
+-		for (j = 0; j < 4; j++)
+-			vall |= (u32)oobptr[j] << (j * 8);
+-
+-		for (j = 0; j < 4; j++)
+-			valm |= (u32)oobptr[j + 4] << ((j - 4) * 8);
+-
+-		nfi_write32(nfc, NFI_FDML(i), vall);
+-		nfi_write32(nfc, NFI_FDMM(i), valm);
++		if (oob) {
++			memcpy(&fdm, oob, sizeof(fdm));
++			oob += nfc->spare_per_sector;
++		}
++		nfi_write32(nfc, NFI_FDML(i), fdm[0]);
++		nfi_write32(nfc, NFI_FDMM(i), fdm[1]);
+ 	}
+ }
+ 
+-static void mt7621_nfc_read_sector_fdm(struct mt7621_nfc *nfc, u32 sect)
++static void mt7621_nfc_read_fdm(struct mt7621_nfc *nfc, uint8_t *oob)
+ {
+ 	struct nand_chip *nand = &nfc->nand;
+-	u32 vall, valm;
+-	u8 *oobptr;
++	uint32_t fdm[2];
+ 	int i;
+ 
+-	vall = nfi_read32(nfc, NFI_FDML(sect));
+-	valm = nfi_read32(nfc, NFI_FDMM(sect));
+-	oobptr = oob_fdm_ptr(nand, sect);
++	for (i = 0; i < nand->ecc.steps; i++) {
++		fdm[0] = nfi_read32(nfc, NFI_FDML(i));
++		fdm[1] = nfi_read32(nfc, NFI_FDMM(i));
++		memcpy(oob, fdm, sizeof(fdm));
++		oob += nfc->spare_per_sector;
++	}
++}
++
++static int mt7621_read_oob_raw(struct nand_chip *nand, uint8_t *oob, int page,
++			       int hwecc)
++{
++	struct mtd_info *mtd = nand_to_mtd(nand);
++	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
++	int chunk = nfc->spare_per_sector;
++	int eccsize = nand->ecc.size;
++	int i, sndrnd = 0, pos, ret;
++
++	/* when hwecc prepad data read from fdm, skip it */
++	if (hwecc) {
++		chunk -= nand->ecc.prepad;
++		eccsize += nand->ecc.prepad;
++		oob += nand->ecc.prepad;
++	}
++
++	ret = nand_read_page_op(nand, page, eccsize, NULL, 0);
++	if (ret)
++		goto err;
+ 
+-	for (i = 0; i < 4; i++)
+-		oobptr[i] = (vall >> (i * 8)) & 0xff;
++	for (i = 0; i < nand->ecc.steps; i++, oob += nfc->spare_per_sector) {
++		if (sndrnd) {
++			pos = eccsize + i * (eccsize + chunk);
++			if (mtd->writesize > 512)
++				ret = nand_change_read_column_op(nand, pos,
++								 NULL, 0,
++								 false);
++			else
++				ret = nand_read_page_op(nand, page, pos, NULL,
++							0);
++			if (ret)
++				goto err;
++		} else
++			sndrnd = 1;
++		ret = nand_read_data_op(nand, oob, chunk, false);
++		if (ret)
++			goto err;
++	}
+ 
+-	for (i = 0; i < 4; i++)
+-		oobptr[i + 4] = (valm >> (i * 8)) & 0xff;
++	chunk = mtd->oobsize - (nand->ecc.steps * nfc->spare_per_sector);
++	if (chunk) {
++		if (hwecc)
++			oob -= nand->ecc.prepad;
++		ret = nand_read_data_op(nand, oob, chunk, false);
++		if (ret)
++			goto err;
++	}
++
++err:
++	nfi_write16(nfc, NFI_CON, 0);
++
++	return ret;
+ }
+ 
+-static int mt7621_nfc_read_page_hwecc(struct nand_chip *nand, uint8_t *buf,
+-				      int oob_required, int page)
++static int mt7621_write_oob_raw(struct nand_chip *nand, const uint8_t *oob,
++				int page, int hwecc)
+ {
+-	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
+ 	struct mtd_info *mtd = nand_to_mtd(nand);
+-	int bitflips = 0;
+-	int rc, i;
++	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
++	int chunk = nfc->spare_per_sector;
++	int eccsize = nand->ecc.size, length = mtd->oobsize;
++	int ret, i, len, pos, sndcmd = 0, steps = nand->ecc.steps;
++
++	pos = eccsize;
++	if (hwecc) {
++		len = steps * chunk;
++		length -= len;
++		if (length == 0)
++			return 0;
++		oob += len;
++		pos = steps * (eccsize + chunk);
++		steps = 0;
++	}
+ 
+-	nand_read_page_op(nand, page, 0, NULL, 0);
++	ret = nand_prog_page_begin_op(nand, page, pos, NULL, 0);
++	if (ret)
++		goto err;
+ 
+-	nfi_write16(nfc, NFI_CNFG, (CNFG_OP_CUSTOM << CNFG_OP_MODE_S) |
+-		    CNFG_READ_MODE | CNFG_AUTO_FMT_EN | CNFG_HW_ECC_EN);
++	for (i = 0; i < steps; i++) {
++		if (sndcmd) {
++			if (mtd->writesize <= 512) {
++				uint32_t fill = 0xFFFFFFFF;
++
++				len = eccsize;
++				while (len > 0) {
++					int num = min_t(int, len, 4);
++
++					ret = nand_write_data_op(nand, &fill,
++								 num, false);
++					if (ret)
++						goto err;
++
++					len -= num;
++				}
++			} else {
++				pos = eccsize + i * (eccsize + chunk);
++				ret = nand_change_write_column_op(nand, pos,
++								  NULL, 0,
++								  false);
++				if (ret)
++					goto err;
++			}
++		} else
++			sndcmd = 1;
++		len = min_t(int, length, chunk);
+ 
+-	mt7621_ecc_decoder_op(nfc, true);
++		ret = nand_write_data_op(nand, oob, len, false);
++		if (ret)
++			goto err;
+ 
+-	nfi_write16(nfc, NFI_CON,
+-		    CON_NFI_BRD | (nand->ecc.steps << CON_NFI_SEC_S));
++		oob += len;
++		length -= len;
++	}
++	if (length > 0) {
++		ret = nand_write_data_op(nand, oob, length, false);
++		if (ret)
++			goto err;
++	}
+ 
+-	for (i = 0; i < nand->ecc.steps; i++) {
+-		if (buf)
+-			mt7621_nfc_read_data(nfc, page_data_ptr(nand, buf, i),
+-					     nand->ecc.size);
+-		else
+-			mt7621_nfc_read_data_discard(nfc, nand->ecc.size);
++err:
++	nfi_write16(nfc, NFI_CON, 0);
++	if (ret)
++		return ret;
++
++	return nand_prog_page_end_op(nand);
++}
++
++static int mt7621_nfc_read_page(struct nand_chip *nand, uint8_t *buf,
++				      uint8_t *oob, int page, int hwecc)
++{
++	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
++	struct mtd_info *mtd = nand_to_mtd(nand);
++	int bitflips = 0;
++	dma_addr_t addr;
++	size_t len = mtd->writesize;
++	int ret;
++	u32 reg;
+ 
+-		rc = mt7621_ecc_decoder_wait_done(nfc, i);
++	/* prepare dma */
++	addr = dma_map_single(nfc->dev, (void *)buf, len, DMA_FROM_DEVICE);
++	ret = dma_mapping_error(nfc->dev, addr);
++	if (ret) {
++		dev_err(nfc->dev, "dma mapping error\n");
++		return -EINVAL;
++	}
++	nfi_write32(nfc, NFI_STRADDR, addr);
++	init_completion(&nfc->nfi_done);
++	init_completion(&nfc->ecc_done);
+ 
+-		mt7621_nfc_read_sector_fdm(nfc, i);
++	ret = nand_read_page_op(nand, page, 0, NULL, 0);
++	if (ret) {
++		bitflips = ret;
++		goto err;
++	}
+ 
+-		if (rc < 0) {
+-			bitflips = -EIO;
+-			continue;
++	/* init nfi/ecc */
++	reg = (CNFG_OP_CUSTOM << CNFG_OP_MODE_S) | CNFG_AUTO_FMT_EN |
++		CNFG_READ_MODE | CNFG_DMA_MODE;
++	if (hwecc)
++		reg |= CNFG_HW_ECC_EN;
++	nfi_write16(nfc, NFI_CNFG, reg);
++	if (hwecc)
++		mt7621_ecc_decoder_op(nfc, true);
++
++	/* start nfi transfer */
++	nfi_write16(nfc, NFI_CON, CON_NFI_BRD |
++		    (nand->ecc.steps << CON_NFI_SEC_S));
++	nfi_write16(nfc, NFI_STRDATA, STR_DATA);
++
++	/* wait nfi interrupt */
++	ret = wait_for_completion_timeout(&nfc->nfi_done,
++					  msecs_to_jiffies(500));
++	if (!ret) {
++		dev_warn(nfc->dev, "read ahb/dma done timeout\n");
++		bitflips = -ETIMEDOUT;
++		goto err;
++	}
++
++	if (hwecc) {
++		/* wait ecc interrupt */
++		ret = wait_for_completion_timeout(&nfc->ecc_done,
++						  msecs_to_jiffies(500));
++		if (!ret) {
++			dev_warn(nfc->dev, "decode timeout\n");
++			bitflips = -ETIMEDOUT;
++			goto err;
+ 		}
+ 
+-		rc = mt7621_ecc_correct_check(nfc,
+-			buf ? page_data_ptr(nand, buf, i) : NULL,
+-			oob_fdm_ptr(nand, i), i);
+-
+-		if (rc < 0) {
+-			dev_warn(nfc->dev,
+-				 "Uncorrectable ECC error at page %d.%d\n",
+-				 page, i);
+-			bitflips = -EBADMSG;
+-			mtd->ecc_stats.failed++;
+-		} else if (bitflips >= 0) {
+-			bitflips += rc;
+-			mtd->ecc_stats.corrected += rc;
+-		}
++		/* update ecc status */
++		bitflips = mt7621_ecc_status(nfc, mtd);
+ 	}
+ 
+-	mt7621_ecc_decoder_op(nfc, false);
++	if (oob)
++		mt7621_nfc_read_fdm(nfc, oob);
+ 
++err:
++	if (hwecc)
++		mt7621_ecc_decoder_op(nfc, false);
++	dma_unmap_single(nfc->dev, addr, len, DMA_FROM_DEVICE);
+ 	nfi_write16(nfc, NFI_CON, 0);
+ 
++	if ((bitflips >= 0) && oob) {
++		ret = mt7621_read_oob_raw(nand, oob, page, hwecc);
++		if (ret)
++			return ret;
++	}
++
+ 	return bitflips;
+ }
+ 
++static int mt7621_nfc_read_page_hwecc(struct nand_chip *nand, uint8_t *buf,
++				      int oob_required, int page)
++{
++	return mt7621_nfc_read_page(nand, buf, oob_required ? nand->oob_poi :
++				    NULL, page, 1);
++}
++
+ static int mt7621_nfc_read_page_raw(struct nand_chip *nand, uint8_t *buf,
+ 				    int oob_required, int page)
+ {
++	return mt7621_nfc_read_page(nand, buf, oob_required ? nand->oob_poi :
++				    NULL, page, 0);
++}
++
++static int mt7621_nfc_read_oob_hwecc(struct nand_chip *nand, int page)
++{
+ 	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
+-	int i;
+ 
+-	nand_read_page_op(nand, page, 0, NULL, 0);
++	return mt7621_nfc_read_page(nand, nfc->block_buf, nand->oob_poi,
++				    page, 1);
++}
++
++static int mt7621_nfc_read_oob_raw(struct nand_chip *nand, int page)
++{
++	return mt7621_read_oob_raw(nand, nand->oob_poi, page, 0);
++}
+ 
++/* write page without check */
++static int mt7621_write_page_hwecc(struct nand_chip *nand, const uint8_t *buf,
++				   const uint8_t *oob, int page)
++{
++	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
++	struct mtd_info *mtd = nand_to_mtd(nand);
++	dma_addr_t addr;
++	size_t len = mtd->writesize;
++	int ret;
++
++	/* prepare dma */
++	addr = dma_map_single(nfc->dev, (void *)buf, len, DMA_TO_DEVICE);
++	ret = dma_mapping_error(nfc->dev, addr);
++	if (ret) {
++		dev_warn(nfc->dev, "dma mapping error\n");
++		return -EINVAL;
++	}
++	nfi_write32(nfc, NFI_STRADDR, addr);
++	init_completion(&nfc->nfi_done);
++	init_completion(&nfc->ecc_done);
++
++	nand_prog_page_begin_op(nand, page, 0, NULL, 0);
++
++	/* init nfi/ecc */
+ 	nfi_write16(nfc, NFI_CNFG, (CNFG_OP_CUSTOM << CNFG_OP_MODE_S) |
+-		    CNFG_READ_MODE);
++		   CNFG_AUTO_FMT_EN | CNFG_HW_ECC_EN | CNFG_DMA_MODE);
++	mt7621_ecc_encoder_op(nfc, true);
+ 
++	mt7621_nfc_write_fdm(nfc, oob);
++
++	/* start nfi transfer */
+ 	nfi_write16(nfc, NFI_CON,
+-		    CON_NFI_BRD | (nand->ecc.steps << CON_NFI_SEC_S));
++		    CON_NFI_BWR | (nand->ecc.steps << CON_NFI_SEC_S));
++	nfi_write16(nfc, NFI_STRDATA, STR_DATA);
+ 
+-	for (i = 0; i < nand->ecc.steps; i++) {
+-		/* Read data */
+-		if (buf)
+-			mt7621_nfc_read_data(nfc, page_data_ptr(nand, buf, i),
+-					     nand->ecc.size);
+-		else
+-			mt7621_nfc_read_data_discard(nfc, nand->ecc.size);
+-
+-		/* Read FDM */
+-		mt7621_nfc_read_data(nfc, oob_fdm_ptr(nand, i), NFI_FDM_SIZE);
+-
+-		/* Read ECC parity data */
+-		mt7621_nfc_read_data(nfc, oob_ecc_ptr(nfc, i),
+-				     nfc->spare_per_sector - NFI_FDM_SIZE);
++	/* wait nfi interrupt */
++	ret = wait_for_completion_timeout(&nfc->nfi_done,
++					  msecs_to_jiffies(500));
++	if (!ret) {
++		dev_warn(nfc->dev, "write ahb/dma done timeout\n");
++		ret = -ETIMEDOUT;
++		goto err;
++	}
++
++	/* wait ecc interrupt */
++	ret = wait_for_completion_timeout(&nfc->ecc_done,
++					  msecs_to_jiffies(500));
++	if (!ret) {
++		dev_warn(nfc->dev, "decode timeout\n");
++		ret = -ETIMEDOUT;
++		goto err;
+ 	}
+ 
++	ret = 0;
++err:
++	mt7621_ecc_encoder_op(nfc, false);
++	dma_unmap_single(nfc->dev, addr, len, DMA_TO_DEVICE);
+ 	nfi_write16(nfc, NFI_CON, 0);
+ 
+-	return 0;
+-}
++	if (ret)
++		return ret;
+ 
+-static int mt7621_nfc_read_oob_hwecc(struct nand_chip *nand, int page)
+-{
+-	return mt7621_nfc_read_page_hwecc(nand, NULL, 1, page);
+-}
++	ret = nand_prog_page_end_op(nand);
++	if ((ret == 0) && oob)
++		ret = mt7621_write_oob_raw(nand, oob, page, 1);
+ 
+-static int mt7621_nfc_read_oob_raw(struct nand_chip *nand, int page)
+-{
+-	return mt7621_nfc_read_page_raw(nand, NULL, 1, page);
++	return ret;
+ }
+ 
+-static int mt7621_nfc_check_empty_page(struct nand_chip *nand, const u8 *buf)
++static int mt7621_block_page_erase(struct nand_chip *nand, int page)
+ {
++	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
+ 	struct mtd_info *mtd = nand_to_mtd(nand);
+-	uint32_t i, j;
+-	u8 *oobptr;
++	int len = mtd->writesize + mtd->oobsize;
++	int i, ret, page_start;
++	u8 *data_buf, *oob_poi;
++	unsigned long *write_map = bitmap_zalloc(nfc->pages_per_block,
++						 GFP_KERNEL);
++	if (!write_map) {
++		dev_err(nfc->dev, "failed to allocate bitmap\n");
++		return -ENOMEM;
++	}
+ 
+-	for (i = 0; i < mtd->writesize; i++)
+-		if (buf[i] != 0xff)
+-			return 0;
++	page_start = page & ~(nfc->pages_per_block - 1);
+ 
+-	for (i = 0; i < nand->ecc.steps; i++) {
+-		oobptr = oob_fdm_ptr(nand, i);
+-		for (j = 0; j < NFI_FDM_SIZE; j++)
+-			if (oobptr[j] != 0xff)
+-				return 0;
++	/* read all pages within this block except the one to be rewritten */
++	data_buf = nfc->block_buf;
++	oob_poi = data_buf + mtd->writesize;
++	for (i = page_start; i < page_start + nfc->pages_per_block; i++,
++	     data_buf += len, oob_poi += len) {
++		if (i == page) {
++			set_bit(i - page_start, write_map);
++			continue;
++		}
++		ret = mt7621_nfc_read_page(nand, data_buf, oob_poi, i, 1);
++		if (ret) {
++			dev_warn(nfc->dev, "failed read, page 0x%08x\n", i);
++			goto err;
++		}
++		if (!(nfi_read32(nfc, NFI_STA) & STA_READ_EMPTY))
++			set_bit(i - page_start, write_map);
+ 	}
+ 
+-	return 1;
++	/* erase this block */
++	ret = nand_erase_op(nand, page_start >>
++			    (nand->phys_erase_shift - nand->page_shift));
++	if (ret) {
++		dev_warn(nfc->dev, "failed erase, page 0x%08x\n", page_start);
++		goto err;
++	}
++
++	/* write back all pages */
++	for_each_set_bit(i, write_map, nfc->pages_per_block) {
++		data_buf = nfc->block_buf + (i * len);
++		oob_poi = data_buf + mtd->writesize;
++		ret = mt7621_write_page_hwecc(nand, data_buf, oob_poi,
++					      i + page_start);
++		if (ret) {
++			dev_warn(nfc->dev, "failed write, page 0x%08x\n",
++				 i + page_start);
++			goto err;
++		}
++	}
++
++err:
++	bitmap_free(write_map);
++	return ret;
+ }
+ 
+-static int mt7621_nfc_write_page_hwecc(struct nand_chip *nand,
+-				       const uint8_t *buf, int oob_required,
+-				       int page)
++static int mt7621_page_empty(struct nand_chip *nand, int page,
++					 u8 **page_buf)
+ {
+ 	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
+ 	struct mtd_info *mtd = nand_to_mtd(nand);
++	int len = mtd->writesize + mtd->oobsize;
++	u8 *data_buf, *oob_poi;
++	int ret, page_idx;
+ 
+-	if (mt7621_nfc_check_empty_page(nand, buf)) {
+-		/*
+-		 * MT7621 ECC engine always generates parity code for input
+-		 * pages, even for empty pages. Doing so will write back ECC
+-		 * parity code to the oob region, which means such pages will
+-		 * no longer be empty pages.
+-		 *
+-		 * To avoid this, stop write operation if current page is an
+-		 * empty page.
+-		 */
+-		return 0;
+-	}
++	page_idx = page & (nfc->pages_per_block - 1);
+ 
+-	nand_prog_page_begin_op(nand, page, 0, NULL, 0);
++	*page_buf = data_buf = nfc->block_buf + (page_idx * len);
++	oob_poi = data_buf + mtd->writesize;
+ 
+-	nfi_write16(nfc, NFI_CNFG, (CNFG_OP_CUSTOM << CNFG_OP_MODE_S) |
+-		   CNFG_AUTO_FMT_EN | CNFG_HW_ECC_EN);
+-
+-	mt7621_ecc_encoder_op(nfc, true);
++	/* read out flash data */
++	ret = mt7621_nfc_read_page(nand, data_buf, oob_poi, page, 1);
++	if (ret)
++		return ret;
+ 
+-	mt7621_nfc_write_fdm(nfc);
++	/* flash page is empty, writing directly */
++	if (nfi_read32(nfc, NFI_STA) & STA_READ_EMPTY)
++		return 1;
+ 
+-	nfi_write16(nfc, NFI_CON,
+-		    CON_NFI_BWR | (nand->ecc.steps << CON_NFI_SEC_S));
++	return 0;
++}
+ 
+-	if (buf)
+-		mt7621_nfc_write_data(nfc, buf, mtd->writesize);
+-	else
+-		mt7621_nfc_write_data_empty(nfc, mtd->writesize);
++static int mt7621_nfc_write_page_hwecc(struct nand_chip *nand,
++				       const uint8_t *buf, int oob_required,
++				       int page)
++{
++	struct mtd_info *mtd = nand_to_mtd(nand);
++	u8 *page_buf;
++	int ret;
+ 
+-	mt7621_nfc_wait_write_completion(nfc, nand);
++	if (!oob_required) {
++		ret = mt7621_page_empty(nand, page, &page_buf);
++		if (ret < 0)
++			return ret;
++		else if (ret == 1)
++			goto write_page;
+ 
+-	mt7621_ecc_encoder_op(nfc, false);
++		/* oob not empty. update data and reserve oob */
++		memcpy(page_buf, buf, mtd->writesize);
+ 
+-	nfi_write16(nfc, NFI_CON, 0);
++		return mt7621_block_page_erase(nand, page);
++	}
+ 
+-	return nand_prog_page_end_op(nand);
++write_page:
++	return mt7621_write_page_hwecc(nand, buf, oob_required ? nand->oob_poi :
++				       NULL, page);
+ }
+ 
+ static int mt7621_nfc_write_page_raw(struct nand_chip *nand,
+@@ -1170,6 +1396,8 @@ static int mt7621_nfc_write_page_raw(str
+ 				     int page)
+ {
+ 	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
++	struct mtd_info *mtd = nand_to_mtd(nand);
++	u8 *oobptr = nand->oob_poi;
+ 	int i;
+ 
+ 	nand_prog_page_begin_op(nand, page, 0, NULL, 0);
+@@ -1179,23 +1407,20 @@ static int mt7621_nfc_write_page_raw(str
+ 	nfi_write16(nfc, NFI_CON,
+ 		    CON_NFI_BWR | (nand->ecc.steps << CON_NFI_SEC_S));
+ 
+-	for (i = 0; i < nand->ecc.steps; i++) {
++	for (i = 0; i < nand->ecc.steps; i++,
++	     buf ? buf += nand->ecc.size : NULL,
++	     oobptr += nfc->spare_per_sector) {
+ 		/* Write data */
+-		if (buf)
+-			mt7621_nfc_write_data(nfc, page_data_ptr(nand, buf, i),
+-					      nand->ecc.size);
+-		else
+-			mt7621_nfc_write_data_empty(nfc, nand->ecc.size);
+-
+-		/* Write FDM */
+-		mt7621_nfc_write_data(nfc, oob_fdm_ptr(nand, i),
+-				      NFI_FDM_SIZE);
+-
+-		/* Write dummy ECC parity data */
+-		mt7621_nfc_write_data_empty(nfc, nfc->spare_per_sector -
+-					    NFI_FDM_SIZE);
++		mt7621_nfc_write_data(nfc, buf, nand->ecc.size);
++
++		/* Write FDM and ECC parity data */
++		mt7621_nfc_write_data(nfc, oobptr, nfc->spare_per_sector);
+ 	}
+ 
++	i = mtd->oobsize - (nand->ecc.steps * nfc->spare_per_sector);
++	if (i)
++		mt7621_nfc_write_data(nfc, oobptr, i);
++
+ 	mt7621_nfc_wait_write_completion(nfc, nand);
+ 
+ 	nfi_write16(nfc, NFI_CON, 0);
+@@ -1205,12 +1430,28 @@ static int mt7621_nfc_write_page_raw(str
+ 
+ static int mt7621_nfc_write_oob_hwecc(struct nand_chip *nand, int page)
+ {
+-	return mt7621_nfc_write_page_hwecc(nand, NULL, 1, page);
++	struct mtd_info *mtd = nand_to_mtd(nand);
++	u8 *page_buf;
++	int ret;
++
++	ret = mt7621_page_empty(nand, page, &page_buf);
++	if (ret < 0)
++		return ret;
++	else if (ret == 1)
++		goto write_page;
++
++	/* data not empty. update oob and reserve data */
++	memcpy(page_buf + mtd->writesize, nand->oob_poi, mtd->oobsize);
++
++	return mt7621_block_page_erase(nand, page);
++
++write_page:
++	return mt7621_write_page_hwecc(nand, page_buf, nand->oob_poi, page);
+ }
+ 
+ static int mt7621_nfc_write_oob_raw(struct nand_chip *nand, int page)
+ {
+-	return mt7621_nfc_write_page_raw(nand, NULL, 1, page);
++	return mt7621_write_oob_raw(nand, nand->oob_poi, page, 0);
+ }
+ 
+ static int mt7621_nfc_init_chip(struct mt7621_nfc *nfc)
+@@ -1236,6 +1477,7 @@ static int mt7621_nfc_init_chip(struct m
+ 	nand->ecc.read_oob_raw = mt7621_nfc_read_oob_raw;
+ 	nand->ecc.write_oob = mt7621_nfc_write_oob_hwecc;
+ 	nand->ecc.write_oob_raw = mt7621_nfc_write_oob_raw;
++	nand->buf_align = 32;
+ 
+ 	mtd = nand_to_mtd(nand);
+ 	mtd->owner = THIS_MODULE;
+@@ -1259,12 +1501,56 @@ static int mt7621_nfc_init_chip(struct m
+ 	return 0;
+ }
+ 
++static irqreturn_t mt7621_nfi_irq(int irq, void *id)
++{
++	struct mt7621_nfc *nfc = id;
++	struct nand_chip *nand = &nfc->nand;
++	int sector;
++	u16 sta;
++
++	sta = nfi_read16(nfc, NFI_INTR);
++	if (!sta)
++		return IRQ_NONE;
++
++	if (sta & INTR_AHB_DONE) {
++		sector = nfi_read16(nfc, NFI_BYTELEN) >> BYTELEN_S;
++		if (sector == nand->ecc.steps)
++			complete(&nfc->nfi_done);
++	}
++
++	return IRQ_HANDLED;
++}
++
++static irqreturn_t mt7621_ecc_irq(int irq, void *id)
++{
++	struct mt7621_nfc *nfc = id;
++	struct nand_chip *nand = &nfc->nand;
++	u16 dec, enc;
++
++	dec = ecc_read16(nfc, ECC_DECIRQSTA);
++	if (dec) {
++		dec = ecc_read16(nfc, ECC_DECDONE);
++		if (dec & BIT(nand->ecc.steps - 1))
++			complete(&nfc->ecc_done);
++		return IRQ_HANDLED;
++	}
++
++	enc = ecc_read16(nfc, ECC_ENCIRQSTA);
++	if (enc) {
++		if (ecc_read16(nfc, ECC_ENCIDLE))
++			complete(&nfc->ecc_done);
++		return IRQ_HANDLED;
++	}
++
++	return IRQ_NONE;
++}
++
+ static int mt7621_nfc_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+ 	struct mt7621_nfc *nfc;
+ 	struct resource *res;
+-	int ret;
++	int ret, nfi_irq, ecc_irq;
+ 
+ 	nfc = devm_kzalloc(dev, sizeof(*nfc), GFP_KERNEL);
+ 	if (!nfc)
+@@ -1299,6 +1585,45 @@ static int mt7621_nfc_probe(struct platf
+ 			return ret;
+ 		}
+ 	}
++#if 1
++	/* enable clock */
++	{
++#define RALINK_SYSCTL_BASE      0xBE000000
++		u32 reg = (*(volatile u32 *)(RALINK_SYSCTL_BASE + 0x30));
++		reg |= BIT(15);
++		(*(volatile u32 *)(RALINK_SYSCTL_BASE + 0x30)) = reg;
++	}
++#endif
++
++	nfi_irq = platform_get_irq_byname(pdev, "nfi");
++	if (nfi_irq < 0) {
++		dev_err(dev, "no nfi irq resource\n");
++		return nfi_irq;
++	}
++	ecc_irq = platform_get_irq_byname(pdev, "ecc");
++	if (ecc_irq < 0) {
++		dev_err(dev, "no ecc irq resource\n");
++		return ecc_irq;
++	}
++
++	ret = devm_request_irq(dev, nfi_irq, mt7621_nfi_irq, 0x0,
++			       "mtk-nand", nfc);
++	if (ret) {
++		dev_err(dev, "failed to request nfi irq\n");
++		return ret;
++	}
++	ret = devm_request_irq(dev, ecc_irq, mt7621_ecc_irq, 0x0,
++			       "mtk-ecc", nfc);
++	if (ret) {
++		dev_err(dev, "failed to request ecc irq\n");
++		return ret;
++	}
++
++	ret = dma_set_mask(dev, DMA_BIT_MASK(32));
++	if (ret) {
++		dev_err(dev, "failed to set dma mask\n");
++		return ret;
++	}
+ 
+ 	platform_set_drvdata(pdev, nfc);
+ 


### PR DESCRIPTION
* improve speed and reduce system usage. use dd to test read speed at partition size 0x07ec0000
time dd if=/dev/mtdblock3 of=/dev/null
=== PIO mode ===
real    0m 44.60s
sys     0m 44.04s
=== DMA mode ===
real    0m 21.77s
sys     0m 7.00s

* use initramfs firmware to verify on three flash chips with jffs2 file system.
  * ESMT 128 MiB, SLC, erase size: 128 KiB, page size: 2048, OOB size: 64
  * Micron 1024 MiB, SLC, erase size: 256 KiB, page size: 4096, OOB size: 224
  * AMD/Spansion 256 MiB, SLC, erase size: 128 KiB, page size: 2048, OOB size: 128